### PR TITLE
Change how Trump's Fists checks for passive regen and remove proc from illusions

### DIFF
--- a/game/scripts/vscripts/items/trumps_fists.lua
+++ b/game/scripts/vscripts/items/trumps_fists.lua
@@ -83,7 +83,7 @@ end
 
 function modifier_item_trumps_fists_passive:OnAttackLanded( kv )
   if IsServer() then
-    if kv.attacker == self:GetParent() then
+    if kv.attacker == self:GetParent() and not kv.attacker:IsIllusion() then
       kv.target:AddNewModifier( self:GetCaster(), self:GetAbility(), "modifier_item_trumps_fists_frostbite", { duration = self.heal_prevent_duration } )
     end
   end

--- a/game/scripts/vscripts/items/trumps_fists.lua
+++ b/game/scripts/vscripts/items/trumps_fists.lua
@@ -126,7 +126,7 @@ function modifier_item_trumps_fists_frostbite:OnHealthGained( kv )
 	if IsServer() then
     -- Check that event is being called for the unit that self is attached to
     -- and that the healing is not passive regen
-		if kv.unit == self:GetParent() and kv.damage_type ~= 0 then
+		if kv.unit == self:GetParent() and not kv.process_procs then
       local desiredHP = kv.unit:GetHealth() + kv.gain * self.heal_prevent_percent / 100
       desiredHP = math.max(desiredHP, 1)
 


### PR DESCRIPTION
Previous method was completely inconsistent. (Go figure). Hopefully this one actually does what it's supposed to do.