### PR TITLE
Fix some modifier_generic_bonus bugs

### DIFF
--- a/game/scripts/vscripts/modifiers/modifier_generic_bonus.lua
+++ b/game/scripts/vscripts/modifiers/modifier_generic_bonus.lua
@@ -47,13 +47,13 @@ end
 
 function modifier_generic_bonus:DeclareFunctions()
   return {
-    MODIFIER_PROPERTY_EXTRA_HEALTH_BONUS,
+    MODIFIER_PROPERTY_HEALTH_BONUS,
     MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS,
     MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS
   }
 end
 
-function modifier_generic_bonus:GetModifierExtraHealthBonus()
+function modifier_generic_bonus:GetModifierHealthBonus()
   return self.bonus_health or 0
 end
 

--- a/game/scripts/vscripts/modifiers/modifier_generic_bonus.lua
+++ b/game/scripts/vscripts/modifiers/modifier_generic_bonus.lua
@@ -65,6 +65,10 @@ function modifier_generic_bonus:GetModifierMagicalResistanceBonus()
   return self.magic_resistance or 0
 end
 
+function modifier_generic_bonus:GetAttributes()
+  return MODIFIER_ATTRIBUTE_MULTIPLE
+end
+
 function modifier_generic_bonus:IsHidden()
   return true
 end


### PR DESCRIPTION
Fixes #586 and #609.

Note that MODIFIER_PROPERTY_HEALTH_BONUS apparently doesn't work on some non-hero units (ran into this when working on Prophet Treants). So modifier_generic_bonus should only be used for heroes.