### PR TITLE
Fix 26 second respawn timer from dying to creeps - if wanted.

### DIFF
--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -165,24 +165,13 @@ function GameMode:InitGameMode()
   DebugPrint('[BAREBONES] Starting to load Barebones gamemode...')
 
   InitModule(GameLengthVotes)
-  	ListenToGameEvent( "entity_killed", Dynamic_Wrap( GameMode, 'OnEntityKilled' ), self )
   -- Commands can be registered for debugging purposes or as functions that can be called by the custom Scaleform UI
   -- Convars:RegisterCommand( "command_example", Dynamic_Wrap(GameMode, 'ExampleConsoleCommand'), "A console command example", FCVAR_CHEAT )
 
   DebugPrint('[BAREBONES] Done loading Barebones gamemode!\n\n')
 end
 
----------------------------------------------------------------------------
--- Event: OnEntityKilled
----------------------------------------------------------------------------
-function GameMode:OnEntityKilled( event )
-  local killedUnit = EntIndexToHScript( event.entindex_killed )
-  local killingUnit = EntIndexToHScript( event.entindex_attacker )
-  local respawnTime = 5
-  if killedUnit:IsRealHero() == true and killingUnit:IsRealHero() ~= true then
-    killedUnit:SetTimeUntilRespawn(respawnTime)    
-  end
-end
+
 
 -- This is an example console command
 -- function GameMode:ExampleConsoleCommand()

--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -165,11 +165,23 @@ function GameMode:InitGameMode()
   DebugPrint('[BAREBONES] Starting to load Barebones gamemode...')
 
   InitModule(GameLengthVotes)
-
+  	ListenToGameEvent( "entity_killed", Dynamic_Wrap( GameMode, 'OnEntityKilled' ), self )
   -- Commands can be registered for debugging purposes or as functions that can be called by the custom Scaleform UI
   -- Convars:RegisterCommand( "command_example", Dynamic_Wrap(GameMode, 'ExampleConsoleCommand'), "A console command example", FCVAR_CHEAT )
 
   DebugPrint('[BAREBONES] Done loading Barebones gamemode!\n\n')
+end
+
+---------------------------------------------------------------------------
+-- Event: OnEntityKilled
+---------------------------------------------------------------------------
+function GameMode:OnEntityKilled( event )
+  local killedUnit = EntIndexToHScript( event.entindex_killed )
+  local killingUnit = EntIndexToHScript( event.entindex_attacker )
+  local respawnTime = 6
+  if killedUnit:IsRealHero() == true and killingUnit:IsRealHero() ~= true then
+    killedUnit:SetTimeUntilRespawn(respawnTime)    
+  end
 end
 
 -- This is an example console command

--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -168,6 +168,7 @@ function GameMode:InitGameMode()
   -- Commands can be registered for debugging purposes or as functions that can be called by the custom Scaleform UI
   -- Convars:RegisterCommand( "command_example", Dynamic_Wrap(GameMode, 'ExampleConsoleCommand'), "A console command example", FCVAR_CHEAT )
 
+  
   DebugPrint('[BAREBONES] Done loading Barebones gamemode!\n\n')
 end
 

--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -178,7 +178,7 @@ end
 function GameMode:OnEntityKilled( event )
   local killedUnit = EntIndexToHScript( event.entindex_killed )
   local killingUnit = EntIndexToHScript( event.entindex_attacker )
-  local respawnTime = 6
+  local respawnTime = 5
   if killedUnit:IsRealHero() == true and killingUnit:IsRealHero() ~= true then
     killedUnit:SetTimeUntilRespawn(respawnTime)    
   end


### PR DESCRIPTION
This is one potential way to fix the 26 second respawn from dying to creeps and set it to 5 seconds.

Maybe there's a better way, or place for this, but this does the job.

If the dying unit == a hero, and the killing unit ~= a hero, then change the time until respawn.