### PR TITLE
Fix greater travels

### DIFF
--- a/game/resource/English/ability/items/tooltip_greater_travel_boots.txt
+++ b/game/resource/English/ability/items/tooltip_greater_travel_boots.txt
@@ -7,7 +7,7 @@
             "DOTA_Tooltip_Ability_item_greater_travel_boots_Lore"                           "The boots of a once renown legendary merchant."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_Note0"                          "Shares cooldown with Town Portal Scrolls."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_movement_speed"           "+$move_speed"
-            "DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_gold_per_minute"          "+$gpm"
+            "DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_gold_per_minute"          "+Gold Per Minute"
 
             "DOTA_Tooltip_Ability_item_greater_travel_boots_2"                              "Boots of Travel"
             "DOTA_Tooltip_Ability_item_recipe_greater_travel_boots_2"                       "Boots of Travel Recipe"
@@ -15,7 +15,7 @@
             "DOTA_Tooltip_Ability_item_greater_travel_boots_Lore_2"                         "The boots of a once renown legendary merchant."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_2_Note0"                        "Shares cooldown with Town Portal Scrolls."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_2_bonus_movement_speed"         "+$move_speed"
-            "DOTA_Tooltip_Ability_item_greater_travel_boots_2_bonus_gold_per_minute"        "+$gpm"
+            "DOTA_Tooltip_Ability_item_greater_travel_boots_2_bonus_gold_per_minute"        "+Gold Per Minute"
 
             "DOTA_Tooltip_Ability_item_greater_travel_boots_3"                              "Boots of Travel"
             "DOTA_Tooltip_Ability_item_recipe_greater_travel_boots_3"                       "Boots of Travel Recipe"
@@ -23,7 +23,7 @@
             "DOTA_Tooltip_Ability_item_greater_travel_boots_Lore_3"                         "The boots of a once renown legendary merchant."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_3_Note0"                        "Shares cooldown with Town Portal Scrolls."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_3_bonus_movement_speed"         "+$move_speed"
-            "DOTA_Tooltip_Ability_item_greater_travel_boots_3_bonus_gold_per_minute"        "+$gpm"
+            "DOTA_Tooltip_Ability_item_greater_travel_boots_3_bonus_gold_per_minute"        "+Gold Per Minute"
 
             "DOTA_Tooltip_Ability_item_greater_travel_boots_4"                              "Boots of Travel"
             "DOTA_Tooltip_Ability_item_recipe_greater_travel_boots_4"                       "Boots of Travel Recipe"
@@ -31,7 +31,7 @@
             "DOTA_Tooltip_Ability_item_greater_travel_boots_Lore_4"                         "The boots of a once renown legendary merchant."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_4_Note0"                        "Shares cooldown with Town Portal Scrolls."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_4_bonus_movement_speed"         "+$move_speed"
-            "DOTA_Tooltip_Ability_item_greater_travel_boots_4_bonus_gold_per_minute"        "+$gpm"
+            "DOTA_Tooltip_Ability_item_greater_travel_boots_4_bonus_gold_per_minute"        "+Gold Per Minute"
 
             "DOTA_Tooltip_Ability_item_greater_travel_boots_5"                              "Boots of Travel"
             "DOTA_Tooltip_Ability_item_recipe_greater_travel_boots_5"                       "Boots of Travel Recipe"
@@ -39,4 +39,4 @@
             "DOTA_Tooltip_Ability_item_greater_travel_boots_Lore_5"                         "The boots of a once renown legendary merchant."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_5_Note0"                        "Shares cooldown with Town Portal Scrolls."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_5_bonus_movement_speed"         "+$move_speed"
-            "DOTA_Tooltip_Ability_item_greater_travel_boots_5_bonus_gold_per_minute"        "+$gpm"
+            "DOTA_Tooltip_Ability_item_greater_travel_boots_5_bonus_gold_per_minute"        "+Gold Per Minute"

--- a/game/resource/English/ability/items/tooltip_greater_travel_boots.txt
+++ b/game/resource/English/ability/items/tooltip_greater_travel_boots.txt
@@ -3,7 +3,7 @@
     //===============================================================================
             "DOTA_Tooltip_Ability_item_greater_travel_boots"                                "Boots of Travel"
             "DOTA_Tooltip_Ability_item_recipe_greater_travel_boots"                         "Boots of Travel Recipe"
-            "DOTA_Tooltip_Ability_item_greater_travel_boots_Description"                    "Active: Teleport - Teleports you to an allied non-hero unit or structure. Double-click to teleport to your team's base fountain. Upgradable to allow you to teleport to allied heroes.\n\nFlat movement speed bonuses from multiple pairs of boots do not stack."
+            "DOTA_Tooltip_Ability_item_greater_travel_boots_Description"                    "Active: Teleport - Teleports you to an allied non-hero unit or structure. Double-click to teleport to your team's base fountain.\n\nFlat movement speed bonuses from multiple pairs of boots do not stack."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_Lore"                           "The boots of a once renown legendary merchant."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_Note0"                          "Shares cooldown with Town Portal Scrolls."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_movement_speed"           "+$move_speed"
@@ -11,7 +11,7 @@
 
             "DOTA_Tooltip_Ability_item_greater_travel_boots_2"                              "Boots of Travel"
             "DOTA_Tooltip_Ability_item_recipe_greater_travel_boots_2"                       "Boots of Travel Recipe"
-            "DOTA_Tooltip_Ability_item_greater_travel_boots_2_Description"                  "Active: Teleport - Teleports you to an allied non-hero unit or structure. Double-click to teleport to your team's base fountain. Upgradable to allow you to teleport to allied heroes.\n\nFlat movement speed bonuses from multiple pairs of boots do not stack."
+            "DOTA_Tooltip_Ability_item_greater_travel_boots_2_Description"                  "Active: Teleport - Teleports you to an allied non-hero unit or structure. Double-click to teleport to your team's base fountain.\n\nFlat movement speed bonuses from multiple pairs of boots do not stack."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_Lore_2"                         "The boots of a once renown legendary merchant."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_2_Note0"                        "Shares cooldown with Town Portal Scrolls."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_2_bonus_movement_speed"         "+$move_speed"
@@ -19,7 +19,7 @@
 
             "DOTA_Tooltip_Ability_item_greater_travel_boots_3"                              "Boots of Travel"
             "DOTA_Tooltip_Ability_item_recipe_greater_travel_boots_3"                       "Boots of Travel Recipe"
-            "DOTA_Tooltip_Ability_item_greater_travel_boots_3_Description"                  "Active: Teleport - Teleports you to an allied non-hero unit or structure. Double-click to teleport to your team's base fountain. Upgradable to allow you to teleport to allied heroes.\n\nFlat movement speed bonuses from multiple pairs of boots do not stack."
+            "DOTA_Tooltip_Ability_item_greater_travel_boots_3_Description"                  "Active: Teleport - Teleports you to an allied non-hero unit or structure. Double-click to teleport to your team's base fountain.\n\nFlat movement speed bonuses from multiple pairs of boots do not stack."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_Lore_3"                         "The boots of a once renown legendary merchant."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_3_Note0"                        "Shares cooldown with Town Portal Scrolls."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_3_bonus_movement_speed"         "+$move_speed"
@@ -27,7 +27,7 @@
 
             "DOTA_Tooltip_Ability_item_greater_travel_boots_4"                              "Boots of Travel"
             "DOTA_Tooltip_Ability_item_recipe_greater_travel_boots_4"                       "Boots of Travel Recipe"
-            "DOTA_Tooltip_Ability_item_greater_travel_boots_4_Description"                  "Active: Teleport - Teleports you to an allied non-hero unit or structure. Double-click to teleport to your team's base fountain. Upgradable to allow you to teleport to allied heroes.\n\nFlat movement speed bonuses from multiple pairs of boots do not stack."
+            "DOTA_Tooltip_Ability_item_greater_travel_boots_4_Description"                  "Active: Teleport - Teleports you to an allied non-hero unit or structure. Double-click to teleport to your team's base fountain.\n\nFlat movement speed bonuses from multiple pairs of boots do not stack."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_Lore_4"                         "The boots of a once renown legendary merchant."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_4_Note0"                        "Shares cooldown with Town Portal Scrolls."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_4_bonus_movement_speed"         "+$move_speed"
@@ -35,7 +35,7 @@
 
             "DOTA_Tooltip_Ability_item_greater_travel_boots_5"                              "Boots of Travel"
             "DOTA_Tooltip_Ability_item_recipe_greater_travel_boots_5"                       "Boots of Travel Recipe"
-            "DOTA_Tooltip_Ability_item_greater_travel_boots_5_Description"                  "Active: Teleport - Teleports you to an allied non-hero unit or structure. Double-click to teleport to your team's base fountain. Upgradable to allow you to teleport to allied heroes.\n\nFlat movement speed bonuses from multiple pairs of boots do not stack."
+            "DOTA_Tooltip_Ability_item_greater_travel_boots_5_Description"                  "Active: Teleport - Teleports you to an allied non-hero unit or structure. Double-click to teleport to your team's base fountain.\n\nFlat movement speed bonuses from multiple pairs of boots do not stack."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_Lore_5"                         "The boots of a once renown legendary merchant."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_5_Note0"                        "Shares cooldown with Town Portal Scrolls."
             "DOTA_Tooltip_Ability_item_greater_travel_boots_5_bonus_movement_speed"         "+$move_speed"


### PR DESCRIPTION
Will now target the nearest valid unit within 2000 radius that is not the caster when ground-targeted or give an error if no target can be found. And will target the caster's fountain when self-targeted. Assumes that a player team will have one and only one fountain. Not having a fountain will cause an error, and having more than one will likely always just pick one over the other with some unknown priority.

Also cleaned up the tooltips a little.