### PR TITLE
Change the rest of the stun-castable Reflex Items to not be fake toggles

### DIFF
--- a/game/scripts/npc/items/reflex_cores/postactive/item_postactive_3b.txt
+++ b/game/scripts/npc/items/reflex_cores/postactive/item_postactive_3b.txt
@@ -35,7 +35,7 @@
     "ID"                    "3834"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "BaseClass"             "item_lua"
     "ScriptFile"            "items/reflex/postactive_hard_dispell.lua"
-    "AbilityBehavior"       "DOTA_ABILITY_BEHAVIOR_TOGGLE | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE"
+    "AbilityBehavior"       "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
     "AbilityTextureName"    "custom/item_postactive_3b"
     // Stats
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/reflex_cores/postactive/item_postactive_3c.txt
+++ b/game/scripts/npc/items/reflex_cores/postactive/item_postactive_3c.txt
@@ -35,7 +35,7 @@
     "ID"                    "3836"                                                      // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "BaseClass"             "item_lua"
     "ScriptFile"            "items/reflex/postactive_regen.lua"
-    "AbilityBehavior"             "DOTA_ABILITY_BEHAVIOR_TOGGLE | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE"
+    "AbilityBehavior"             "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
     "AbilityTextureName"    "custom/item_postactive_3c"
     // Stats
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/vscripts/items/reflex/postactive_hard_dispell.lua
+++ b/game/scripts/vscripts/items/reflex/postactive_hard_dispell.lua
@@ -5,5 +5,5 @@ function item_postactive_3b:OnSpellStart()
   local caster = self:GetCaster()
 
   -- void Purge(bool bRemovePositiveBuffs, bool bRemoveDebuffs, bool bFrameOnly, bool bRemoveStuns, bool bRemoveExceptions)
-  caster:Purge(false, true, false, true, false)
+  caster:Purge(false, true, false, true, true)
 end

--- a/game/scripts/vscripts/items/reflex/postactive_hard_dispell.lua
+++ b/game/scripts/vscripts/items/reflex/postactive_hard_dispell.lua
@@ -1,22 +1,9 @@
 
 item_postactive_3b = class({})
 
-function item_postactive_3b:ResetToggleOnRespawn()
-  return true
-end
-
-function item_postactive_3b:OnToggle(keys)
+function item_postactive_3b:OnSpellStart()
   local caster = self:GetCaster()
 
   -- void Purge(bool bRemovePositiveBuffs, bool bRemoveDebuffs, bool bFrameOnly, bool bRemoveStuns, bool bRemoveExceptions)
   caster:Purge(false, true, false, true, false)
-
-  -- important else you can use while on CD every other time
-  if self:GetToggleState() then
-    self:ToggleAbility()
-  end
-
-  self:StartCooldown(self:GetCooldownTime())
-
-  return false
 end

--- a/game/scripts/vscripts/items/reflex/postactive_regen.lua
+++ b/game/scripts/vscripts/items/reflex/postactive_regen.lua
@@ -2,24 +2,11 @@ LinkLuaModifier( "modifier_item_postactive_regen", "items/reflex/postactive_rege
 
 item_postactive_3c = class({})
 
-function item_postactive_3c:ResetToggleOnRespawn()
-  return true
-end
-
-function item_postactive_3c:OnToggle(keys)
+function item_postactive_3c:OnSpellStart()
   local caster = self:GetCaster()
   caster:AddNewModifier(caster, self, 'modifier_item_postactive_regen', {
     duration = self:GetSpecialValueFor( "duration" )
   })
-
-  -- important else you can use while on CD every other time
-  if self:GetToggleState() then
-    self:ToggleAbility()
-  end
-
-  self:StartCooldown(self:GetCooldownTime())
-
-  return false
 end
 
 modifier_item_postactive_regen = class({})


### PR DESCRIPTION
Also changed Postactive 3b (Divine Enrage Crystal) to `RemoveExceptions` for its `Purge`. This is the flag for strong dispel. As implied by the wiki description for the `IsPurgeException` method on Lua modifiers: "	True/false if this modifier can be purged by strong dispels."