### PR TITLE
Corrected First Mana's illusion count tooltip

### DIFF
--- a/game/scripts/npc/items/item_manta.txt
+++ b/game/scripts/npc/items/item_manta.txt
@@ -81,7 +81,7 @@
 			"06"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"images_count"			"2 3 4"
+				"images_count"			"2 2 2 3"
 			}
 			"07"
 			{


### PR DESCRIPTION
All the others say "2 2 2 3", except the first one.