### PR TITLE
Patched a permadeath case where if people died then reconnect after duel

### DIFF
--- a/game/scripts/vscripts/events.lua
+++ b/game/scripts/vscripts/events.lua
@@ -113,6 +113,16 @@ function GameMode:OnPlayerReconnect(keys)
   OnPlayerReconnectEvent(keys)
   DebugPrint( '[BAREBONES] OnPlayerReconnect' )
   DebugPrintTable(keys)
+
+  local playID = keys.PlayerID
+  if not playID then return end
+
+  local hero = PlayerResource:GetSelectedHeroEntity(playID)
+
+  hero:SetRespawnsDisabled(false)
+  if not hero:IsAlive() then
+    hero:RespawnHero(false,false,false)
+  end
 end
 
 -- An item was purchased by a player


### PR DESCRIPTION
There is a standing bug that caused permadeath in the case that a player is dead during a duel and disconnects, then the duel ends and the player returns. I figured this could be fixed by respawning that hero when they rejoin the game. If we fix the underlying cause (Duels not respawning DCed heroes) we can always remove this later. It's just 10 lines of code.

Temporary fix where if a player reconnects to the game, it checks to see if they are dead and respawns them. If we had longer respawn times I would think this could be a problem as it could be abused, but as it I think it's fine.