### PR TITLE
Fix Tier 1 Boss stats

### DIFF
--- a/game/scripts/npc/units/boss/npc_dota_boss_tier_1.txt
+++ b/game/scripts/npc/units/boss/npc_dota_boss_tier_1.txt
@@ -20,8 +20,6 @@
     "Ability1"                  "roshan_spell_block"
     "Ability2"                  "roshan_bash"
     "Ability3"                  "roshan_slam"
-    "Ability4"                  "roshan_inherent_buffs"
-    "Ability5"                  "roshan_devotion"
 
 		// Armor
 		//----------------------------------------------------------------

--- a/game/scripts/npc/units/boss/npc_dota_boss_tier_1.txt
+++ b/game/scripts/npc/units/boss/npc_dota_boss_tier_1.txt
@@ -20,6 +20,7 @@
     "Ability1"                  "roshan_spell_block"
     "Ability2"                  "roshan_bash"
     "Ability3"                  "roshan_slam"
+    "Ability4"                  "boss_resistance"
 
 		// Armor
 		//----------------------------------------------------------------

--- a/game/scripts/npc/units/boss/npc_dota_boss_tier_1.txt
+++ b/game/scripts/npc/units/boss/npc_dota_boss_tier_1.txt
@@ -33,8 +33,8 @@
 		"AttackDamageMin"			"500"		// Damage range min.
 		"AttackDamageMax"			"600"		// Damage range max.
 		"AttackDamageType"			"DAMAGE_TYPE_ArmorPhysical"
-		"AttackRate"				"2.0"			// Speed of attack.
-		"AttackAnimationPoint"		"0.3"		// Normalized time in animation cycle to attack.
+		"AttackRate"				"1.0"			// Speed of attack.
+		"AttackAnimationPoint"		"0.6"		// Normalized time in animation cycle to attack.
 		"AttackAcquisitionRange"	"150"		// Range within a target can be acquired.
 		"AttackRange"				"128"		// Range within a target can be attacked.
 


### PR DESCRIPTION
The tier 1 boss still needs Boss Resistance because only the actual Rosh class has protection from %damage spells, but we can't use actual Rosh because he can only be attacked from inside his non-existent pit.

Removed the Rosh buff abilities because it messes with the base health. Health can't be less than (or possibly even always will be) 5500 when starting. Buffs also cause scaling behaviour that we may not want.

Changed AttackRate and AttackAnimationPoint to match actual Rosh. Actual Rosh technically has AttackRate 2.0 and then inherent_buffs gives him attack speed to bring him up to 1 sec per attack.

Also to note, I don't think this unit will ever use Slam (no AI for it). Didn't test for T1 boss specifically, but the mini Roshans in the farming cave don't use Slam, so T1 boss would probably be the same.

P.S. This is hardly literal Roshan seeing as he has tons more attack damage and higher armor. :p Though I suppose he's even less like Roshan in this PR.