### PR TITLE
Change Postactive 2a to not be a fake toggle

### DIFF
--- a/game/scripts/npc/items/reflex_cores/postactive/item_postactive_2a.txt
+++ b/game/scripts/npc/items/reflex_cores/postactive/item_postactive_2a.txt
@@ -33,7 +33,7 @@
     "ID"                    "3828"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "BaseClass"             "item_lua"
     "ScriptFile"            "items/reflex/postactive_invisibility.lua"
-    "AbilityBehavior"       "DOTA_ABILITY_BEHAVIOR_TOGGLE | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE"
+    "AbilityBehavior"       "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
     "AbilityTextureName"    "custom/item_postactive_2a"
     // Stats
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/vscripts/items/reflex/postactive_invisibility.lua
+++ b/game/scripts/vscripts/items/reflex/postactive_invisibility.lua
@@ -2,23 +2,10 @@ LinkLuaModifier( "modifier_item_glimmer_cape_fade", LUA_MODIFIER_MOTION_NONE )
 
 item_postactive_2a = class({})
 
-function item_postactive_2a:ResetToggleOnRespawn()
-  return true
-end
-
-function item_postactive_2a:OnToggle(keys)
+function item_postactive_2a:OnSpellStart()
   local caster = self:GetCaster()
   local shroud_duration = self:GetSpecialValueFor( "duration" )
 
   caster:AddNewModifier( caster, self, "modifier_item_glimmer_cape_fade", { duration = shroud_duration } )
   EmitSoundOn( "Item.GlimmerCape.Activate", caster )
-
-  -- important else you can use while on CD every other time
-  if self:GetToggleState() then
-    self:ToggleAbility()
-  end
-
-  self:StartCooldown(self:GetCooldownTime())
-
-  return false
 end


### PR DESCRIPTION
Did some testing. Seems that having both `DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE` and `DOTA_ABILITY_BEHAVIOR_IMMEDIATE` allows the ability to be used while stunned.