### PR TITLE
Add audiovisual effects for Postactive 1

### DIFF
--- a/game/scripts/npc/items/reflex_cores/postactive/item_postactive.txt
+++ b/game/scripts/npc/items/reflex_cores/postactive/item_postactive.txt
@@ -5,15 +5,15 @@
 	//=================================================================================================================
 	"item_recipe_postactive"
 	{
-		"ID"							"3562"		// unique ID
-		"BaseClass"                     "item_datadriven"
-		"AbilityTextureName"			"item_recipe"
-		"Model"							"models/props_gameplay/recipe.mdl"
+		"ID"							      "3562"		// unique ID
+    "BaseClass"             "item_datadriven"
+		"AbilityTextureName"	  "item_recipe"
+		"Model"							    "models/props_gameplay/recipe.mdl"
 		"FightRecapLevel"				"1"
-		"ItemCost"						"2300"
+		"ItemCost"						  "2300"
 		"ItemShopTags"					""
-		"ItemRecipe"					"1"
-		"ItemResult"					"item_postactive"
+		"ItemRecipe"					  "1"
+		"ItemResult"					  "item_postactive"
 		"ItemRequirements"
 		{
 			"01"						"item_reflex_core"
@@ -27,15 +27,15 @@
 	{
 		// General
 		//-------------------------------------------------------------------------------------------------------------
-		"ID"							"3563"														// unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
-		"BaseClass"                     "item_lua"
-    "ScriptFile"                    "items/reflex/postactive.lua"
-		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
-		"AbilityTextureName"            "item_firecrackers"
+		"ID"                    "3563"														// unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+		"BaseClass"             "item_lua"
+    "ScriptFile"            "items/reflex/postactive.lua"
+		"AbilityBehavior"			  "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
+		"AbilityTextureName"    "item_firecrackers"
 		// Stats
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityCooldown"				"10.0"
-		"AbilityCastPoint"				"0.0"
+		"AbilityCastPoint"		  "0.0"
 
 		"MaxUpgradeLevel"				"1"
 		"ItemBaseLevel"					"1"
@@ -43,16 +43,24 @@
 		// Item Info
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityManaCost"				"100"
-		"ItemCost"						"5000"
+		"ItemCost"						  "5000"
 		"ItemShopTags"					"agi;str;int;attack_speed;move_speed;hard_to_tag"
-		"ItemQuality"					"epic"
-		"ItemAliases"					"wing chun"
-		"ItemDisassembleRule"			"DOTA_ITEM_DISASSEMBLE_ALWAYS"
-		"ItemDeclarations"				"DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
+		"ItemQuality"					  "epic"
+		"ItemAliases"					  "wing chun"
+		"ItemDisassembleRule"		"DOTA_ITEM_DISASSEMBLE_ALWAYS"
+		"ItemDeclarations"			"DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
 		// Special
 		//-------------------------------------------------------------------------------------------------------------
 
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "precache"
+    {
+      "soundfile"  "soundevents/game_sounds_heroes/game_sounds_abaddon.vsndevts"
+      "particle"   "particles/items3_fx/lotus_orb_shell_shield_cast.vpcf"
+    }
 	}
 
 }

--- a/game/scripts/vscripts/addon_game_mode.lua
+++ b/game/scripts/vscripts/addon_game_mode.lua
@@ -18,6 +18,8 @@ function Precache( context )
 
   DebugPrint("[BAREBONES] Performing pre-load precache")
 
+  PrecacheItemByNameSync("item_postactive", context)
+
   -- Particles can be precached individually or by folder
   -- It it likely that precaching a single particle system will precache all of its children, but this may not be guaranteed
   --PrecacheResource("particle", "particles/econ/generic/generic_aoe_explosion_sphere_1/generic_aoe_explosion_sphere_1.vpcf", context)

--- a/game/scripts/vscripts/items/reflex/postactive.lua
+++ b/game/scripts/vscripts/items/reflex/postactive.lua
@@ -31,6 +31,12 @@ function item_postactive:OnSpellStart()
   local modifiers = caster:FindAllModifiers()
   local purgableDebuffs = filter(IsPurgableDebuff, iter(modifiers))
 
+  -- Audiovisual effects
+  EmitSoundOn("Hero_Abaddon.AphoticShield.Cast", caster)
+  local particleName1 = "particles/items3_fx/lotus_orb_shell_shield_cast.vpcf"
+  local particle1 = ParticleManager:CreateParticle(particleName1, PATTACH_ABSORIGIN_FOLLOW, caster)
+  ParticleManager:ReleaseParticleIndex(particle1)
+
   if is_null(purgableDebuffs) then
     return
   end


### PR DESCRIPTION
Gave casting the Abaddon Aphotic Shield sound and the Lotus Orb cast glow (without the shell).

@darklordabc, could you add the icon? Seems like not all the icon files you showed in #390 were actually pushed to the repo.