### PR TITLE
Roshling Gold

### DIFF
--- a/game/scripts/vscripts/components/cave/cave.lua
+++ b/game/scripts/vscripts/components/cave/cave.lua
@@ -220,7 +220,7 @@ function CaveHandler:GiveBounty (teamID, k)
   each(DebugPrint, PlayerResource:GetPlayerIDsForTeam(teamID))
   local round = math.floor
 
-  local pool = (56 * k^2 + 85 * k + 37) / 37 * roshGold * roshCount
+  local pool = (8 * k + 6) * roshGold * roshCount
   local bounty = round(pool / playerCount)
   DebugPrint("Giving " .. playerCount .. " players " .. bounty .. " gold each from a pool of " .. pool .. " gold.")
 


### PR DESCRIPTION
Way back when we made the farming cave gold and experience use the same multipliers as the rest of the game, we neglected to do the same to the roshlings' gold, which was handled in a separate file (because it shared across the team). This fixes that. Roshlings should give WAY more gold now.
#MakeFarmingCaveGreatAgain