### PR TITLE
Add handling for Chen Penitence to Boss Resistance

### DIFF
--- a/game/scripts/vscripts/abilities/boss_resistance.lua
+++ b/game/scripts/vscripts/abilities/boss_resistance.lua
@@ -85,11 +85,13 @@ function modifier_boss_resistance:GetModifierIncomingDamage_Percentage(keys)
   -- List of modifiers with all damage amplification that need to stack multiplicatively with Boss Resistance
   local damageAmpModifiers = {
     "modifier_bloodseeker_bloodrage",
+    "modifier_chen_penitence",
     "modifier_shadow_demon_soul_catcher"
   }
   -- A list matched with the previous one for the AbilitySpecial keys that contain the damage amp values of the modifiers
   local ampAbilitySpecialKeys = {
     "damage_increase_pct",
+    "bonus_damage_taken",
     "bonus_damage_taken"
   }
 


### PR DESCRIPTION
Closes #756, assuming there isn't another all damage amp ability we haven't thought of yet. There's also the matter of the Reduction Orbs that Haganeko brought up in #756. We'll probably want to implement the same thing for those, I'm just not sure where's a good place to move this code so that it's accessible from both Boss Resistance and the Reduction Orbs. Presumably somewhere in `components`, but I can't really think of a good name right now. Also, would I then `require` it from `gamemode.lua` or from the ability lua files instead? Particularly since I've observed ability files being flaky about accessing stuff `require`d in `gamemode.lua`, at least in local testing.