### PR TITLE
Made Units not walk away in duels

### DIFF
--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -185,6 +185,10 @@ function Duels:ActuallyStartDuel ()
     Duels:MoveCameraToPlayer(goodGuy.id, goodHero)
     Duels:MoveCameraToPlayer(badGuy.id, badHero)
 
+    -- stop player action
+    goodHero:Stop()
+    badHero:Stop()
+
     -- disable respawn
     goodHero:SetRespawnsDisabled(true)
     badHero:SetRespawnsDisabled(true)

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -220,6 +220,10 @@ function Duels:ActuallyStartDuel ()
     Duels:MoveCameraToPlayer(goodGuy.id, goodHero)
     Duels:MoveCameraToPlayer(badGuy.id, badHero)
 
+    -- stop player action
+    goodHero:Stop()
+    badHero:Stop()
+
     -- disable respawn
     goodHero:SetRespawnsDisabled(true)
     badHero:SetRespawnsDisabled(true)


### PR DESCRIPTION
Just calling Stop() when a duel starts. This prevents players to just walk away or cast spells ordered before the duel.