### PR TITLE
Update Nature's Call and refactor talent checking to use a function

### DIFF
--- a/game/scripts/vscripts/abilities/oaa_demonic_conversion.lua
+++ b/game/scripts/vscripts/abilities/oaa_demonic_conversion.lua
@@ -22,7 +22,7 @@ function enigma_demonic_conversion:OnSpellStart()
 
   -- Grant extra ediolon spawns from talent
   if casterHasExtraEidolons then
-    spawnCount = spawnCount + extraEidolonsAbility:GetSpecialValueFor("value")
+    spawnCount = spawnCount + caster:FindAbilityByName("special_bonus_unique_enigma"):GetSpecialValueFor("value")
   end
 
   -- Kill the target and spawn Eidolons

--- a/game/scripts/vscripts/abilities/oaa_demonic_conversion.lua
+++ b/game/scripts/vscripts/abilities/oaa_demonic_conversion.lua
@@ -18,11 +18,7 @@ function enigma_demonic_conversion:OnSpellStart()
                       "npc_dota_colossal_eidolon"}
 
   -- Check whether the caster has learnt the extra eidolons talent
-  local extraEidolonsAbility = caster:FindAbilityByName("special_bonus_unique_enigma")
-  local casterHasExtraEidolons = false
-  if extraEidolonsAbility then
-    casterHasExtraEidolons = extraEidolonsAbility:GetLevel() > 0
-  end
+  local casterHasExtraEidolons = caster:HasLearnedAbility("special_bonus_unique_enigma")
 
   -- Grant extra ediolon spawns from talent
   if casterHasExtraEidolons then

--- a/game/scripts/vscripts/abilities/oaa_force_of_nature.lua
+++ b/game/scripts/vscripts/abilities/oaa_force_of_nature.lua
@@ -59,15 +59,16 @@ function furion_force_of_nature:OnSpellStart()
 
   GridNav:DestroyTreesAroundPoint( target_point, area_of_effect, true )
 
+  -- Check whether the caster has learnt the 2x Treant health/damage talent
+  local caster_has_treant_bonus = caster:HasLearnedAbility( "special_bonus_unique_furion" )
+  -- Check whether the caster has learnt the +4 Treants talent
+  local caster_has_plus_treants = caster:HasLearnedAbility( "special_bonus_unique_furion_2" )
   -- Figure out how many of each treant type to spawn
+  if caster_has_plus_treants then
+    max_treants = max_treants + 4
+  end
   local giant_treants_to_spawn = math.min( max_giant_treants, tree_count )
   local treants_to_spawn = math.min( max_treants, tree_count - giant_treants_to_spawn )
-  -- Check whether the caster has learnt the 2x Treant health/damage talent
-  local treant_bonus_ability = caster:FindAbilityByName( "special_bonus_unique_furion" )
-  local caster_has_treant_bonus = false
-  if treant_bonus_ability then
-    caster_has_treant_bonus = treant_bonus_ability:GetLevel() > 0
-  end
 
   -- Spawn giant treants
   for i=1,giant_treants_to_spawn do

--- a/game/scripts/vscripts/abilities/oaa_force_of_nature.lua
+++ b/game/scripts/vscripts/abilities/oaa_force_of_nature.lua
@@ -65,7 +65,7 @@ function furion_force_of_nature:OnSpellStart()
   local caster_has_plus_treants = caster:HasLearnedAbility( "special_bonus_unique_furion_2" )
   -- Figure out how many of each treant type to spawn
   if caster_has_plus_treants then
-    max_treants = max_treants + 4
+    max_treants = max_treants + caster:FindAbilityByName( "special_bonus_unique_furion_2" ):GetSpecialValueFor( "value" )
   end
   local giant_treants_to_spawn = math.min( max_giant_treants, tree_count )
   local treants_to_spawn = math.min( max_treants, tree_count - giant_treants_to_spawn )

--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -42,6 +42,8 @@ require('libraries/selection')
 require('libraries/math')
 -- chat command registry made easy
 require('libraries/chatcommand')
+-- Extensions to CDOTA_BaseNPC
+require('libraries/basenpc')
 
 -- These internal libraries set up barebones's events and processes.  Feel free to inspect them/change them if you need to.
 require('internal/gamemode')

--- a/game/scripts/vscripts/libraries/basenpc.lua
+++ b/game/scripts/vscripts/libraries/basenpc.lua
@@ -1,0 +1,14 @@
+--[[ Extension functions for CDOTA_BaseNPC
+
+-HasLearnedAbility(abilityName)
+  Checks if the unit has at least one point in ability abilityName.
+  Primarily for checking if talents have been learned.
+--]]
+
+function CDOTA_BaseNPC:HasLearnedAbility(abilityName)
+  local ability = self:FindAbilityByName(abilityName)
+  if ability then
+    return ability:GetLevel() > 0
+  end
+  return false
+end


### PR DESCRIPTION
7.04 gave Nature's Prophet a +4 Treants talent at level 15. This patch just sets the talent to spawn +4 normal Treants at all levels. Should probably change to +1 Giant Treant at levels 5 and 6 or something, but I don't know if that'd confuse players or anything (it's also a little difficult to try and think of a good way to implement it).

P.S. The tooltip for Nature's Call hasn't been changed to reflect its functionality. I know putting that here probably won't be seen by the relevant people, but thought I'd mention it anyway.