### PR TITLE
Courier Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-29-orange.svg?style=flat-square)](#contributors)
 A really great Dota 2 game mode built by [really great people](#contributors).
 
-# Installation
+# Installation1
 This addon uses the [Dota 2 Addon Manager](https://github.com/chrisinajar/dota2-addon-manager).
 
 For detailed instructions, check [here](docs/install.md)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-29-orange.svg?style=flat-square)](#contributors)
 A really great Dota 2 game mode built by [really great people](#contributors).
 
-# Installation1
+# Installation
 This addon uses the [Dota 2 Addon Manager](https://github.com/chrisinajar/dota2-addon-manager).
 
 For detailed instructions, check [here](docs/install.md)

--- a/game/scripts/vscripts/components/courier/courier.lua
+++ b/game/scripts/vscripts/components/courier/courier.lua
@@ -15,8 +15,25 @@ function Courier:Init ()
 end
 
 function Courier:SpawnCourier (hero)
-  DebugPrint("Creating Courier for Team " .. hero:GetTeamNumber())
-  courier = hero:AddItemByName('item_courier')
-  flying = hero:AddItemByName('item_flying_courier')
-  Courier.hasCourier[hero:GetTeamNumber()] = true
+  Timers:CreateTimer(1, function ()
+    DebugPrint("Creating Courier for Team " .. hero:GetTeamNumber())
+
+    -- Check if there is an item blocking slot 1, if so sell it
+    slot1Item = hero:GetItemInSlot(0)
+    if slot1Item then
+      hero:SellItem(slot1Item)
+    end
+
+    -- Create couriers and then cast them straight away
+    local courier = hero:AddItemByName('item_courier')
+    if courier then
+        hero:CastAbilityImmediately(courier, hero:GetPlayerID())
+    end
+    local flying = hero:AddItemByName('item_flying_courier')
+    if flying then
+        hero:CastAbilityImmediately(flying, hero:GetPlayerID())
+    end
+
+    Courier.hasCourier[hero:GetTeamNumber()] = true
+  end)
 end


### PR DESCRIPTION
This adds a 1 second timer to courier spawning. It checks if there is an item blocking first slot in inventory, if so, sells the item (players get full refund), adds the courier, casts it immediately, adds the flying courier and casts that immediately. 