### PR TITLE
Change purge tester to call RemoveSelf on the unit when done

### DIFF
--- a/game/scripts/vscripts/items/reflex/postactive.lua
+++ b/game/scripts/vscripts/items/reflex/postactive.lua
@@ -15,7 +15,7 @@ function item_postactive:OnSpellStart()
     testUnit:AddNewModifier(modifier:GetCaster(), modifier:GetAbility(), modifier:GetName(), nil)
     testUnit:Purge(false, true, true, false, false)
     local modifierIsPurgableDebuff = not testUnit:HasModifier(modifier:GetName())
-    testUnit:ForceKill(false)
+    testUnit:RemoveSelf()
     return modifierIsPurgableDebuff
   end
 


### PR DESCRIPTION
Probably removes the entity more completely so as to not cause a memory leak.