### PR TITLE
Perminant fix for infinite death

### DIFF
--- a/game/scripts/vscripts/internal/events.lua
+++ b/game/scripts/vscripts/internal/events.lua
@@ -81,6 +81,11 @@ function GameMode:_OnEntityKilled( keys )
       GameRules:GetGameModeEntity():SetTopBarTeamValue ( DOTA_TEAM_GOODGUYS, GetTeamHeroKills(DOTA_TEAM_GOODGUYS) )
     end
 
+    if not Duels.currentDuel and killedUnit:GetRespawnsDisabled() then
+      killedUnit:SetRespawnsDisabled(false)
+      killedUnit:SetTimeUntilRespawn(5)
+    end
+
     if killerTeam ~= DOTA_TEAM_BADGUYS and killerTeam ~= DOTA_TEAM_GOODGUYS and not killedUnit:IsReincarnating() then
       killedUnit:SetTimeUntilRespawn(10)
     else

--- a/game/scripts/vscripts/internal/events.lua
+++ b/game/scripts/vscripts/internal/events.lua
@@ -83,7 +83,9 @@ function GameMode:_OnEntityKilled( keys )
 
     if not Duels.currentDuel and killedUnit:GetRespawnsDisabled() then
       killedUnit:SetRespawnsDisabled(false)
-      killedUnit:SetTimeUntilRespawn(5)
+      if not killedUnit:IsReincarnating() then
+        killedUnit:SetTimeUntilRespawn(5)
+      end
     end
 
     if killerTeam ~= DOTA_TEAM_BADGUYS and killerTeam ~= DOTA_TEAM_GOODGUYS and not killedUnit:IsReincarnating() then


### PR DESCRIPTION
When any hero dies, check if there is a duel, if not ensure respawn works.