### PR TITLE
Change Preemptive Reflex Items to use the AbilityCooldown KV for their cooldowns

### DIFF
--- a/game/scripts/npc/items/reflex_cores/preemptive/item_preemptive.txt
+++ b/game/scripts/npc/items/reflex_cores/preemptive/item_preemptive.txt
@@ -35,6 +35,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"       "0"
+    "AbilityCooldown"       "20"
     "AbilitySharedCooldown" "reflex"
     "AbilityCastPoint"      "0.0"
 
@@ -69,20 +70,15 @@
       }
       "03"
       {
-        "var_type"        "FIELD_FLOAT"
-        "cooldown"        "20.0"
+        "var_type"        "FIELD_INTEGER"
+        "bonus_health"        "250"
       }
       "04"
       {
         "var_type"        "FIELD_INTEGER"
-        "bonus_health"        "250"
-      }
-      "05"
-      {
-        "var_type"        "FIELD_INTEGER"
         "bonus_armor"     "5"
       }
-      "06"
+      "05"
       {
         "var_type"        "FIELD_INTEGER"
         "magic_resistance"    "5"

--- a/game/scripts/npc/items/reflex_cores/preemptive/item_preemptive_2a.txt
+++ b/game/scripts/npc/items/reflex_cores/preemptive/item_preemptive_2a.txt
@@ -40,6 +40,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"       "0"
+    "AbilityCooldown"       "20"
     "AbilitySharedCooldown" "reflex"
     "AbilityCastPoint"      "0.0"
 
@@ -68,20 +69,15 @@
       }
       "03"
       {
-        "var_type"        "FIELD_FLOAT"
-        "cooldown"        "20.0"
+        "var_type"        "FIELD_INTEGER"
+        "bonus_health"        "1000"
       }
       "04"
       {
         "var_type"        "FIELD_INTEGER"
-        "bonus_health"        "1000"
-      }
-      "05"
-      {
-        "var_type"        "FIELD_INTEGER"
         "bonus_armor"     "10"
       }
-      "06"
+      "05"
       {
         "var_type"        "FIELD_INTEGER"
         "magic_resistance"    "10"

--- a/game/scripts/npc/items/reflex_cores/preemptive/item_preemptive_2b.txt
+++ b/game/scripts/npc/items/reflex_cores/preemptive/item_preemptive_2b.txt
@@ -40,6 +40,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"       "0"
+    "AbilityCooldown"       "20"
     "AbilitySharedCooldown" "reflex"
     "AbilityCastPoint"      "0.0"
 
@@ -66,27 +67,22 @@
         "var_type"          "FIELD_INTEGER"
         "damage_as_healing"  "0"
       }
-      "04"
+      "03"
       {
         "var_type"        "FIELD_FLOAT"
         "duration"        "2.0"
       }
-      "05"
-      {
-        "var_type"        "FIELD_FLOAT"
-        "cooldown"        "20.0"
-      }
-       "06"
+      "04"
       {
         "var_type"        "FIELD_INTEGER"
         "bonus_health"        "1000"
       }
-      "07"
+      "05"
       {
         "var_type"        "FIELD_INTEGER"
         "bonus_armor"     "10"
       }
-      "08"
+      "06"
       {
         "var_type"        "FIELD_INTEGER"
         "magic_resistance"    "10"

--- a/game/scripts/npc/items/reflex_cores/preemptive/item_preemptive_3a.txt
+++ b/game/scripts/npc/items/reflex_cores/preemptive/item_preemptive_3a.txt
@@ -43,6 +43,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"       "0"
+    "AbilityCooldown"       "20"
     "AbilitySharedCooldown" "reflex"
     "AbilityCastPoint"      "0.0"
 
@@ -71,20 +72,15 @@
       }
       "03"
       {
-        "var_type"        "FIELD_FLOAT"
-        "cooldown"        "20.0"
+        "var_type"        "FIELD_INTEGER"
+        "bonus_health"        "4000"
       }
       "04"
       {
         "var_type"        "FIELD_INTEGER"
-        "bonus_health"        "4000"
-      }
-      "05"
-      {
-        "var_type"        "FIELD_INTEGER"
         "bonus_armor"     "20"
       }
-      "06"
+      "05"
       {
         "var_type"        "FIELD_INTEGER"
         "magic_resistance"    "20"

--- a/game/scripts/npc/items/reflex_cores/preemptive/item_preemptive_3b.txt
+++ b/game/scripts/npc/items/reflex_cores/preemptive/item_preemptive_3b.txt
@@ -43,6 +43,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"       "0"
+    "AbilityCooldown"       "20"
     "AbilitySharedCooldown" "reflex"
     "AbilityCastPoint"      "0.0"
 
@@ -69,27 +70,22 @@
         "var_type"          "FIELD_INTEGER"
         "damage_as_healing"  "50"
       }
-      "04"
+      "03"
       {
         "var_type"        "FIELD_FLOAT"
         "duration"        "4.0"
       }
-      "05"
-      {
-        "var_type"        "FIELD_FLOAT"
-        "cooldown"        "20.0"
-      }
-      "06"
+      "04"
       {
         "var_type"        "FIELD_INTEGER"
         "bonus_health"        "4000"
       }
-      "07"
+      "05"
       {
         "var_type"        "FIELD_INTEGER"
         "bonus_armor"     "20"
       }
-      "08"
+      "06"
       {
         "var_type"        "FIELD_INTEGER"
         "magic_resistance"    "20"

--- a/game/scripts/vscripts/items/reflex/preemptive.lua
+++ b/game/scripts/vscripts/items/reflex/preemptive.lua
@@ -20,10 +20,6 @@ function item_preemptive:OnSpellStart()
   return true
 end
 
-function item_preemptive:GetCooldown( nLevel )
-  return self:GetSpecialValueFor( "cooldown" )
-end
-
 function item_preemptive:ProcsMagicStick ()
   return false
 end

--- a/game/scripts/vscripts/items/reflex/preemptive_damage_block.lua
+++ b/game/scripts/vscripts/items/reflex/preemptive_damage_block.lua
@@ -34,10 +34,6 @@ function item_preemptive_2b:OnSpellStart()
   return true
 end
 
-function item_preemptive_2b:GetCooldown( nLevel )
-  return self:GetSpecialValueFor( "cooldown" )
-end
-
 function item_preemptive_2b:ProcsMagicStick ()
   return false
 end

--- a/game/scripts/vscripts/items/reflex/preemptive_purge.lua
+++ b/game/scripts/vscripts/items/reflex/preemptive_purge.lua
@@ -22,10 +22,6 @@ function item_preemptive_2a:OnSpellStart()
   return true
 end
 
-function item_preemptive_2a:GetCooldown( nLevel )
-  return self:GetSpecialValueFor( "cooldown" )
-end
-
 function item_preemptive_2a:ProcsMagicStick ()
   return false
 end


### PR DESCRIPTION
Let's hope this doesn't go and conflict with the other PR editing the Reflex KVs.