### PR TITLE
Doom Doom typo fix

### DIFF
--- a/game/scripts/npc/abilities/doom_bringer_doom.txt
+++ b/game/scripts/npc/abilities/doom_bringer_doom.txt
@@ -55,7 +55,7 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"damage_scepter"		"20 35 50 800 200"
+				"damage_scepter"		"20 35 50 80 200"
 			}
 			"05"
 			{


### PR DESCRIPTION
Rescaled Scepter upgrade damage from 20/35/50/800/200 to 20/35/50/80/200, a very necessary nerf