### PR TITLE
Fix being able to sell blacklisted items by dragging item to shopkeeper

### DIFF
--- a/content/panorama/layout/custom_game/custom_ui_manifest.xml
+++ b/content/panorama/layout/custom_game/custom_ui_manifest.xml
@@ -6,6 +6,7 @@
     <include src="file://{resources}/scripts/custom_game/abilitylevels.js" />
     <include src="file://{resources}/scripts/util.js" />
     <include src="file://{resources}/scripts/custom_game/leveldots.js" />
+    <include src="file://{resources}/scripts/custom_game/huderrors.js" />
   </scripts>
   <script>
     // Uncomment any of the following lines in order to disable that portion of the default UI

--- a/content/panorama/scripts/custom_game/huderrors.js
+++ b/content/panorama/scripts/custom_game/huderrors.js
@@ -1,0 +1,9 @@
+'use strict';
+
+(function () {
+  GameEvents.Subscribe('custom_dota_hud_error_message', DisplayHudError);
+}());
+
+function DisplayHudError (data) {
+  GameEvents.SendEventClientSide('dota_hud_error_message', data);
+}

--- a/game/scripts/vscripts/components/sellblacklist/filter.lua
+++ b/game/scripts/vscripts/components/sellblacklist/filter.lua
@@ -22,14 +22,7 @@ function SellBlackList:OrderFilter (filterTable)
     for _,v in ipairs(ItemSellBlackList) do
       if string.find(ability:GetName(), v) ~= nil then
         DebugPrint('Someone is trying to sell an item (' .. ability:GetName() .. ') on the blacklist(' .. v .. ').')
-        Notifications:Bottom(PlayerResource:GetPlayer(issuerID), {
-          text="You can't sell this Item!",
-          duration=1.5,
-          style={
-            color="#b71c1c",
-            ["font-size"]="28px"
-          }
-        })
+        CustomGameEventManager:Send_ServerToPlayer(PlayerResource:GetPlayer(issuerID), "custom_dota_hud_error_message", {reason=70, message=""})
         return false
       end
     end

--- a/game/scripts/vscripts/components/sellblacklist/filter.lua
+++ b/game/scripts/vscripts/components/sellblacklist/filter.lua
@@ -17,8 +17,10 @@ function SellBlackList:OrderFilter (filterTable)
   local abilityEID = filterTable.entindex_ability
   local ability = EntIndexToHScript(abilityEID)
   local issuerID = filterTable.issuer_player_id_const
+  local target = EntIndexToHScript(filterTable.entindex_target)
+  local targetIsShop = string.find(target:GetName(), "shop") ~= nil
 
-  if order == DOTA_UNIT_ORDER_SELL_ITEM then
+  if order == DOTA_UNIT_ORDER_SELL_ITEM or (targetIsShop and order == DOTA_UNIT_ORDER_GIVE_ITEM) then
     for _,v in ipairs(ItemSellBlackList) do
       if string.find(ability:GetName(), v) ~= nil then
         DebugPrint('Someone is trying to sell an item (' .. ability:GetName() .. ') on the blacklist(' .. v .. ').')


### PR DESCRIPTION
Also make the error message use the default Dota "Can't Be Sold" error. This way it has a sound and should be already localised since it's a default string.