### PR TITLE
Add Quick Stat Display for Bottlecount Cave Cleares and Score Goal

### DIFF
--- a/content/panorama/layout/custom_game/custom_ui_manifest.xml
+++ b/content/panorama/layout/custom_game/custom_ui_manifest.xml
@@ -61,6 +61,7 @@
     <CustomUIElement type="Hud"                 layoutfile="file://{resources}/layout/custom_game/need_greed_pass/layout.xml" />
     <CustomUIElement type="Hud"                 layoutfile="file://{resources}/layout/custom_game/barebones_notifications.xml" />
     <CustomUIElement type="Hud"                 layoutfile="file://{resources}/layout/custom_game/statcollection.xml" />
+    <CustomUIElement type="Hud"                 layoutfile="file://{resources}/layout/custom_game/stat_display.xml" />
 
     <!-- From Overthrow.
 

--- a/content/panorama/layout/custom_game/stat_display.xml
+++ b/content/panorama/layout/custom_game/stat_display.xml
@@ -1,0 +1,31 @@
+<root>
+  <styles>
+    <include src="file://{resources}/styles/custom_game/stat_display.css"/>
+  </styles>
+  <scripts>
+    <include src="file://{resources}/scripts/util.js" />
+    <include src="file://{resources}/scripts/custom_game/stat_display.js"/>
+  </scripts>
+  <Panel class="StatDisplay">
+    <Panel class="StatDisplayContainer" id="OAAStatDisplay" hittest="false" hittestchildren="false">
+      <Panel id="BCRow">
+        <Panel class="StatDisplayHeaderContainer">
+          <Label class="QuickStatLabel" id="QuickStatLabelHeader" text="Bottles"/>
+          <Label class="QuickStatLabel" id="QuickStatLabelValue" text="0" />
+        </Panel>
+      </Panel>
+      <Panel id="CCRow">
+        <Panel class="StatDisplayHeaderContainer">
+          <Label class="QuickStatLabel" id="QuickStatLabelHeader" text="CC"/>
+          <Label class="QuickStatLabel" id="QuickStatLabelValue" text="0" />
+        </Panel>
+      </Panel>
+      <Panel id="SLRow">
+        <Panel class="StatDisplayHeaderContainer">
+          <Label class="QuickStatLabel" id="QuickStatLabelHeader" text="Goal"/>
+          <Label class="QuickStatLabel" id="QuickStatLabelValue" text="0" />
+        </Panel>
+      </Panel>
+    </Panel>
+  </Panel>
+</root>

--- a/content/panorama/scripts/custom_game/pointsmanager.js
+++ b/content/panorama/scripts/custom_game/pointsmanager.js
@@ -8,32 +8,21 @@
 
 function onScoreChange (table, key, data) {
   // console.log('[PointsManager] onScoreChange')
-  var limit;
 
   if (key === 'score') {
-    limit = CustomNetTables.GetTableValue('team_scores', 'limit')['value'];
     var goodguys = data['goodguys'];
     var badguys = data['badguys'];
+    UpdatePointsHud(goodguys, badguys);
   } else if (key === 'limit') {
     // assuming this only happens on gamestart
-    limit = data['value'];
     var length = data['name'];
     FindDotaHudElement('PreGame').FindChildTraverse('GameModeLabel').text = $.Localize(('#oaa_game_length_' + length + '_title').toLowerCase());
   }
-  UpdatePointsHud(limit, goodguys, badguys);
 }
 
-function UpdatePointsHud (limit, goodguys, badguys) {
-  var goodguysLabel = FindDotaHudElement('TopBarRadiantScore');
-  var badguysLabel = FindDotaHudElement('TopBarDireScore');
-
-  goodguysLabel.style.fontSize = '18px';
-  goodguysLabel.style.marginTop = '2px';
-  goodguysLabel.style.lineHeight = '17px';
-  badguysLabel.style.fontSize = '18px';
-  badguysLabel.style.marginTop = '2px';
-  badguysLabel.style.lineHeight = '17px';
-
-  goodguysLabel.text = goodguys + '\n' + limit;
-  badguysLabel.text = badguys + '\n' + limit;
+function UpdatePointsHud (goodguys, badguys) {
+  FindDotaHudElement('TopBarRadiantScore').text = goodguys;
+  FindDotaHudElement('RadiantScoreLabel').text = goodguys;
+  FindDotaHudElement('TopBarDireScore').text = badguys;
+  FindDotaHudElement('DireScoreLabel').text = badguys;
 }

--- a/content/panorama/scripts/custom_game/stat_display.js
+++ b/content/panorama/scripts/custom_game/stat_display.js
@@ -1,0 +1,22 @@
+/* global $ CustomNetTables, Game */
+
+(function () {
+  CustomNetTables.SubscribeNetTableListener('stat_display', onStatChange);
+}());
+
+function onStatChange (table, key, data) {
+  for (var entry in data.value) {
+    $.Msg(entry);
+  }
+  var playerID = Game.GetLocalPlayerID();
+  $.Msg('onStatChange:');
+  $.Msg(playerID + ' : ' + key + ' = ' + data.value[playerID]);
+  UpdateStatDisplay(key, data.value[playerID]);
+}
+
+function UpdateStatDisplay (name, value) {
+  var display = $('#OAAStatDisplay');
+
+  $.Msg('Looking for QuickStatLabelValue of ' + name + 'Row');
+  display.FindChildTraverse(name + 'Row').FindChildTraverse('QuickStatLabelValue').text = value;
+}

--- a/content/panorama/styles/custom_game/stat_display.css
+++ b/content/panorama/styles/custom_game/stat_display.css
@@ -1,0 +1,73 @@
+.StatDisplay
+{
+  vertical-align: top;
+  text-shadow: 0 0 6px 6 #000000;
+  opacity: 1;
+  transition-property: opacity;
+  transition-duration: 0.15s;
+  flow-children: none;
+  width: 250px;
+  height: fit-children;
+  margin-top: 116px;
+  z-index: 0;
+}
+
+.StatDisplayContainer
+{
+  z-index: 10;
+  flow-children: down;
+  horizontal-align: left;
+  opacity: 1;
+  padding-left: 10px;
+  padding-right: 10px;
+  background-color: gradient( linear, 0% 0%, 100% 0%, from( #425663cc ), color-stop( .5, #42566355 ), to( #0000 ) );
+  width: 175px;
+  transition-property: opacity;
+  transition-duration: 0.12s;
+  transition-timing-function: ease-out;
+}
+
+.StatDisplayHeaderContainer
+{
+  flow-children: none;
+  padding-top: 0;
+  padding-left: 8px;
+}
+
+#BCRow .StatDisplayHeaderContainer
+{
+  padding-top: 4px;
+  margin-top: -4px;
+}
+
+.QuickStatLabel
+{
+  font-weight: thin;
+  font-size: 16px;
+  text-shadow: 1px 1px 1px 2 #00000099;
+  width: fit-children;
+}
+
+#QuickStatLabelHeader
+{
+  color: #A3B5D0CC;
+  text-align: left;
+  horizontal-align: left;
+  margin-right: 12px;
+}
+
+#QuickStatLabelValue
+{
+  color: white;
+  text-align: center;
+  margin-left: 68px;
+  horizontal-align: center;
+  flow-children: down;
+  font-family: RadianceM;
+  margin-right: 4px;
+}
+
+Label, TextEntry
+{
+  font-family: Radiance,FZLanTingHei-R-GBK,TH Sarabun New,YDYGO 540,Gulim,MingLiU;
+}

--- a/game/scripts/custom_net_tables.txt
+++ b/game/scripts/custom_net_tables.txt
@@ -3,6 +3,7 @@
   custom_net_tables =
   [
     "team_scores",
-    "ngp"
+    "ngp",
+    "stat_display"
   ]
 }

--- a/game/scripts/vscripts/components/cave/cave.lua
+++ b/game/scripts/vscripts/components/cave/cave.lua
@@ -190,6 +190,11 @@ function CaveHandler:CreepDeath (teamID, roomID)
       end)
 
       cave.timescleared = cave.timescleared + 1
+      for playerID in PlayerResource:GetPlayerIDsForTeam(teamID) do
+        local statTable = CustomNetTables:GetTableValue('stat_display', 'CC').value
+        table.insert(statTable, { [tostring(playerID)] = cave.timescleared })
+        CustomNetTables:SetTableValue('stat_display', 'CC', { value = statTable })
+      end
       -- inform players
       Notifications:TopToTeam(teamID, {
         text = "Your last Room got cleared. Every player on your Team got " .. bounty .. " gold",

--- a/game/scripts/vscripts/components/filters/bottlecounter.lua
+++ b/game/scripts/vscripts/components/filters/bottlecounter.lua
@@ -8,16 +8,8 @@ if BottleCounter == nil then
 end
 
 function BottleCounter:Init()
-  self.bottleCount = {}
+  self.bottleCount = tomap(zip(PlayerResource:GetAllTeamPlayerIDs(), duplicate(0)))
   FilterManager:AddFilter(FilterManager.ItemAddedToInventory, self, Dynamic_Wrap(BottleCounter, 'Filter'))
-
-  for _,playerID in PlayerResource:GetAllTeamPlayerIDs() do
-    local hero = PlayerResource:GetSelectedHeroEntity(playerID)
-    self.bottleCount[playerID] = 0
-    if hero then
-      hero:AddNewModifier(hero, nil, 'modifier_bottle_counter', {})
-    end
-  end
 end
 
 function BottleCounter:Filter(filterTable)
@@ -35,7 +27,7 @@ function BottleCounter:Filter(filterTable)
     if item:GetName() == "item_infinite_bottle" and not item.firstPickedUp then
       item.firstPickedUp = true
       self.bottleCount[playerID] = self.bottleCount[playerID] + 1
-      hero:AddNewModifier(hero, nil, 'modifier_bottle_counter', {})
+      CustomNetTables:SetTableValue('stat_display', 'BC', { value = self.bottleCount })
     end
   end
   return true

--- a/game/scripts/vscripts/components/points/game_length_vote.lua
+++ b/game/scripts/vscripts/components/points/game_length_vote.lua
@@ -36,22 +36,26 @@ function GameLengthVotes:SetGameLength ()
   end
 
   local length
+  local scoreLimit
   if votes.long > votes.normal then
     if votes.long > votes.short then
       length = 'long'
-      CustomNetTables:SetTableValue( 'team_scores', 'limit', { value = 200, name = length } )
+      scoreLimit = 200
+      CustomNetTables:SetTableValue( 'team_scores', 'limit', { value = scoreLimit, name = length } )
     else
       length = 'short'
-      CustomNetTables:SetTableValue( 'team_scores', 'limit', { value = 50, name = length } )
+      scoreLimit = 50
+      CustomNetTables:SetTableValue( 'team_scores', 'limit', { value = scoreLimit, name = length } )
     end
   elseif votes.short > votes.normal then
     length = 'short'
-    CustomNetTables:SetTableValue( 'team_scores', 'limit', { value = 50, name = length } )
+    scoreLimit = 50
+    CustomNetTables:SetTableValue( 'team_scores', 'limit', { value = scoreLimit, name = length } )
   else
     length = 'normal'
-    CustomNetTables:SetTableValue( 'team_scores', 'limit', { value = 100, name = length } )
+    scoreLimit = 100
+    CustomNetTables:SetTableValue( 'team_scores', 'limit', { value = scoreLimit, name = length } )
   end
   DebugPrint ( 'votes ' .. votes.short .. ', ' .. votes.normal .. ', ' .. votes.long .. ' result: ' .. length)
   GameRules.GameLength = length
-
 end


### PR DESCRIPTION
BUG: I cannot get the FlyingScoreboard infront of the display

![example image](https://i.imgur.com/eD9ZILU.png)