### PR TITLE
duels.lua - fix for players respawning during duels.

### DIFF
--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -279,7 +279,7 @@ function Duels:EndDuel ()
       local hero = player:GetAssignedHero()
       hero:SetRespawnsDisabled(false)
       if not hero:IsAlive() then
-        hero:RespawnUnit()
+        hero:RespawnHero(false,false,false)
       end
 
       Duels:RestorePlayerState (hero, state)
@@ -290,7 +290,7 @@ end
 
 function Duels:ResetPlayerState (hero)
   if not hero:IsAlive() then
-    hero:RespawnUnit()
+    hero:RespawnHero(false,false,false)
   end
 
   hero:SetHealth(hero:GetMaxHealth())


### PR DESCRIPTION
This is a fix for players respawning during a duel, regardless of SetRespawnsDisabled(true)

It is loosely linked to the infinite death #146 bug.

RespawnUnit apparently doesn't remove the respawn timer. RespawnHero apparently does.

From the testing I've been able to do, it does actually **stop the respawning**. I haven't noticed any bugs from changing it.

void RespawnHero(bool buyback, bool IsActuallyBeingSpawnedForTheFirstTime, bool RespawnPenalty) 
so RespawnHero(false,false,false)