### PR TITLE
Update Postactive Reflex item

### DIFF
--- a/game/scripts/vscripts/items/reflex/postactive.lua
+++ b/game/scripts/vscripts/items/reflex/postactive.lua
@@ -28,7 +28,7 @@ function item_postactive:OnSpellStart()
   end
 
   local modifiers = caster:FindAllModifiers()
-  local purgableDebuffs = wrap(filter(IsPurgableDebuff, iter(modifiers)))
+  local purgableDebuffs = filter(IsPurgableDebuff, iter(modifiers))
 
   if is_null(purgableDebuffs) then
     return

--- a/game/scripts/vscripts/items/reflex/postactive.lua
+++ b/game/scripts/vscripts/items/reflex/postactive.lua
@@ -1,4 +1,4 @@
-LinkLuaModifier("modifier_purgetester", "modifiers/modifier_purgetetser.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_purgetester", "modifiers/modifier_purgetester.lua", LUA_MODIFIER_MOTION_NONE)
 
 item_postactive = class({})
 

--- a/game/scripts/vscripts/items/reflex/postactive.lua
+++ b/game/scripts/vscripts/items/reflex/postactive.lua
@@ -1,6 +1,6 @@
-if not item_postactive then
-  item_postactive = class({})
-end
+LinkLuaModifier("modifier_purgetester", "modifiers/modifier_purgetetser.lua", LUA_MODIFIER_MOTION_NONE)
+
+item_postactive = class({})
 
 function item_postactive:OnSpellStart()
   local caster = self:GetCaster()
@@ -11,6 +11,7 @@ function item_postactive:OnSpellStart()
   --for built-in modifiers)
   function IsPurgableDebuff(modifier)
     local testUnit = CreateUnitByName("npc_dota_lone_druid_bear1", Vector(0, 0, 0), false, caster, caster:GetOwner(), caster:GetTeamNumber())
+    testUnit:AddNewModifier(testUnit, nil, "modifier_purgetester", nil)
     testUnit:AddNewModifier(modifier:GetCaster(), modifier:GetAbility(), modifier:GetName(), nil)
     testUnit:Purge(false, true, true, false, false)
     local modifierIsPurgableDebuff = not testUnit:HasModifier(modifier:GetName())

--- a/game/scripts/vscripts/modifiers/modifier_purgetester.lua
+++ b/game/scripts/vscripts/modifiers/modifier_purgetester.lua
@@ -1,0 +1,25 @@
+-- Modifier that grants 500% damage reduction. Mainly for protecting "purge tester" units, like in
+-- items/reflex/postactive.lua
+modifier_purgetester = class({})
+
+function modifier_purgetester:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE
+  }
+end
+
+function modifier_purgetester:IsHidden()
+  return true
+end
+
+function modifier_purgetester:IsPurgable()
+  return false
+end
+
+function modifier_purgetester:IsPurgeException()
+  return false
+end
+
+function modifier_purgetester:GetModifierIncomingDamage_Percentage(keys)
+  return -500
+end

--- a/game/scripts/vscripts/modifiers/modifier_purgetester.lua
+++ b/game/scripts/vscripts/modifiers/modifier_purgetester.lua
@@ -1,10 +1,12 @@
--- Modifier that grants 500% damage reduction. Mainly for protecting "purge tester" units, like in
+-- Modifier that grants complete damage immunity. Mainly for protecting "purge tester" units, like in
 -- items/reflex/postactive.lua
 modifier_purgetester = class({})
 
 function modifier_purgetester:DeclareFunctions()
   return {
-    MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE
+    MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_MAGICAL,
+    MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_PHYSICAL,
+    MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_PURE
   }
 end
 
@@ -20,6 +22,14 @@ function modifier_purgetester:IsPurgeException()
   return false
 end
 
-function modifier_purgetester:GetModifierIncomingDamage_Percentage(keys)
-  return -500
+function modifier_purgetester:GetAbsoluteNoDamageMagical(keys)
+  return 1
+end
+
+function modifier_purgetester:GetAbsoluteNoDamagePhysical(keys)
+  return 1
+end
+
+function modifier_purgetester:GetAbsoluteNoDamagePure(keys)
+  return 1
 end


### PR DESCRIPTION
Remove unnecessary call of `wrap`.
Add a 500% damage reduction modifier to the purge-testing unit to ensure it doesn't die. I'd use invulnerability, but I don't know if that would cause problems with trying to apply and purge modifiers on the test unit.