### PR TITLE
Modify nil target check in sell blacklist filter so that it doesn't skip order type check

### DIFF
--- a/game/scripts/vscripts/components/sellblacklist/filter.lua
+++ b/game/scripts/vscripts/components/sellblacklist/filter.lua
@@ -18,11 +18,10 @@ function SellBlackList:OrderFilter (filterTable)
   local ability = EntIndexToHScript(abilityEID)
   local issuerID = filterTable.issuer_player_id_const
   local target = EntIndexToHScript(filterTable.entindex_target)
-  if not target then
-    -- fuck it
-    return true
+  local targetIsShop = false
+  if target then
+    targetIsShop = string.find(target:GetName(), "shop") ~= nil
   end
-  local targetIsShop = string.find(target:GetName(), "shop") ~= nil
 
   if order == DOTA_UNIT_ORDER_SELL_ITEM or (targetIsShop and order == DOTA_UNIT_ORDER_GIVE_ITEM) then
     for _,v in ipairs(ItemSellBlackList) do


### PR DESCRIPTION
Just in case sell item orders can come in with nil targets.