### PR TITLE
Add creep XP reduction factor based on number of players at the start of the game

### DIFF
--- a/game/scripts/vscripts/components/creeps/creep_power.lua
+++ b/game/scripts/vscripts/components/creeps/creep_power.lua
@@ -1,28 +1,37 @@
+if CreepPower == nil then
+  DebugPrint ( 'Creating new CreepPower object...' )
+  CreepPower = class({})
+end
 
---defines creep property multipliers for power levels
---nth power level corresponds to creeps spawned at minute n
---if levels are not defined, GetPowerLevelPropertyMultiplier will interpolate values
-CreepPowerTable = {
-  --  LEVEL     HEALTH    MANA      DAMAGE    ARMOR     GOLD      EXP
-  {   0,        1.0,      1.0,      1.0,      1.0,      1.0,      1.0}
-}
-
-function AddScaleValue (minute)
-  table.insert(CreepPowerTable, {
+function CreepPower:AddScaleValue (minute)
+  table.insert(self.PowerTable, {
     minute,                                   -- minute
     ((minute / 8) ^ 2 / 75) + 1,              -- hp
     minute,                                   -- mana
     (minute / 20) + 1,                        -- damage
     minute ^ 0.5,                             -- armor
     (minute / 2) + 1,                         -- gold
-    (3 * (minute^2) + (19 * minute) + 89)/89  -- xp
+    ((3 * (minute^2) + (19 * minute) + 89)/89) * self.numPlayersXPFactor  -- xp
   })
 end
 
-for minute = 1,60 do
-  AddScaleValue(minute)
-end
+function CreepPower:Init ()
+  local maxTeamPlayerCount = 10 -- TODO: Make maxTeamPlayerCount based on values set in settings.lua (?)
+  self.numPlayersXPFactor = PlayerResource:GetTeamPlayerCount() / maxTeamPlayerCount
 
-AddScaleValue(100)
-AddScaleValue(500)
-AddScaleValue(1000)
+  --defines creep property multipliers for power levels
+  --nth power level corresponds to creeps spawned at minute n
+  --if levels are not defined, GetPowerLevelPropertyMultiplier will interpolate values
+  self.PowerTable = {
+    --  LEVEL     HEALTH    MANA      DAMAGE    ARMOR     GOLD      EXP
+    {   0,        1.0,      1.0,      1.0,      1.0,      1.0,      1.0 * self.numPlayersXPFactor}
+  }
+
+  for minute = 1,60 do
+    self:AddScaleValue(minute)
+  end
+
+  self:AddScaleValue(100)
+  self:AddScaleValue(500)
+  self:AddScaleValue(1000)
+end

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -175,6 +175,7 @@ end
 function GetPowerLevelPropertyMultiplier( property_enum, powerLevel )
   local powerLevelPropertyMultiplier = 1
   local lowerIndex = 1
+  local CreepPowerTable = CreepPower.PowerTable
   local higherIndex = #CreepPowerTable
 
   for i=1, #CreepPowerTable do

--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -141,6 +141,7 @@ function GameMode:OnGameInProgress()
 
   -- initialize modules
   InitModule(PointsManager)
+  InitModule(CreepPower)
   InitModule(CreepCamps)
   InitModule(Gold)
   InitModule(BlinkBlock)


### PR DESCRIPTION
Closes #355.

I had to restructure the `CreepPowerTable` to be a module with an `Init` function so that it wouldn't attempt to access `PlayerResource` immediately when `require`'d because that's too early (`PlayerResource` is still `nil` at that point).