### PR TITLE
Add illusion, reincarnating, and distant kill checking for Bloodstone charge handling

### DIFF
--- a/game/scripts/vscripts/items/bloodstone.lua
+++ b/game/scripts/vscripts/items/bloodstone.lua
@@ -1,5 +1,5 @@
 LinkLuaModifier("modifier_item_bloodstone_oaa", "items/bloodstone.lua", LUA_MODIFIER_MOTION_NONE)
-LinkLuaModifier("modifier_item_bloodstone_charge_collector", "items/bloodstone.lua", LUA_MODIFIER_MOTION_NONE)
+--LinkLuaModifier("modifier_item_bloodstone_charge_collector", "items/bloodstone.lua", LUA_MODIFIER_MOTION_NONE)
 
 item_bloodstone_1 = class({})
 

--- a/game/scripts/vscripts/items/bloodstone.lua
+++ b/game/scripts/vscripts/items/bloodstone.lua
@@ -173,10 +173,10 @@ end
 -- charge loss
 
 function modifier_item_bloodstone_oaa:OnDeath(keys)
-  local dead = self:GetCaster()
+  local caster = self:GetCaster()
 
-  if dead ~= keys.unit then
-    -- someone else died
+  if caster ~= keys.unit or caster:IsReincarnating() then
+    -- someone else died or owner is reincarnating
     return
   end
 
@@ -187,14 +187,14 @@ function modifier_item_bloodstone_oaa:OnDeath(keys)
   stone:SetCurrentCharges(newCharges)
   self.charges = newCharges
 
-  if not dead:IsRealHero() or dead:IsTempestDouble() then
+  if not caster:IsRealHero() or caster:IsTempestDouble() then
     return
   end
 
   local healAmount = stone:GetSpecialValueFor("heal_on_death_base") + (stone:GetSpecialValueFor("heal_on_death_per_charge") * oldCharges)
   local heroes = FindUnitsInRadius(
-    dead:GetTeamNumber(),
-    dead:GetAbsOrigin(),
+    caster:GetTeamNumber(),
+    caster:GetAbsOrigin(),
     nil,
     stone:GetSpecialValueFor("heal_on_death_range"),
     DOTA_UNIT_TARGET_TEAM_FRIENDLY,
@@ -260,8 +260,8 @@ function modifier_item_bloodstone_charge_collector:OnDeath(keys)
 
   local dead = self:GetParent()
 
-  if dead ~= keys.unit then
-    -- someone else died
+  if dead ~= keys.unit or not keys.unit:IsRealHero() or keys.unit:IsReincarnating() or keys.unit:IsTempestDouble() then
+    -- someone else died or it was not a real hero, Tempest Double, or is reincarnating
     return
   end
 

--- a/game/scripts/vscripts/items/bloodstone.lua
+++ b/game/scripts/vscripts/items/bloodstone.lua
@@ -184,7 +184,7 @@ function modifier_item_bloodstone_oaa:OnDeath(keys)
     if caster:GetTeamNumber() ~= dead:GetTeamNumber() and dead:IsRealHero() and not dead:IsTempestDouble() and not dead:IsReincarnating() then
       -- Charge gain
 
-      function IsItemBloodstone(item)
+      local function IsItemBloodstone(item)
         return string.sub(item:GetAbilityName(), 0, 15) == "item_bloodstone"
       end
 


### PR DESCRIPTION
Closes #777. There is, however, still the issue of the current implementation not granting charges for distant kills by Bloostone owners. I was in the middle of rewriting it to do the charge gain in `modifier_item_bloodstone_oaa:OnDeath` when I realised that has the issue of incrementing charges on all Bloodstones in the inventory rather than just the most top-left one.