### PR TITLE
Move module initialisation

### DIFF
--- a/game/scripts/vscripts/components/gold/gold.lua
+++ b/game/scripts/vscripts/components/gold/gold.lua
@@ -54,7 +54,8 @@ end
 function Gold:Think()
   foreach(function(i)
     if PlayerResource:IsValidPlayerID(i) then
-      if GameRules:State_Get() == DOTA_GAMERULES_STATE_GAME_IN_PROGRESS then
+      local gameState = GameRules:State_Get()
+      if gameState == DOTA_GAMERULES_STATE_GAME_IN_PROGRESS or gameState == DOTA_GAMERULES_STATE_PRE_GAME then
 
         local currentGold = Gold:GetGold(i)
         local currentDotaGold = PlayerResource:GetGold(i)

--- a/game/scripts/vscripts/events.lua
+++ b/game/scripts/vscripts/events.lua
@@ -38,6 +38,18 @@ function GameMode:OnGameRulesStateChange(keys)
   -- Strategy time started
   if newState == DOTA_GAMERULES_STATE_STRATEGY_TIME then
     GameMode:OnStrategyTime()
+  -- Pre-Game started
+  elseif newState == DOTA_GAMERULES_STATE_PRE_GAME then
+    print("Pre-game started")
+    -- initialize modules
+    InitModule(PointsManager)
+    InitModule(Gold)
+    InitModule(BlinkBlock)
+    InitModule(ZoneControl)
+    InitModule(AbilityLevels)
+    InitModule(HeroProgression)
+    InitModule(SellBlackList)
+    InitModule(NGP)
   end
 end
 

--- a/game/scripts/vscripts/events.lua
+++ b/game/scripts/vscripts/events.lua
@@ -40,16 +40,7 @@ function GameMode:OnGameRulesStateChange(keys)
     GameMode:OnStrategyTime()
   -- Pre-Game started
   elseif newState == DOTA_GAMERULES_STATE_PRE_GAME then
-    print("Pre-game started")
-    -- initialize modules
-    InitModule(PointsManager)
-    InitModule(Gold)
-    InitModule(BlinkBlock)
-    InitModule(ZoneControl)
-    InitModule(AbilityLevels)
-    InitModule(HeroProgression)
-    InitModule(SellBlackList)
-    InitModule(NGP)
+    GameMode:OnPreGame()
   end
 end
 

--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -142,6 +142,18 @@ function GameMode:OnStrategyTime()
   PlayerResource:RandomHeroForPlayersWithoutHero()
 end
 
+function GameMode:OnPreGame()
+  -- initialize modules
+  InitModule(PointsManager)
+  InitModule(Gold)
+  InitModule(BlinkBlock)
+  InitModule(ZoneControl)
+  InitModule(AbilityLevels)
+  InitModule(HeroProgression)
+  InitModule(SellBlackList)
+  InitModule(NGP)
+end
+
 --[[
   This function is called once and only once when the game completely begins (about 0:00 on the clock).  At this point,
   gold will begin to go up in ticks if configured, creeps will spawn, towers will become damageable etc.  This function

--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -151,19 +151,11 @@ function GameMode:OnGameInProgress()
   DebugPrint("[BAREBONES] The game has officially begun")
 
   -- initialize modules
-  InitModule(PointsManager)
   InitModule(CreepPower)
   InitModule(CreepCamps)
-  InitModule(Gold)
-  InitModule(BlinkBlock)
   InitModule(CreepItemDrop)
-  InitModule(ZoneControl)
   InitModule(Duels)
-  InitModule(AbilityLevels)
   InitModule(BossSpawner)
-  InitModule(NGP)
-  InitModule(HeroProgression)
-  InitModule(SellBlackList)
 
 end
 


### PR DESCRIPTION
Initialise PointsManager, custom gold, blink blocker handler, zone control handler, custom ability level requirements, HeroProgression, SellBlacklist, and NGP handler at start of pre-game instead of at minute 0.