### PR TITLE
Change Mini Rosh base class to npc_dota_creep_neutral

### DIFF
--- a/game/scripts/npc/units/npc_dota_mini_roshan.txt
+++ b/game/scripts/npc/units/npc_dota_mini_roshan.txt
@@ -4,7 +4,7 @@
 	{
 		// General
 		//
-    "BaseClass"					"npc_dota_creature"
+    "BaseClass"					"npc_dota_creep_neutral"
 		"Model"						"models/creeps/roshan/roshan.vmdl"	// Model.
 		"SoundSet"					"Roshan"					// Name of sound set.
 		"ModelScale"				"0.25"


### PR DESCRIPTION
This gives the Mini Roshes the default neutral creep leash behaviour. Might be somewhat abusable using range, but definitely better than being able to lead them back to fountain.