### PR TITLE
Made Skip Phase Faster

### DIFF
--- a/game/scripts/vscripts/internal/gamemode.lua
+++ b/game/scripts/vscripts/internal/gamemode.lua
@@ -30,10 +30,12 @@ function GameMode:_InitGameMode()
   GameRules:SetCustomVictoryMessageDuration( VICTORY_MESSAGE_DURATION )
   GameRules:SetStartingGold( STARTING_GOLD )
 
-  if SKIP_TEAM_SETUP then
+  if SKIP_TEAM_SETUP or IsInToolsMode() then
     GameRules:SetCustomGameSetupAutoLaunchDelay( 0 )
     GameRules:LockCustomGameSetupTeamAssignment( true )
     GameRules:EnableCustomGameSetupAutoLaunch( true )
+    GameRules:SetStrategyTime( 0 )
+    GameRules:SetShowcaseTime( 0 )
   else
     GameRules:SetCustomGameSetupAutoLaunchDelay( AUTO_LAUNCH_DELAY )
     GameRules:LockCustomGameSetupTeamAssignment( LOCK_TEAM_SETUP )

--- a/game/scripts/vscripts/internal/gamemode.lua
+++ b/game/scripts/vscripts/internal/gamemode.lua
@@ -30,7 +30,7 @@ function GameMode:_InitGameMode()
   GameRules:SetCustomVictoryMessageDuration( VICTORY_MESSAGE_DURATION )
   GameRules:SetStartingGold( STARTING_GOLD )
 
-  if SKIP_TEAM_SETUP or IsInToolsMode() then
+  if SKIP_TEAM_SETUP then
     GameRules:SetCustomGameSetupAutoLaunchDelay( 0 )
     GameRules:LockCustomGameSetupTeamAssignment( true )
     GameRules:EnableCustomGameSetupAutoLaunch( true )


### PR DESCRIPTION
Made it so skip phase is always enabled in tools mode, also skips the selection phase (about 1 second), and also removed the showcase phase. 

Enabling it always in toolsmode will cause problems if you are trying to test the Panorama menu at the start, but having it enabled, with these modifications will save like 4 or 5 seconds each time you restart the map, which will add up over time. 