### PR TITLE
Illusions having too many stats FIX 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-29-orange.svg?style=flat-square)](#contributors)
 A really great Dota 2 game mode built by [really great people](#contributors).
 
-# Installation
+# Installation1
 This addon uses the [Dota 2 Addon Manager](https://github.com/chrisinajar/dota2-addon-manager).
 
 For detailed instructions, check [here](docs/install.md)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-29-orange.svg?style=flat-square)](#contributors)
 A really great Dota 2 game mode built by [really great people](#contributors).
 
-# Installation1
+# Installation
 This addon uses the [Dota 2 Addon Manager](https://github.com/chrisinajar/dota2-addon-manager).
 
 For detailed instructions, check [here](docs/install.md)

--- a/game/scripts/vscripts/events.lua
+++ b/game/scripts/vscripts/events.lua
@@ -47,6 +47,7 @@ function GameMode:OnNPCSpawned(keys)
 
   local npc = EntIndexToHScript(keys.entindex)
 
+  -- ILLUSION HAVING WRONG STATS FIX START --
   local realHero = nil
   if npc.IsIllusion and npc:IsIllusion() and npc:IsHero() then
     -- Search nearby radius to find the real hero

--- a/game/scripts/vscripts/events.lua
+++ b/game/scripts/vscripts/events.lua
@@ -47,6 +47,29 @@ function GameMode:OnNPCSpawned(keys)
 
   local npc = EntIndexToHScript(keys.entindex)
 
+  -- ILLUSION HAVING WRONG STATS FIX START --
+  local owner = npc:GetOwner()
+  -- If spawned entity has an owner, and the owner is a player
+  if owner and owner:IsPlayer() then
+    -- Get Hero entity
+    ownerHero = PlayerResource:GetSelectedHeroEntity(owner:GetPlayerID())
+    -- If Hero entity was found and hero is alive
+    if ownerHero and owner:IsAlive() then
+      -- If the entity that spawned is illusion and a hero
+      if npc:IsIllusion() and npc:IsHero() then
+        Timers:CreateTimer(.1, function ()
+          -- Modify illusions stats so that they are the same as the owning hero
+          npc:ModifyAgility((npc:GetAgility() - ownerHero:GetAgility()) * -1)
+          npc:ModifyStrength((npc:GetStrength() - ownerHero:GetStrength()) * -1)
+          npc:ModifyIntellect((npc:GetIntellect() - ownerHero:GetIntellect()) * -1)
+          npc:SetHealth(ownerHero:GetHealth())
+          npc:SetMana(ownerHero:GetMana())
+        end)
+      end
+    end
+  end
+  -- ILLUSION HAVING WRONG STATS FIX END --
+
   npc.deathEvent = Event()
   function npc:OnDeath(fn)
     return npc.deathEvent.listen(fn)

--- a/game/scripts/vscripts/events.lua
+++ b/game/scripts/vscripts/events.lua
@@ -54,9 +54,6 @@ function GameMode:OnNPCSpawned(keys)
     local nearbyUnits = Entities:FindAllInSphere(npc:GetAbsOrigin(), 1000)
 
     for _, unit in pairs(nearbyUnits) do
-      if unit.IsRealHero and unit:IsIllusion() then
-        print(unit:GetLevel())
-      end
       -- We have found the real hero if: Hero is Real and Not Illusion and has same gold amount as the illusion that spawned
       if unit.IsRealHero and unit:IsRealHero() and not unit:IsIllusion() and unit:GetName() == npc:GetName() then
         realHero = unit

--- a/game/scripts/vscripts/events.lua
+++ b/game/scripts/vscripts/events.lua
@@ -55,8 +55,8 @@ function GameMode:OnNPCSpawned(keys)
     ownerHero = PlayerResource:GetSelectedHeroEntity(owner:GetPlayerID())
     -- If Hero entity was found and hero is alive
     if ownerHero and owner:IsAlive() then
-      -- If the entity that spawned is illusion and a hero
-      if npc:IsIllusion() and npc:IsHero() then
+      -- If the entity that spawned is illusion and a hero, and the hero is the same as the owners hero
+      if npc:IsIllusion() and npc:IsHero() and npc:GetModelName() == ownerHero:GetModelName() then
         Timers:CreateTimer(.1, function ()
           -- Modify illusions stats so that they are the same as the owning hero
           npc:ModifyAgility((npc:GetAgility() - ownerHero:GetAgility()) * -1)

--- a/game/scripts/vscripts/events.lua
+++ b/game/scripts/vscripts/events.lua
@@ -54,7 +54,7 @@ function GameMode:OnNPCSpawned(keys)
     local nearbyUnits = Entities:FindAllInSphere(npc:GetAbsOrigin(), 1000)
 
     for _, unit in pairs(nearbyUnits) do
-      -- We have found the real hero if: Hero is Real and Not Illusion and has same gold amount as the illusion that spawned
+      -- We have found the real hero if: Hero is Real and Not Illusion and unit has same name as the spawned illusion
       if unit.IsRealHero and unit:IsRealHero() and not unit:IsIllusion() and unit:GetName() == npc:GetName() then
         realHero = unit
       end


### PR DESCRIPTION
Basic logic:
Listener for unit spawns, if the spawned unit is an hero illusion, search within 100 radius for all nearby heros, and any hero that matches the illusion hero name, it copies its stats. 

Still Todo: This illusion fix only applies to illusions of yourself. It doesnt yet apply to illusions of allied or enemy illusions, like with wall of replica and disruption. 