### PR TITLE
Fixed Siege Mode 2 being _TOGGLE instead of _NO_TARGET

### DIFF
--- a/game/scripts/npc/items/item_siege_mode_2.txt
+++ b/game/scripts/npc/items/item_siege_mode_2.txt
@@ -40,7 +40,7 @@
 		"ID"							"3349"														// unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
 		"BaseClass"                    	"item_lua"
 		"ScriptFile"                   	"items/item_siege_mode.lua"
-		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_TOGGLE"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
 		"AbilityUnitTargetTeam"			"DOTA_UNIT_TARGET_TEAM_ENEMY"
 		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
 		"AbilityUnitTargetFlags"		"DOTA_UNIT_TARGET_FLAG_NONE"


### PR DESCRIPTION
This meant that when you activated it, it didn't actually do anything.