### PR TITLE
Refactored duel mechanic, hopefully fixed a few issues in the process

### DIFF
--- a/game/scripts/vscripts/components/duels/duel.lua
+++ b/game/scripts/vscripts/components/duels/duel.lua
@@ -12,7 +12,7 @@ function Duel:Init (teams, spawns, zone)
     self.scores[index] = {#team}
     for _,player in pairs(team) do
       player.team = index
-  	end
+    end
   end
 
   GameEvents:OnHeroKilled(function (keys)

--- a/game/scripts/vscripts/components/duels/duel.lua
+++ b/game/scripts/vscripts/components/duels/duel.lua
@@ -1,0 +1,156 @@
+Duel = class({})
+
+function Duel:Init (teams, spawns, zone)
+  self.zone = zone
+  self.states = {}
+  DebugPrint('Starting a duel')
+  self.teams = teams
+  self.spawns = spawns
+  self.scores = {}
+
+  for index, team in pairs(teams) do
+    self.scores[index] = {#team}
+	for _,player in pairs(team) do
+	  player.team = index
+	end
+  end
+
+  GameEvents:OnHeroKilled(function (keys)
+    Duel:CheckDuelStatus(keys)
+  end)
+  Duel:Start()
+
+  self.over = false
+end
+
+function Duel:Start()
+  for index, team in pairs(self.teams) do
+    local teamSpawn = self.spawns[index]
+	for _, player in pairs(team) do
+	  Duel:SpawnPlayer(player, teamSpawn)
+	end
+  end
+end
+
+function Duel.Map(func)
+  for _, team in pairs(self.teams) do
+    for _, player in pairs(team) do
+	  func(player)
+	end
+  end
+end
+
+function Duel:SpawnPlayer(player, spawn)
+  local hero = player:GetAssignedHero()
+
+  self.states[player.id] = Duel:GetPlayerState(hero)
+  Duel:ResetPlayerState(hero)
+
+  self.zone.addPlayer(player.id)
+  FindClearSpaceForUnit(hero, spawn, true)
+  self.MoveCameraToPlayer(player.id, hero)
+
+  hero:SetRespawnsDisabled(true)
+end
+
+function Duel:ResetPlayerState (player)
+  local hero = player:GetAssignedHero()
+
+  if not hero:IsAlive() then
+    hero:RespawnHero(false,false,false)
+  end
+
+  hero:SetHealth(hero:GetMaxHealth())
+  hero:SetMana(hero:GetMaxMana())
+
+  for abilityIndex = 0,hero:GetAbilityCount() do
+    local ability = hero:GetAbilityByIndex(abilityIndex)
+    if ability ~= nil then
+      ability:EndCooldown()
+    end
+  end
+end
+
+function Duel:GetPlayerState(hero)
+  local state = {
+    location = hero:GetAbsOrigin(),
+    abilityCount = hero:GetAbilityCount(),
+    maxAbility = 0,
+    abilities = {},
+    hp = hero:GetHealth(),
+    mana = hero:GetMana()
+  }
+
+  for abilityIndex = 0,state.abilityCount-1 do
+    local ability = hero:GetAbilityByIndex(abilityIndex)
+    if ability ~= nil then
+      state.maxAbility = abilityIndex
+      state.abilities[abilityIndex] = {
+        cooldown = ability:GetCooldownTimeRemaining()
+      }
+    end
+  end
+  return state
+end
+
+function Duel:RestorePlayerState(player)
+  local hero = player:GetAssignedHero()
+  local s = self.states[player.id]
+
+  hero.SetAbsOrigin(s.location)
+  Duel:MoveCameraToPlayer(player.id, hero)
+
+  if s.hp > 0 then
+    hero.SetHealth(s.hp)
+  end
+  hero:setMana(s.mana)
+
+  for abilityIndex = 0,state.maxAbility-1 do
+	local ability = hero:GetAbilityByIndex(abilityIndex)
+	if ability ~= nil then
+	  ability:StartCooldown(state.abilities[abilityIndex].cooldown)
+	end
+  end
+  self.zone.removePlayer(player.id)
+end
+
+function Duel:MoveCameraToPlayer (playerId, entity)
+  PlayerResource:SetCameraTarget(playerId, entity)
+
+  Timers:CreateTimer(1, function ()
+    PlayerResource:SetCameraTarget(playerId, nil)
+  end)
+end
+
+function Duel:CheckDuelStatus (keys)
+  if keys.killed:IsReincarnating() then
+    return
+  end
+
+  local playerId = keys.killed:GetPlayerOwnerID()
+  local foundIt = false
+
+  Duel:Map(function (player)
+    if foundIt or player.id ~= playerId then
+      return
+    end
+    foundIt = true
+    local scoreIndex = player.team
+    DebugPrint('Found dead player on team ' .. player.team)
+
+    self.scores[scoreIndex] = Duel.scores[scoreIndex] - 1
+
+    if self.scores[scoreIndex] <= 0 then
+      Duel:EndDuel()
+    end
+  end)
+end
+
+function Duel:EndDuel()
+  Duel:Map(Duel:RestorePlayerState)
+  self.over = true
+  --Need to unsubscribe from event manager!
+end
+
+
+

--- a/game/scripts/vscripts/components/duels/duel.lua
+++ b/game/scripts/vscripts/components/duels/duel.lua
@@ -10,9 +10,9 @@ function Duel:Init (teams, spawns, zone)
 
   for index, team in pairs(teams) do
     self.scores[index] = {#team}
-	for _,player in pairs(team) do
-	  player.team = index
-	end
+	  for _,player in pairs(team) do
+	    player.team = index
+  	end
   end
 
   GameEvents:OnHeroKilled(function (keys)
@@ -26,17 +26,17 @@ end
 function Duel:Start()
   for index, team in pairs(self.teams) do
     local teamSpawn = self.spawns[index]
-	for _, player in pairs(team) do
-	  Duel:SpawnPlayer(player, teamSpawn)
-	end
+	  for _, player in pairs(team) do
+	    Duel:SpawnPlayer(player, teamSpawn)
+	  end
   end
 end
 
 function Duel.Map(func)
   for _, team in pairs(self.teams) do
     for _, player in pairs(team) do
-	  func(player)
-	end
+	      func(player)
+	  end
   end
 end
 

--- a/game/scripts/vscripts/components/duels/duel.lua
+++ b/game/scripts/vscripts/components/duels/duel.lua
@@ -106,10 +106,10 @@ function Duel:RestorePlayerState(player)
   hero:setMana(s.mana)
 
   for abilityIndex = 0,state.maxAbility-1 do
-	local ability = hero:GetAbilityByIndex(abilityIndex)
-	if ability ~= nil then
-	  ability:StartCooldown(state.abilities[abilityIndex].cooldown)
-	end
+	  local ability = hero:GetAbilityByIndex(abilityIndex)
+	  if ability ~= nil then
+	    ability:StartCooldown(state.abilities[abilityIndex].cooldown)
+	  end
   end
   self.zone.removePlayer(player.id)
 end

--- a/game/scripts/vscripts/components/duels/duel.lua
+++ b/game/scripts/vscripts/components/duels/duel.lua
@@ -11,7 +11,7 @@ function Duel:Init (teams, spawns, zone)
   for index, team in pairs(teams) do
     self.scores[index] = {#team}
     for _,player in pairs(team) do
-	    player.team = index
+      player.team = index
   	end
   end
 
@@ -106,10 +106,10 @@ function Duel:RestorePlayerState(player)
   hero:setMana(s.mana)
 
   for abilityIndex = 0,state.maxAbility-1 do
-	  local ability = hero:GetAbilityByIndex(abilityIndex)
-	  if ability ~= nil then
-	    ability:StartCooldown(state.abilities[abilityIndex].cooldown)
-	  end
+    local ability = hero:GetAbilityByIndex(abilityIndex)
+    if ability ~= nil then
+      ability:StartCooldown(state.abilities[abilityIndex].cooldown)
+    end
   end
   self.zone.removePlayer(player.id)
 end

--- a/game/scripts/vscripts/components/duels/duel.lua
+++ b/game/scripts/vscripts/components/duels/duel.lua
@@ -10,7 +10,7 @@ function Duel:Init (teams, spawns, zone)
 
   for index, team in pairs(teams) do
     self.scores[index] = {#team}
-	  for _,player in pairs(team) do
+    for _,player in pairs(team) do
 	    player.team = index
   	end
   end
@@ -26,9 +26,9 @@ end
 function Duel:Start()
   for index, team in pairs(self.teams) do
     local teamSpawn = self.spawns[index]
-	  for _, player in pairs(team) do
-	    Duel:SpawnPlayer(player, teamSpawn)
-	  end
+    for _, player in pairs(team) do
+      Duel:SpawnPlayer(player, teamSpawn)
+    end
   end
 end
 

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -8,7 +8,7 @@ if Duels == nil then
   Debug.EnabledModules['duels:*'] = true
   Debug.EnabledModules['zonecontrol:*'] = true
 
-  ChatCommand:LinkCommand("-duel", "Warn", Duels)
+  ChatCommand:LinkCommand("-duel", "QueueDuels", Duels)
   ChatCommand:LinkCommand("-end_duel", "EndDuels", Duels)
 end
 
@@ -29,12 +29,12 @@ function Duels:Init ()
   self.teams = Duels:GetTeams()
 
   Timers:CreateTimer(1, function ()
-    Duels:Warn()
+    Duels:QueueDuels()
   end)
 
 end
 
-function Duels:Warn()
+function Duels:QueueDuels()
   Notifications:TopToAll({text="A duel will start in 10 seconds!", duration=5.0})
   for index = 1,5 do
     Timers:CreateTimer(4 + index, function ()

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -53,11 +53,11 @@ function Duels:GetTeams()
 
   for playerId = 0,19 do
     local player = PlayerResource:GetPlayer(playerId)
-	  if player:GetTeam() == 3 then
-	    table.insert(teams[1], player)
-	  elseif player:GetTeam() == 2 then
-	    table.insert(teams[2], player)
-	  end
+    if player:GetTeam() == 3 then
+      table.insert(teams[1], player)
+    elseif player:GetTeam() == 2 then
+      table.insert(teams[2], player)
+    end
   end
   return teams
 end
@@ -91,8 +91,8 @@ function Duels:CreateDuels()
   local maxPlayers = 20
   for _, team in self.teams do
     if #team < maxPlayers then
-	    maxPlayers = #team
-	  end
+      maxPlayers = #team
+    end
   end
 
   DebugPrint('Max players per team for this duel ' .. maxPlayers)

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -53,11 +53,11 @@ function Duels:GetTeams()
 
   for playerId = 0,19 do
     local player = PlayerResource:GetPlayer(playerId)
-	if player:GetTeam() == 3 then
-	  table.insert(teams[1], player)
-	elseif player:GetTeam() == 2 then
-	  table.insert(teams[2], player)
-	end
+	  if player:GetTeam() == 3 then
+	    table.insert(teams[1], player)
+	  elseif player:GetTeam() == 2 then
+	    table.insert(teams[2], player)
+	  end
   end
   return teams
 end
@@ -91,8 +91,8 @@ function Duels:CreateDuels()
   local maxPlayers = 20
   for _, team in self.teams do
     if #team < maxPlayers then
-	  maxPlayers = #team
-	end
+	    maxPlayers = #team
+	  end
   end
 
   DebugPrint('Max players per team for this duel ' .. maxPlayers)
@@ -110,8 +110,8 @@ function Duels:CreateDuels()
   local duelists = {{},{}}
   for playerNumber = 1,playerSplitOffset do
     for index, team in pairs(self.teams) do
-	  table.insert(duelists[index], team[playerNumber])
-	end
+	    table.insert(duelists[index], team[playerNumber])
+	  end
   end
 
   local spawns = Duels:GetSpawns(1)
@@ -120,8 +120,8 @@ function Duels:CreateDuels()
   local duelists2 = {{},{}}
   for playerNumber = playerSplitOffset+1, maxPlayers do
     for index, team in pairs(self.teams) do
-	  table.insert(duelists[index], team[playerNumber])
-	end
+	    table.insert(duelists[index], team[playerNumber])
+	  end
   end
 
   local spawns2 = Duels.GetSpawns(2)

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -8,78 +8,33 @@ if Duels == nil then
   Debug.EnabledModules['duels:*'] = true
   Debug.EnabledModules['zonecontrol:*'] = true
 
-  ChatCommand:LinkCommand("-duel", "StartDuel", Duels)
-  ChatCommand:LinkCommand("-end_duel", "EndDuel", Duels)
+  ChatCommand:LinkCommand("-duel", "Warn", Duels)
+  ChatCommand:LinkCommand("-end_duel", "EndDuels", Duels)
 end
-
---[[
- TODO: Refactor this file into a few modules so that there's less of a wall of code here
-]]
 
 function Duels:Init ()
   DebugPrint('Init duels')
 
-  Duels.currentDuel = nil
-  Duels.zone1 = ZoneControl:CreateZone('duel_1', {
+  self.zone1 = ZoneControl:CreateZone('duel_1', {
     mode = ZONE_CONTROL_INCLUSIVE,
     players = {
     }
   })
 
-  Duels.zone2 = ZoneControl:CreateZone('duel_2', {
+  self.zone2 = ZoneControl:CreateZone('duel_2', {
     mode = ZONE_CONTROL_INCLUSIVE,
     players = {
     }
   })
-
-  GameEvents:OnHeroKilled(function (keys)
-    Duels:CheckDuelStatus(keys)
-  end)
+  self.teams = Duels:GetTeams()
 
   Timers:CreateTimer(1, function ()
-    Duels:StartDuel()
+    Duels:Warn()
   end)
+
 end
 
-local DUEL_IS_STARTING = 21
-
-function Duels:CheckDuelStatus (keys)
-  if not Duels.currentDuel or Duels.currentDuel == DUEL_IS_STARTING or keys.killed:IsReincarnating() then
-    return
-  end
-
-  local playerId = keys.killed:GetPlayerOwnerID()
-  local foundIt = false
-
-  Duels:AllPlayers(Duels.currentDuel, function (player)
-    if foundIt or player.id ~= playerId then
-      return
-    end
-    foundIt = true
-    local scoreIndex = player.team .. 'Living' .. player.duelNumber
-    DebugPrint('Found dead player on ' .. player.team .. ' team with scoreindex ' .. scoreIndex)
-
-    Duels.currentDuel[scoreIndex] = Duels.currentDuel[scoreIndex] - 1
-
-    if Duels.currentDuel[scoreIndex] <= 0 then
-      Duels.currentDuel['duelEnd' .. player.duelNumber] = true
-      DebugPrint('Duel number ' .. scoreIndex .. ' is over and ' .. player.team .. ' lost')
-    end
-
-    if Duels.currentDuel.duelEnd1 and Duels.currentDuel.duelEnd2 then
-      DebugPrint('both duels are over, resuming normal play!')
-      Duels:EndDuel()
-    end
-  end)
-end
-
-function Duels:StartDuel ()
-  if Duels.currentDuel then
-    DebugPrint ('There is already a duel running')
-    return
-  end
-  Duels.currentDuel = DUEL_IS_STARTING
-
+function Duels:Warn()
   Notifications:TopToAll({text="A duel will start in 10 seconds!", duration=5.0})
   for index = 1,5 do
     Timers:CreateTimer(4 + index, function ()
@@ -89,46 +44,56 @@ function Duels:StartDuel ()
 
   Timers:CreateTimer(10, function ()
     Notifications:TopToAll({text="DUEL!", duration=3.0, style={color="red", ["font-size"]="110px"}})
-    Duels:ActuallyStartDuel()
+    Duels:CreateDuels()
   end)
 end
 
-function Duels:ActuallyStartDuel ()
-  -- respawn everyone
-  local goodPlayerIndex = 1
-  local badPlayerIndex = 1
-
-  local goodPlayers = {}
-  local badPlayers = {}
+function Duels:GetTeams()
+  local teams = {{},{}}
 
   for playerId = 0,19 do
     local player = PlayerResource:GetPlayer(playerId)
-    if player ~= nil then
-      DebugPrint ('Players team ' .. player:GetTeam())
-      if player:GetTeam() == 3 then
-        badPlayers[badPlayerIndex] = Duels:SavePlayerState(player:GetAssignedHero())
-        badPlayers[badPlayerIndex].id = playerId
-        -- used to generate keynames like badEnd1
-        -- not used in dota apis
-        badPlayers[badPlayerIndex].team = 'bad'
-        badPlayerIndex = badPlayerIndex + 1
+	if player:GetTeam() == 3 then
+	  table.insert(teams[1], player)
+	elseif player:GetTeam() == 2 then
+	  table.insert(teams[2], player)
+	end
+  end
+  return teams
+end
 
-      elseif player:GetTeam() == 2 then
-        goodPlayers[goodPlayerIndex] = Duels:SavePlayerState(player:GetAssignedHero())
-        goodPlayers[goodPlayerIndex].id = playerId
-        goodPlayers[goodPlayerIndex].team = 'good'
-        goodPlayerIndex = goodPlayerIndex + 1
-      end
-
-      Duels:ResetPlayerState(player:GetAssignedHero())
+function Duels:ShuffleTeams()
+  for _,t in self.teams do
+    local n = #t
+    while n > 2 do
+      local k = math.random(n)
+      t[n], t[k] = t[k], t[n]
+      n = n - 1
     end
   end
+end
 
-  goodPlayerIndex = goodPlayerIndex - 1
-  badPlayerIndex = badPlayerIndex - 1
+function Duels:GetSpawns(zone)
+  local spawnLocations = math.random(0, 1) == 1
+  local spawn1 = Entities:FindByName(nil, 'duel_'..zone..'_spawn_1'):GetAbsOrigin()
+  local spawn2 = Entities:FindByName(nil, 'duel_'..zone..'_spawn_2'):GetAbsOrigin()
 
-  -- split up players, put them in the duels
-  local maxPlayers = math.min(goodPlayerIndex, badPlayerIndex)
+  if spawnLocations then
+    local tmp = spawn1
+    spawn1 = spawn2
+    spawn2 = tmp
+  end
+
+  return {spawn1, spawn2}
+end
+
+function Duels:CreateDuels()
+  local maxPlayers = 20
+  for _, team in self.teams do
+    if #team < maxPlayers then
+	  maxPlayers = #team
+	end
+  end
 
   DebugPrint('Max players per team for this duel ' .. maxPlayers)
 
@@ -139,228 +104,46 @@ function Duels:ActuallyStartDuel ()
   end
 
   local playerSplitOffset = math.random(0, maxPlayers)
-  -- local playerSplitOffset = maxPlayers
-  local spawnLocations = math.random(0, 1) == 1
-  local spawn1 = Entities:FindByName(nil, 'duel_1_spawn_1'):GetAbsOrigin()
-  local spawn2 = Entities:FindByName(nil, 'duel_1_spawn_2'):GetAbsOrigin()
 
-  if spawnLocations then
-    local tmp = spawn1
-    spawn1 = spawn2
-    spawn2 = tmp
-  end
+  Duels:ShuffleTeams()
 
+  local duelists = {{},{}}
   for playerNumber = 1,playerSplitOffset do
-    DebugPrint('Checking player number ' .. playerNumber)
-    local goodGuy = Duels:GetUnassignedPlayer(goodPlayers, goodPlayerIndex)
-    local badGuy = Duels:GetUnassignedPlayer(badPlayers, badPlayerIndex)
-    local goodPlayer = PlayerResource:GetPlayer(goodGuy.id)
-    local badPlayer = PlayerResource:GetPlayer(badGuy.id)
-    local goodHero = goodPlayer:GetAssignedHero()
-    local badHero = badPlayer:GetAssignedHero()
-
-    goodGuy.duelNumber = 1
-    badGuy.duelNumber = 1
-
-    FindClearSpaceForUnit(goodHero, spawn1, true)
-    FindClearSpaceForUnit(badHero, spawn2, true)
-
-    Duels.zone1.addPlayer(goodGuy.id)
-    Duels.zone1.addPlayer(badGuy.id)
-
-    Duels:MoveCameraToPlayer(goodGuy.id, goodHero)
-    Duels:MoveCameraToPlayer(badGuy.id, badHero)
-
-    -- disable respawn
-    goodHero:SetRespawnsDisabled(true)
-    badHero:SetRespawnsDisabled(true)
+    for index, team in pairs(self.teams) do
+	  table.insert(duelists[index], team[playerNumber])
+	end
   end
 
-  spawn1 = Entities:FindByName(nil, 'duel_2_spawn_1'):GetAbsOrigin()
-  spawn2 = Entities:FindByName(nil, 'duel_2_spawn_2'):GetAbsOrigin()
+  local spawns = Duels:GetSpawns(1)
+  self.duel1 = duelLib.Duel(duelists, spawns, self.zone1)
 
-  if spawnLocations then
-    local tmp = spawn1
-    spawn1 = spawn2
-    spawn2 = tmp
+  local duelists2 = {{},{}}
+  for playerNumber = playerSplitOffset+1, maxPlayers do
+    for index, team in pairs(self.teams) do
+	  table.insert(duelists[index], team[playerNumber])
+	end
   end
 
-  for playerNumber = playerSplitOffset+1,maxPlayers do
-    DebugPrint('Checking player number ' .. playerNumber)
-    local goodGuy = Duels:GetUnassignedPlayer(goodPlayers, goodPlayerIndex)
-    local badGuy = Duels:GetUnassignedPlayer(badPlayers, badPlayerIndex)
-    local goodPlayer = PlayerResource:GetPlayer(goodGuy.id)
-    local badPlayer = PlayerResource:GetPlayer(badGuy.id)
-    local goodHero = goodPlayer:GetAssignedHero()
-    local badHero = badPlayer:GetAssignedHero()
+  local spawns2 = Duels.GetSpawns(2)
+  self.duel2 = duelLib.Duel(duelists2, spawns2, self.zone2)
 
-    goodGuy.duelNumber = 2
-    badGuy.duelNumber = 2
-
-    FindClearSpaceForUnit(goodHero, spawn1, true)
-    FindClearSpaceForUnit(badHero, spawn2, true)
-
-    Duels.zone2.addPlayer(goodGuy.id)
-    Duels.zone2.addPlayer(badGuy.id)
-
-    Duels:MoveCameraToPlayer(goodGuy.id, goodHero)
-    Duels:MoveCameraToPlayer(badGuy.id, badHero)
-
-    -- disable respawn
-    goodHero:SetRespawnsDisabled(true)
-    badHero:SetRespawnsDisabled(true)
-  end
-
-  Duels.currentDuel = {
-    goodLiving1 = playerSplitOffset,
-    badLiving1 = playerSplitOffset,
-    goodLiving2 = maxPlayers - playerSplitOffset,
-    badLiving2 = maxPlayers - playerSplitOffset,
-    duelEnd1 = playerSplitOffset == 0,
-    duelEnd2 = maxPlayers == playerSplitOffset,
-    badPlayers = badPlayers,
-    goodPlayers = goodPlayers,
-    badPlayerIndex = badPlayerIndex,
-    goodPlayerIndex = goodPlayerIndex
-  }
-
-  Timers:CreateTimer(90, Dynamic_Wrap(Duels, 'EndDuel'))
+  Timers:CreateTimer(90, Dynamic_Wrap(Duels, 'EndDuels'))
 end
 
-function Duels:MoveCameraToPlayer (playerId, entity)
-  PlayerResource:SetCameraTarget(playerId, entity)
-
-  Timers:CreateTimer(1, function ()
-    PlayerResource:SetCameraTarget(playerId, nil)
-  end)
-end
-
-function Duels:GetUnassignedPlayer (group, max)
-  while true do
-    local playerIndex = math.random(1, max)
-    if group[playerIndex].assigned == nil then
-      group[playerIndex].assigned = true
-      return group[playerIndex]
-    end
-  end
-end
-
-function Duels:EndDuel ()
-  if Duels.currentDuel == nil then
-    DebugPrint ('There is no duel running')
-    return
-  end
-
-  DebugPrint('Duel has ended')
-
+function Duels:EndDuels ()
   local nextDuelIn = 300
   -- why dont these run?
-  Timers:CreateTimer(nextDuelIn, Dynamic_Wrap(Duels, 'StartDuel'))
+  Timers:CreateTimer(nextDuelIn, Dynamic_Wrap(Duels, 'Warn'))
   Timers:CreateTimer(nextDuelIn - 50, function ()
     Notifications:TopToAll({text="A duel will start in 1 minute!", duration=10.0})
   end)
 
-  for playerId = 0,19 do
-    Duels.zone1.removePlayer(playerId)
-    Duels.zone2.removePlayer(playerId)
-    local player = PlayerResource:GetPlayer(playerId)
-    if player ~= nil then
-      player:GetAssignedHero():SetRespawnsDisabled(false)
-    end
+  if not self.duel1.over then
+    self.duel1.EndDuel()
   end
-
-  local currentDuel = Duels.currentDuel
-  Duels.currentDuel = nil
-
-  Timers:CreateTimer(function ()
-    Duels:AllPlayers(currentDuel, function (state)
-      -- DebugPrintTable(state)
-      DebugPrint('Is this a player id? ' .. state.id)
-      local player = PlayerResource:GetPlayer(state.id)
-      local hero = player:GetAssignedHero()
-      hero:SetRespawnsDisabled(false)
-      if not hero:IsAlive() then
-        hero:RespawnHero(false,false,false)
-      end
-
-      Duels:RestorePlayerState (hero, state)
-      Duels:MoveCameraToPlayer(state.id, hero)
-    end)
-  end)
+  if not self.duel2.over then
+    self.duel2.EndDuel()
+  end
+  DebugPrint('Duel has ended')
 end
 
-function Duels:ResetPlayerState (hero)
-  if not hero:IsAlive() then
-    hero:RespawnHero(false,false,false)
-  end
-
-  hero:SetHealth(hero:GetMaxHealth())
-  hero:SetMana(hero:GetMaxMana())
-
-  for abilityIndex = 0,hero:GetAbilityCount() do
-    local ability = hero:GetAbilityByIndex(abilityIndex)
-    if ability ~= nil then
-      ability:EndCooldown()
-    end
-  end
-end
-
-function Duels:SavePlayerState (hero)
-  local state = {
-    location = hero:GetAbsOrigin(),
-    abilityCount = hero:GetAbilityCount(),
-    maxAbility = 0,
-    abilities = {},
-    hp = hero:GetHealth(),
-    mana = hero:GetMana()
-  }
-
-  for abilityIndex = 0,state.abilityCount-1 do
-    local ability = hero:GetAbilityByIndex(abilityIndex)
-    if ability ~= nil then
-      state.maxAbility = abilityIndex
-      state.abilities[abilityIndex] = {
-        cooldown = ability:GetCooldownTimeRemaining()
-      }
-    end
-  end
-
-  return state
-end
-
-function Duels:RestorePlayerState (hero, state)
-  hero:SetAbsOrigin(state.location)
-  if state.hp > 0 then
-    hero:SetHealth(state.hp)
-  end
-  hero:SetMana(state.mana)
-
-  for abilityIndex = 0,state.maxAbility-1 do
-    local ability = hero:GetAbilityByIndex(abilityIndex)
-    if ability ~= nil then
-      ability:StartCooldown(state.abilities[abilityIndex].cooldown)
-    end
-  end
-end
-
-function Duels:AllPlayers (state, cb)
-  if state == nil then
-    for playerId = 0,19 do
-      local player = PlayerResource:GetPlayer(playerId)
-      if player ~= nil then
-        cb(player)
-      end
-    end
-  else
-    for playerIndex = 1,state.badPlayerIndex do
-      if state.badPlayers[playerIndex] ~= nil then
-        cb(state.badPlayers[playerIndex])
-      end
-    end
-    for playerIndex = 1,state.goodPlayerIndex do
-      if state.goodPlayers[playerIndex] ~= nil then
-        cb(state.goodPlayers[playerIndex])
-      end
-    end
-  end
-end


### PR DESCRIPTION
I've refactored the duel mechanic to have one "duels" handler that maintains the timers and generates teams for duels. It then instantiates duel objects which take care of player state and movement into/out of the duel. I think there was some kind of problem somewhere in the team allocation code that was causing a lot of the issues with people not being sent into duels properly etc. Hopefully this fix the issue, and if not it'll be a lot quicker to fix now that the functions are much simplified.