### PR TITLE
Add script for automatic checking for updates on ability stats

### DIFF
--- a/scripts/diff-abilities.js
+++ b/scripts/diff-abilities.js
@@ -39,10 +39,21 @@ const filteredElements = ['MaxLevel', 'RequiredLevel', 'LevelsBetweenUpgrades'];
  */
 function isOriginalDotaOnly(element) {
 
-  if(element[path]) {
+  if(element['path']) {
 
     return !filteredElements.includes(element['path'][1]);
   }
+  return true;
+}
+
+function hasNewValues(diff) {
+
+  // TODO There is an object which has no includes in the diff...
+  if (typeof diff.oaaStats === 'string' || diff.oaaStats instanceof String ||
+      typeof diff.oaaStats === 'array' || diff.oaaStats instanceof Array) {
+    return !diff.oaaStats.includes(diff.dotaStats);
+  }
+
   return true;
 }
 
@@ -59,6 +70,8 @@ function printDifferences(diff, abilityName) {
   // and generate a valid (merged) KV
   diff = JSON.parse(JSON.stringify(diff).split('rhs').join('dotaStats'));
   diff = JSON.parse(JSON.stringify(diff).split('lhs').join('oaaStats'));
+
+  diff = diff.filter(hasNewValues);
 
   console.log('=====================');
   console.log(' Diff for: ' + abilityName);

--- a/scripts/diff-abilities.js
+++ b/scripts/diff-abilities.js
@@ -1,6 +1,6 @@
 /**
  * This script checks for diff on abilitiy stats between OAA and original dota.
- * 
+ *
  * Requirements: `deep-diff` from npm
  *
  * Usage: node diff-abilities.js
@@ -9,7 +9,7 @@
  * https://raw.githubusercontent.com/dotabuff/d2vpkr/master/dota/scripts/npc/npc_abilities.txt
  *
  * This file is not well-formatted!
- * There are two lines which should be a comment, but they are only containing 
+ * There are two lines which should be a comment, but they are only containing
  * one slash.
  * Use: `ag '\t\/ Damage.' npc_abilities.txt`
  * To find this lines. (5565, 5623)
@@ -37,20 +37,17 @@ const filteredElements = ['MaxLevel', 'RequiredLevel', 'LevelsBetweenUpgrades'];
  * Check, of this diff-element should be ignored, since OAA is not using this
  * property.
  */
-function isOriginalDotaOnly(element) {
-
-  if(element['path']) {
-
+function isOriginalDotaOnly (element) {
+  if (element['path']) {
     return !filteredElements.includes(element['path'][1]);
   }
   return true;
 }
 
-function hasNewValues(diff) {
-
+function hasNewValues (diff) {
   // TODO There is an object which has no includes in the diff...
   if (typeof diff.oaaStats === 'string' || diff.oaaStats instanceof String ||
-      typeof diff.oaaStats === 'array' || diff.oaaStats instanceof Array) {
+      diff.oaaStats instanceof Array) {
     return !diff.oaaStats.includes(diff.dotaStats);
   }
 
@@ -61,8 +58,7 @@ function hasNewValues(diff) {
  * Print the diff for one abilitiy.
  * This method should write the changes to OAA files.
  */
-function printDifferences(diff, abilityName) {
-
+function printDifferences (diff, abilityName) {
   diff = diff.filter(isOriginalDotaOnly);
 
   // rename keys to be more readable
@@ -83,8 +79,7 @@ function printDifferences(diff, abilityName) {
 /**
  * Parse the original dota file.
  */
-function parseOriginal(err, origContent) {
-
+function parseOriginal (err, origContent) {
   if (err) {
     throw err;
   }
@@ -96,9 +91,11 @@ function parseOriginal(err, origContent) {
 
   // Walk the directory with files for all abilities in OAA
   fs.readdir(abilitiesPath, 'utf8', (err, files) => {
+    if (err) {
+      throw err;
+    }
 
     files.forEach((file) => {
-
       // Absolute path of the current KV file
       var absoluteKVFilePath = path.join(abilitiesPath, file);
       // Name of the current abilitiy
@@ -106,12 +103,15 @@ function parseOriginal(err, origContent) {
 
       // If the current file has no corresponding section in the original dota
       // KV file, skip
-      if(!abilityList.includes(abilityName)) {
+      if (!abilityList.includes(abilityName)) {
         return;
       }
 
       // Read one file in the OAA directory.
       fs.readFile(absoluteKVFilePath, (err, oaaContent) => {
+        if (err) {
+          throw err;
+        }
 
         var oaaKVData = parseKV(oaaContent);
 
@@ -122,7 +122,7 @@ function parseOriginal(err, origContent) {
         var differences = diff(oaaAbil, origAbil);
 
         // If there are differences, print them
-        if(differences) {
+        if (differences) {
           printDifferences(differences, abilityName);
         }
       });

--- a/scripts/diff-abilities.js
+++ b/scripts/diff-abilities.js
@@ -1,0 +1,120 @@
+/**
+ * This script checks for diff on abilitiy stats between OAA and original dota.
+ * 
+ * Requirements: `deep-diff` from npm
+ *
+ * Usage: node diff-abilities.js
+ *
+ * Currently this uses a local copy of the KV file from here:
+ * https://raw.githubusercontent.com/dotabuff/d2vpkr/master/dota/scripts/npc/npc_abilities.txt
+ *
+ * This file is not well-formatted!
+ * There are two lines which should be a comment, but they are only containing 
+ * one slash.
+ * Use: `ag '\t\/ Damage.' npc_abilities.txt`
+ * To find this lines. (5565, 5623)
+ *
+ * TODO; get files from url above instead of manual download
+ * TODO: automatic fix of ill-formatted lines using a regex
+ * TODO: update files in OAA directory
+ *
+ */
+var parseKV = require('parse-kv');
+var fs = require('fs');
+var path = require('path');
+var diff = require('deep-diff').diff;
+
+// root dir of OAA.
+const basePath = path.join(__dirname, '../');
+// path in the OAA repo, relative to the root.
+const abilitiesPath = path.join(basePath, 'game', 'scripts', 'npc', 'abilities');
+// regex for removing file extension of KV files.
+const fileExtRegex = /.txt/g;
+
+const filteredElements = ['MaxLevel', 'RequiredLevel', 'LevelsBetweenUpgrades'];
+
+/**
+ * Check, of this diff-element should be ignored, since OAA is not using this
+ * property.
+ */
+function isOriginalDotaOnly(element) {
+
+  if(element[path]) {
+
+    return !filteredElements.includes(element['path'][1]);
+  }
+  return true;
+}
+
+/**
+ * Print the diff for one abilitiy.
+ * This method should write the changes to OAA files.
+ */
+function printDifferences(diff, abilityName) {
+
+  diff = diff.filter(isOriginalDotaOnly);
+
+  // rename keys to be more readable
+  // TODO remove this, if we have have a good way to replace values
+  // and generate a valid (merged) KV
+  diff = JSON.parse(JSON.stringify(diff).split('rhs').join('dotaStats'));
+  diff = JSON.parse(JSON.stringify(diff).split('lhs').join('oaaStats'));
+
+  console.log('=====================');
+  console.log(' Diff for: ' + abilityName);
+  console.log('=====================');
+  console.log(JSON.stringify(diff));
+  console.log();
+}
+
+/**
+ * Parse the original dota file.
+ */
+function parseOriginal(err, origContent) {
+
+  if (err) {
+    throw err;
+  }
+
+  // Parsed KV data from original dota
+  var origKVData = parseKV(origContent);
+
+  var abilityList = Object.keys(origKVData['DOTAAbilities']);
+
+  // Walk the directory with files for all abilities in OAA
+  fs.readdir(abilitiesPath, 'utf8', (err, files) => {
+
+    files.forEach((file) => {
+
+      // Absolute path of the current KV file
+      var absoluteKVFilePath = path.join(abilitiesPath, file);
+      // Name of the current abilitiy
+      var abilityName = file.replace(fileExtRegex, '');
+
+      // If the current file has no corresponding section in the original dota
+      // KV file, skip
+      if(!abilityList.includes(abilityName)) {
+        return;
+      }
+
+      // Read one file in the OAA directory.
+      fs.readFile(absoluteKVFilePath, (err, oaaContent) => {
+
+        var oaaKVData = parseKV(oaaContent);
+
+        var oaaAbil = oaaKVData['DOTAAbilities'][abilityName];
+        var origAbil = origKVData['DOTAAbilities'][abilityName];
+
+        // do a diff on the two abilities.
+        var differences = diff(oaaAbil, origAbil);
+
+        // If there are differences, print them
+        if(differences) {
+          printDifferences(differences, abilityName);
+        }
+      });
+    });
+  });
+}
+
+fs.readFile(path.join('npc_abilities.txt'), 'utf8', parseOriginal);


### PR DESCRIPTION
This is a first WIP script for automatic update the ability KVs.

Issues left: 

- The kv file from https://github.com/dotabuff/d2vpkr is not valid.
there are two lines which should be a comment, but only contain one (instead of two) slashes. See my script header for details.

- The file https://github.com/OpenAngelArena/oaa/blob/master/game/scripts/npc/abilities/zuus_cloud.txt is also not valid, since it does not start with the usual `"DOTAAbilities" {` header.

Until now, this script only produces a diff, printed into the terminal. You can use it and pipe the output into a file. The content looks something like this at the moment:

```
=====================
 Diff for: abaddon_death_coil
=====================
[{"kind":"E","path":["AbilitySpecial","04","values","missile_speed"],"oaaStats":"2000","dotaStats":"1600"}]

=====================
 Diff for: alchemist_acid_spray
=====================
[{"kind":"E","path":["AbilitySpecial","01","values","radius"],"oaaStats":"625","dotaStats":"400 475 550 625"}]

=====================
 Diff for: alchemist_chemical_rage
=====================
[{"kind":"E","path":["values","AbilityCooldown"],"oaaStats":"45.0","dotaStats":"55.0"}]
```

I'm going to work on writing the changes into the KV files soon. I wan't to use this pull request for further discussions on how to do it best.
Maybe we wan't something like an interactive thing, which asks  if updates should be done, before writing them into the file. Or you could just run the script and check `git diff` afterwards.

