### PR TITLE
Fix Trump's Fists heal reduction disabling passive health regen

### DIFF
--- a/game/scripts/vscripts/items/trumps_fists.lua
+++ b/game/scripts/vscripts/items/trumps_fists.lua
@@ -98,7 +98,11 @@ end
 modifier_item_trumps_fists_frostbite = class({})
 
 function modifier_item_trumps_fists_frostbite:OnCreated()
-  self.heal_prevent_percent = self:GetAbility():GetSpecialValueFor( "heal_prevent_percent" )
+  if IsServer() then
+  	self.heal_prevent_percent = self:GetAbility():GetSpecialValueFor( "heal_prevent_percent" )
+    self.passive_heal_reduction = self:GetParent():GetHealthRegen() * self.heal_prevent_percent / 100
+    self:StartIntervalThink(0.1)
+  end
 end
 
 function modifier_item_trumps_fists_frostbite:IsDebuff()
@@ -106,22 +110,33 @@ function modifier_item_trumps_fists_frostbite:IsDebuff()
 end
 
 function modifier_item_trumps_fists_frostbite:DeclareFunctions()
-  local funcs = {
-    MODIFIER_EVENT_ON_HEALTH_GAINED,
-  }
-  return funcs
+	local funcs = {
+		MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT,
+    MODIFIER_EVENT_ON_HEALTH_GAINED
+	}
+	return funcs
 end
 
+function modifier_item_trumps_fists_frostbite:OnIntervalThink()
+  -- Update passive health regen reduction
+  self.passive_heal_reduction = (self:GetParent():GetHealthRegen() - self.passive_heal_reduction) * self.heal_prevent_percent / 100
+end
+
+function modifier_item_trumps_fists_frostbite:GetModifierConstantHealthRegen()
+  return self.passive_heal_reduction
+end
 
 function modifier_item_trumps_fists_frostbite:OnHealthGained( kv )
-  if IsServer() then
-    if kv.unit == self:GetParent() then
+	if IsServer() then
+    -- Check that event is being called for the unit that self is attached to
+    -- and that the healing is not passive regen
+		if kv.unit == self:GetParent() and kv.damage_type ~= 0 then
       local desiredHP = kv.unit:GetHealth() + kv.gain * self.heal_prevent_percent / 100
       desiredHP = math.max(desiredHP, 1)
 
       kv.unit:SetHealth( desiredHP )
-    end
-  end
+		end
+	end
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
To be honest, I'm not sure this will work 100% correct since the check for HealthGain being from passive regen is just derived from some relatively short testing and observation.