### PR TITLE
Reworked Satanic Core

### DIFF
--- a/game/resource/English/ability/items/tooltip_satanic_core.txt
+++ b/game/resource/English/ability/items/tooltip_satanic_core.txt
@@ -14,7 +14,7 @@
 "DOTA_Tooltip_Ability_item_satanic_core_hero_lifesteal"                     "%HERO SPELL LIFESTEAL:"
 "DOTA_Tooltip_Ability_item_satanic_core_creep_lifesteal"                    "%CREEP SPELL LIFESTEAL:"
 "DOTA_Tooltip_Ability_item_satanic_core_lifesteal_percent"                  "%LIFESTEAL:"
-"DOTA_Tooltip_Ability_item_satanic_core_unholy_lifesteal_percent"           "%UNHOLY RAGE LIFESTEAL:"
+"DOTA_Tooltip_Ability_item_satanic_core_unholy_lifesteal_total_tooltip"     "%UNHOLY RAGE LIFESTEAL:"
 "DOTA_Tooltip_Ability_item_satanic_core_unholy_duration"                    "%UNHOLY RAGE DURATION:"
 
 "DOTA_Tooltip_Ability_item_satanic_core_2"                                  "Satanic Core"
@@ -30,7 +30,7 @@
 "DOTA_Tooltip_Ability_item_satanic_core_2_hero_lifesteal"                   "%HERO SPELL LIFESTEAL:"
 "DOTA_Tooltip_Ability_item_satanic_core_2_creep_lifesteal"                  "%CREEP SPELL LIFESTEAL:"
 "DOTA_Tooltip_Ability_item_satanic_core_2_lifesteal_percent"                "%LIFESTEAL:"
-"DOTA_Tooltip_Ability_item_satanic_core_2_unholy_lifesteal_percent"         "%UNHOLY RAGE LIFESTEAL:"
+"DOTA_Tooltip_Ability_item_satanic_core_2_unholy_lifesteal_total_tooltip"   "%UNHOLY RAGE LIFESTEAL:"
 "DOTA_Tooltip_Ability_item_satanic_core_2_unholy_duration"                  "%UNHOLY RAGE DURATION:"
 
 "DOTA_Tooltip_Ability_item_satanic_core_3"                                  "Satanic Core"
@@ -46,5 +46,5 @@
 "DOTA_Tooltip_Ability_item_satanic_core_3_hero_lifesteal"                   "%HERO SPELL LIFESTEAL:"
 "DOTA_Tooltip_Ability_item_satanic_core_3_creep_lifesteal"                  "%CREEP SPELL LIFESTEAL:"
 "DOTA_Tooltip_Ability_item_satanic_core_3_lifesteal_percent"                "%LIFESTEAL:"
-"DOTA_Tooltip_Ability_item_satanic_core_3_unholy_lifesteal_percent"         "%UNHOLY RAGE LIFESTEAL:"
+"DOTA_Tooltip_Ability_item_satanic_core_3_unholy_lifesteal_total_tooltip"   "%UNHOLY RAGE LIFESTEAL:"
 "DOTA_Tooltip_Ability_item_satanic_core_3_unholy_duration"                  "%UNHOLY RAGE DURATION:"

--- a/game/scripts/npc/items/item_octarine_core.txt
+++ b/game/scripts/npc/items/item_octarine_core.txt
@@ -67,7 +67,7 @@
 			"05"
 			{
 				"var_type"				"FIELD_FLOAT"
-				"hero_lifesteal"		"25 35"
+				"hero_lifesteal"		"25 30"
 			}
 			"06"
 			{

--- a/game/scripts/npc/items/item_satanic.txt
+++ b/game/scripts/npc/items/item_satanic.txt
@@ -66,12 +66,12 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"lifesteal_percent"		"25"
+				"lifesteal_percent"		"25 30 35 40 45"
 			}
 			"05"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"unholy_lifesteal_percent"	"175"
+				"unholy_lifesteal_percent"	"175 170 165 160 155"
 			}
 			"06"
 			{

--- a/game/scripts/npc/items/item_satanic_2.txt
+++ b/game/scripts/npc/items/item_satanic_2.txt
@@ -71,12 +71,12 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"lifesteal_percent"		"25"
+				"lifesteal_percent"		"25 30 35 40 45"
 			}
 			"05"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"unholy_lifesteal_percent"	"175"
+				"unholy_lifesteal_percent"	"175 170 165 160 155"
 			}
 			"06"
 			{

--- a/game/scripts/npc/items/item_satanic_3.txt
+++ b/game/scripts/npc/items/item_satanic_3.txt
@@ -70,12 +70,12 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"lifesteal_percent"		"25"
+				"lifesteal_percent"		"25 30 35 40 45"
 			}
 			"05"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"unholy_lifesteal_percent"	"175"
+				"unholy_lifesteal_percent"	"175 170 165 160 155"
 			}
 			"06"
 			{

--- a/game/scripts/npc/items/item_satanic_4.txt
+++ b/game/scripts/npc/items/item_satanic_4.txt
@@ -69,12 +69,12 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"lifesteal_percent"		"25"
+				"lifesteal_percent"		"25 30 35 40 45"
 			}
 			"05"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"unholy_lifesteal_percent"	"175"
+				"unholy_lifesteal_percent"	"175 170 165 160 155"
 			}
 			"06"
 			{

--- a/game/scripts/npc/items/item_satanic_5.txt
+++ b/game/scripts/npc/items/item_satanic_5.txt
@@ -67,12 +67,12 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"lifesteal_percent"		"25"
+				"lifesteal_percent"		"25 30 35 40 45"
 			}
 			"05"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"unholy_lifesteal_percent"	"175"
+				"unholy_lifesteal_percent"	"175 170 165 160 155"
 			}
 			"06"
 			{

--- a/game/scripts/npc/items/item_satanic_core.txt
+++ b/game/scripts/npc/items/item_satanic_core.txt
@@ -135,7 +135,7 @@
 			"14"
 			{
 				"var_type"        "FIELD_FLOAT"
-				"creep_spellsteal_unholy"   "165"
+				"creep_spellsteal_unholy"   "190 180 170"
 >>>>>>> nerfed satanic core spell lifesteal; made unholy rage work like satanic's
 			}
 		}

--- a/game/scripts/npc/items/item_satanic_core.txt
+++ b/game/scripts/npc/items/item_satanic_core.txt
@@ -90,45 +90,54 @@
 			"06"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"lifesteal_percent"		"25"
+				"lifesteal_percent"		"35"
 			}
 			"07"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"unholy_lifesteal_percent"	"200"
+				"unholy_lifesteal_percent"	"165"
 			}
 			"08"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"unholy_lifesteal_total_tooltip"	"200"
+			}
+			"09"
 			{
 				"var_type"				"FIELD_FLOAT"
 				"unholy_duration"		"4.5"
 			}
 			// Octarine Core Parameters
-			"09"
+			"10"
 			{
 				"var_type"				"FIELD_INTEGER"
 				"bonus_cooldown"		"25 25 25"
 			}
-			"10"
+			"11"
 			{
 				"var_type"				"FIELD_FLOAT"
+<<<<<<< HEAD
 				"hero_lifesteal"		"35 45 55"
+=======
+				"hero_lifesteal"		"35"
 			}
-      "11"
-      {
-        "var_type"        "FIELD_FLOAT"
-        "creep_lifesteal"   "10 20 30"
-      }
-      // unholy spellsteal
-      "12"
-      {
-        "var_type"        "FIELD_FLOAT"
-        "hero_spellsteal_unholy"   "200"
-      }
-      "13"
-      {
-        "var_type"        "FIELD_FLOAT"
-        "creep_spellsteal_unholy"   "200"
-      }
+			"12"
+			{
+				"var_type"        "FIELD_FLOAT"
+				"creep_lifesteal"   "10 20 30"
+			}
+			// unholy spellsteal
+			"13"
+			{
+				"var_type"        "FIELD_FLOAT"
+				"hero_spellsteal_unholy"   "165"
+			}
+			"14"
+			{
+				"var_type"        "FIELD_FLOAT"
+				"creep_spellsteal_unholy"   "165"
+>>>>>>> nerfed satanic core spell lifesteal; made unholy rage work like satanic's
+			}
 		}
 	}
 }

--- a/game/scripts/npc/items/item_satanic_core.txt
+++ b/game/scripts/npc/items/item_satanic_core.txt
@@ -70,7 +70,7 @@
 			"02"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"bonus_intelligence"	"25 35 45"
+				"bonus_intelligence"		"25 35 45"
 			}
 			"03"
 			{
@@ -116,27 +116,23 @@
 			"11"
 			{
 				"var_type"				"FIELD_FLOAT"
-<<<<<<< HEAD
-				"hero_lifesteal"		"35 45 55"
-=======
 				"hero_lifesteal"		"35"
 			}
 			"12"
 			{
-				"var_type"        "FIELD_FLOAT"
-				"creep_lifesteal"   "10 20 30"
+				"var_type"				"FIELD_FLOAT"
+				"creep_lifesteal"		"10 20 30"
 			}
 			// unholy spellsteal
 			"13"
 			{
-				"var_type"        "FIELD_FLOAT"
-				"hero_spellsteal_unholy"   "165"
+				"var_type"				"FIELD_FLOAT"
+				"hero_spellsteal_unholy"	"165"
 			}
 			"14"
 			{
-				"var_type"        "FIELD_FLOAT"
-				"creep_spellsteal_unholy"   "190 180 170"
->>>>>>> nerfed satanic core spell lifesteal; made unholy rage work like satanic's
+				"var_type"				"FIELD_FLOAT"
+				"creep_spellsteal_unholy"	"190 180 170"
 			}
 		}
 	}

--- a/game/scripts/npc/items/item_satanic_core_2.txt
+++ b/game/scripts/npc/items/item_satanic_core_2.txt
@@ -58,7 +58,7 @@
 			"02"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"bonus_intelligence"	"25 35 45"
+				"bonus_intelligence"		"25 35 45"
 			}
 			"03"
 			{
@@ -104,27 +104,23 @@
 			"11"
 			{
 				"var_type"				"FIELD_FLOAT"
-<<<<<<< HEAD
-				"hero_lifesteal"		"35 45 55"
-=======
 				"hero_lifesteal"		"35"
->>>>>>> nerfed satanic core spell lifesteal; made unholy rage work like satanic's
 			}
 			"12"
 			{
-				"var_type"        "FIELD_FLOAT"
-				"creep_lifesteal"   "10 20 30"
+				"var_type"				"FIELD_FLOAT"
+				"creep_lifesteal"		"10 20 30"
 			}
 			// unholy spellsteal
 			"13"
 			{
-				"var_type"        "FIELD_FLOAT"
-				"hero_spellsteal_unholy"   "165"
+				"var_type"				"FIELD_FLOAT"
+				"hero_spellsteal_unholy"	"165"
 			}
 			"14"
 			{
-				"var_type"        "FIELD_FLOAT"
-				"creep_spellsteal_unholy"   "190 180 170"
+				"var_type"				"FIELD_FLOAT"
+				"creep_spellsteal_unholy"	"190 180 170"
 			}
 		}
 	}

--- a/game/scripts/npc/items/item_satanic_core_2.txt
+++ b/game/scripts/npc/items/item_satanic_core_2.txt
@@ -124,7 +124,7 @@
 			"14"
 			{
 				"var_type"        "FIELD_FLOAT"
-				"creep_spellsteal_unholy"   "165"
+				"creep_spellsteal_unholy"   "190 180 170"
 			}
 		}
 	}

--- a/game/scripts/npc/items/item_satanic_core_2.txt
+++ b/game/scripts/npc/items/item_satanic_core_2.txt
@@ -78,45 +78,54 @@
 			"06"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"lifesteal_percent"		"25"
+				"lifesteal_percent"		"35"
 			}
 			"07"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"unholy_lifesteal_percent"	"200"
+				"unholy_lifesteal_percent"	"165"
 			}
 			"08"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"unholy_lifesteal_total_tooltip"	"200"
+			}
+			"09"
 			{
 				"var_type"				"FIELD_FLOAT"
 				"unholy_duration"		"4.5"
 			}
 			// Octarine Core Parameters
-			"09"
+			"10"
 			{
 				"var_type"				"FIELD_INTEGER"
 				"bonus_cooldown"		"25 25 25"
 			}
-			"10"
-			{
-				"var_type"				"FIELD_FLOAT"
-				"hero_lifesteal"		"35 45 55"
-			}
 			"11"
 			{
 				"var_type"				"FIELD_FLOAT"
-				"creep_lifesteal"		"10 20 30"
+<<<<<<< HEAD
+				"hero_lifesteal"		"35 45 55"
+=======
+				"hero_lifesteal"		"35"
+>>>>>>> nerfed satanic core spell lifesteal; made unholy rage work like satanic's
 			}
-      // unholy spellsteal
-      "12"
-      {
-        "var_type"        "FIELD_FLOAT"
-        "hero_spellsteal_unholy"   "200"
-      }
-      "13"
-      {
-        "var_type"        "FIELD_FLOAT"
-        "creep_spellsteal_unholy"   "200"
-      }
+			"12"
+			{
+				"var_type"        "FIELD_FLOAT"
+				"creep_lifesteal"   "10 20 30"
+			}
+			// unholy spellsteal
+			"13"
+			{
+				"var_type"        "FIELD_FLOAT"
+				"hero_spellsteal_unholy"   "165"
+			}
+			"14"
+			{
+				"var_type"        "FIELD_FLOAT"
+				"creep_spellsteal_unholy"   "165"
+			}
 		}
 	}
 }

--- a/game/scripts/npc/items/item_satanic_core_3.txt
+++ b/game/scripts/npc/items/item_satanic_core_3.txt
@@ -57,7 +57,7 @@
 			"02"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"bonus_intelligence"	"25 35 45"
+				"bonus_intelligence"		"25 35 45"
 			}
 			"03"
 			{
@@ -103,27 +103,23 @@
 			"11"
 			{
 				"var_type"				"FIELD_FLOAT"
-<<<<<<< HEAD
-				"hero_lifesteal"		"35 45 55"
-=======
 				"hero_lifesteal"		"35"
->>>>>>> nerfed satanic core spell lifesteal; made unholy rage work like satanic's
 			}
 			"12"
 			{
-				"var_type"        "FIELD_FLOAT"
-				"creep_lifesteal"   "10 20 30"
+				"var_type"				"FIELD_FLOAT"
+				"creep_lifesteal"		"10 20 30"
 			}
 			// unholy spellsteal
 			"13"
 			{
-				"var_type"        "FIELD_FLOAT"
-				"hero_spellsteal_unholy"   "165"
+				"var_type"				"FIELD_FLOAT"
+				"hero_spellsteal_unholy"	"165"
 			}
 			"14"
 			{
-				"var_type"        "FIELD_FLOAT"
-				"creep_spellsteal_unholy"   "190 180 170"
+				"var_type"				"FIELD_FLOAT"
+				"creep_spellsteal_unholy"	"190 180 170"
 			}
 		}
 	}

--- a/game/scripts/npc/items/item_satanic_core_3.txt
+++ b/game/scripts/npc/items/item_satanic_core_3.txt
@@ -123,7 +123,7 @@
 			"14"
 			{
 				"var_type"        "FIELD_FLOAT"
-				"creep_spellsteal_unholy"   "165"
+				"creep_spellsteal_unholy"   "190 180 170"
 			}
 		}
 	}

--- a/game/scripts/npc/items/item_satanic_core_3.txt
+++ b/game/scripts/npc/items/item_satanic_core_3.txt
@@ -77,45 +77,54 @@
 			"06"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"lifesteal_percent"		"25"
+				"lifesteal_percent"		"35"
 			}
 			"07"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"unholy_lifesteal_percent"	"200"
+				"unholy_lifesteal_percent"	"165"
 			}
 			"08"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"unholy_lifesteal_total_tooltip"	"200"
+			}
+			"09"
 			{
 				"var_type"				"FIELD_FLOAT"
 				"unholy_duration"		"4.5"
 			}
 			// Octarine Core Parameters
-			"09"
+			"10"
 			{
 				"var_type"				"FIELD_INTEGER"
 				"bonus_cooldown"		"25 25 25"
 			}
-			"10"
-			{
-				"var_type"				"FIELD_FLOAT"
-				"hero_lifesteal"		"35 45 55"
-			}
 			"11"
 			{
 				"var_type"				"FIELD_FLOAT"
-				"creep_lifesteal"		"10 20 30"
+<<<<<<< HEAD
+				"hero_lifesteal"		"35 45 55"
+=======
+				"hero_lifesteal"		"35"
+>>>>>>> nerfed satanic core spell lifesteal; made unholy rage work like satanic's
 			}
-      // unholy spellsteal
-      "12"
-      {
-        "var_type"        "FIELD_FLOAT"
-        "hero_spellsteal_unholy"   "200"
-      }
-      "13"
-      {
-        "var_type"        "FIELD_FLOAT"
-        "creep_spellsteal_unholy"   "200"
-      }
+			"12"
+			{
+				"var_type"        "FIELD_FLOAT"
+				"creep_lifesteal"   "10 20 30"
+			}
+			// unholy spellsteal
+			"13"
+			{
+				"var_type"        "FIELD_FLOAT"
+				"hero_spellsteal_unholy"   "165"
+			}
+			"14"
+			{
+				"var_type"        "FIELD_FLOAT"
+				"creep_spellsteal_unholy"   "165"
+			}
 		}
 	}
 }


### PR DESCRIPTION
Reduced hero spell lifesteal, increased normal lifesteal a bit.
Unholy Rage didn't work like normal Satanic's; fixed that.
Buffed Satanic lifesteal so it wouldn't lose.