### PR TITLE
Make Bottle drops non-random and rework creep spawner internals

### DIFF
--- a/game/scripts/vscripts/components/creeps/item_drop.lua
+++ b/game/scripts/vscripts/components/creeps/item_drop.lua
@@ -82,6 +82,12 @@ function CreepItemDrop:CreateDrop (itemName, pos)
 end
 
 function CreepItemDrop:AddFixedDropsToCamp(creeps, numberOfCreepsSpawned)
+  local function IsNotNumber(value)
+    return not (type(value) == "number")
+  end
+
+  local sequencedCreeps = totable(filter(IsNotNumber, pairs(creeps)))
+
   local function AddItemToCamp(item)
     local from = item[FROM_ENUM]
     local to = item[TO_ENUM]
@@ -90,7 +96,11 @@ function CreepItemDrop:AddFixedDropsToCamp(creeps, numberOfCreepsSpawned)
 
     if (from < 0 or (from >= 0 and ItemPowerLevel >= from)) and (to < 0 or (to >= 0 and ItemPowerLevel <= to)) and numberOfCreepsSpawned % every == 0 then
       for i = 1,numDrops do
-        local selectedCreep = creeps[RandomInt(1, #creeps)]
+        local creepIndex = RandomInt(1, #sequencedCreeps)
+        local selectedCreep = sequencedCreeps[creepIndex]
+        if not selectedCreep then
+          return
+        end
         selectedCreep:AddNewModifier(nil, nil, "modifier_creep_loot", {drop = item[NAME_ENUM]})
       end
     end

--- a/game/scripts/vscripts/components/creeps/item_drop.lua
+++ b/game/scripts/vscripts/components/creeps/item_drop.lua
@@ -1,3 +1,4 @@
+LinkLuaModifier("modifier_creep_loot", "modifiers/modifier_creep_loot.lua", LUA_MODIFIER_MOTION_NONE)
 
 -- Taken from bb template
 if CreepItemDrop == nil then
@@ -16,6 +17,8 @@ local NAME_ENUM = 1
 local FROM_ENUM = 2
 local TO_ENUM = 3
 local RARITY_ENUM = 4
+local DROPS_ENUM = 4
+local EVERY_ENUM = 5
 
 --defines items drop levels.
 --item will start dropping, between FROM and TO itemPowerLevel.
@@ -26,10 +29,18 @@ local RARITY_ENUM = 4
 --  *TO   -> any level larger or equal than FROM will have  a chance to drop the item.
 --  *FROM and TO -> item will drop at any level.
 --  *RARITY -> item will not drop.
+--for PerCampDrops:
+--  DROPS is how many of the item to drop for every EVERY number of creeps spawned in a camp
 --it is possible to define the same item twice, for maximum flexibility
-ItemPowerTable = {
-  --NAME                        FROM    TO        RARITY
-  { "item_infinite_bottle",      3,      -1,      1},
+local ItemPowerTable = {
+  RandomDrops = {
+    --NAME                        FROM    TO        RARITY
+    --{ "item_infinite_bottle",      3,      -1,      1},
+  },
+  PerCreepDrops = {
+    --NAME                        FROM    TO        DROPS      EVERY
+    {"item_infinite_bottle",      -1,       -1,       1,           4}
+  }
 }
 
 function CreepItemDrop:Init ()
@@ -70,6 +81,24 @@ function CreepItemDrop:CreateDrop (itemName, pos)
   end)
 end
 
+function CreepItemDrop:AddFixedDropsToCamp(creeps, numberOfCreepsSpawned)
+  local function AddItemToCamp(item)
+    local from = item[FROM_ENUM]
+    local to = item[TO_ENUM]
+    local numDrops = item[DROPS_ENUM]
+    local every = item[EVERY_ENUM]
+
+    if (from < 0 or (from >= 0 and ItemPowerLevel >= from)) and (to < 0 or (to >= 0 and ItemPowerLevel <= to)) and numberOfCreepsSpawned % every == 0 then
+      for i = 1,numDrops do
+        local selectedCreep = creeps[RandomInt(1, #creeps)]
+        selectedCreep:AddNewModifier(nil, nil, "modifier_creep_loot", {drop = item[NAME_ENUM]})
+      end
+    end
+  end
+
+  foreach(AddItemToCamp, ItemPowerTable.PerCreepDrops)
+end
+
 function CreepItemDrop:OnEntityKilled (event)
   local killedEntity = EntIndexToHScript(event.entindex_killed)
 
@@ -94,14 +123,14 @@ function CreepItemDrop:RandomDropItemName( property_enum, powerLevel )
   local totalChancePool = 0.0
   local filteredItemTable = {}
 
-  for i=1, #ItemPowerTable do
-    local from = ItemPowerTable[i][FROM_ENUM]
-    local to = ItemPowerTable[i][TO_ENUM]
-    local rarity = ItemPowerTable[i][RARITY_ENUM]
+  for i=1, #ItemPowerTable.RandomDrops do
+    local from = ItemPowerTable.RandomDrops[i][FROM_ENUM]
+    local to = ItemPowerTable.RandomDrops[i][TO_ENUM]
+    local rarity = ItemPowerTable.RandomDrops[i][RARITY_ENUM]
 
     if (from < 0 or (from >= 0 and ItemPowerLevel >= from)) and (to < 0 or (to >= 0 and ItemPowerLevel <= to)) and rarity > 0 then
       totalChancePool = totalChancePool + 1.0 / rarity
-      filteredItemTable[#filteredItemTable + 1] = ItemPowerTable[i]
+      filteredItemTable[#filteredItemTable + 1] = ItemPowerTable.RandomDrops[i]
     end
   end
 

--- a/game/scripts/vscripts/components/creeps/item_drop.lua
+++ b/game/scripts/vscripts/components/creeps/item_drop.lua
@@ -86,6 +86,8 @@ function CreepItemDrop:AddFixedDropsToCamp(creeps, numberOfCreepsSpawned)
     return not (type(value) == "number")
   end
 
+  -- creeps table is not a sequence and has a count property
+  -- so we filter out the numeric count property and form the rest of the data into a sequence
   local sequencedCreeps = totable(filter(IsNotNumber, pairs(creeps)))
 
   local function AddItemToCamp(item)

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -1,3 +1,5 @@
+LinkLuaModifier("modifier_creep_camp_tracker", "modifiers/modifier_creep_camp_tracker.lua", LUA_MODIFIER_MOTION_NONE)
+
 -- Taken from bb template
 if CreepCamps == nil then
     Debug.EnabledModules['creeps:*'] = false
@@ -121,13 +123,15 @@ function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
     local currentUnitIndex = #self.LivingCreepsTable[locationString]
     self.LivingCreepsTable[locationString].count = self.LivingCreepsTable[locationString].count + 1
 
-    -- Set OnDeath event to clear creep from LivingCreepsTable
-    creepHandle:OnDeath(function ()
-      self.LivingCreepsTable[locationString][currentUnitIndex] = nil
-      self.LivingCreepsTable[locationString].count = self.LivingCreepsTable[locationString].count - 1
-    end)
+    -- Set modifier that will clear creep from LivingCreepsTable OnDeath or OnDominated
+    creepHandle:AddNewModifier(nil, nil, "modifier_creep_camp_tracker",
+      {
+        locationString = locationString,
+        creepIndex = currentUnitIndex
+      }
+    )
 
-    print(locationString .. ":" .. self.LivingCreepsTable[locationString].count)
+    --print(locationString .. ":" .. self.LivingCreepsTable[locationString].count)
 
     -- Increment spawn counter for camp
     if not self.NumberOfSpawnsTable[locationString] then

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -27,6 +27,7 @@ local EXP_BOUNTY_ENUM = 7
 function CreepCamps:Init ()
   DebugPrint ( 'Initializing.' )
   CreepCamps = self
+  self.NumberOfSpawnsTable = {}
   Timers:CreateTimer(Dynamic_Wrap(CreepCamps, 'CreepSpawnTimer'))
 end
 
@@ -68,6 +69,7 @@ function CreepCamps:DoSpawn (location, difficulty, maximumUnits)
     CreepCamps:SpawnCreepInCamp (location, creepGroup[i], maximumUnits)
   end
 end
+
 function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
   if creepProperties == nil then
     DebugPrint ('[creeps/spawner] unknown creep type ')
@@ -105,7 +107,18 @@ function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
   if creepHandle ~= nil then
     CreepCamps:SetCreepPropertiesOnHandle(creepHandle, creepProperties)
     creepHandle.Is_ItemDropEnabled = true
+    table.insert(units, creepHandle)
   end
+
+  -- Increment spawn counter for camp
+  local locationString = location.x .. "," .. location.y
+  if not self.NumberOfSpawnsTable[locationString] then
+    self.NumberOfSpawnsTable[locationString] = 0
+  end
+  self.NumberOfSpawnsTable[locationString] = self.NumberOfSpawnsTable[locationString] + 1
+
+  -- Add per spawn drops
+  CreepItemDrop:AddFixedDropsToCamp(units, self.NumberOfSpawnsTable[locationString])
 
   return true
 end

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -28,6 +28,7 @@ function CreepCamps:Init ()
   DebugPrint ( 'Initializing.' )
   CreepCamps = self
   self.NumberOfSpawnsTable = {}
+  self.LivingCreepsTable = {}
   Timers:CreateTimer(Dynamic_Wrap(CreepCamps, 'CreepSpawnTimer'))
 end
 
@@ -76,28 +77,37 @@ function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
     return false
   end
 
+  -- String for identifying cams based on spawn location
+  local locationString = location.x .. "," .. location.y
+
+  if not self.LivingCreepsTable[locationString] then
+    self.LivingCreepsTable[locationString] = {count = 0}
+  end
+
   -- ( iTeamNumber, vPosition, hCacheUnit, flRadius, iTeamFilter, iTypeFilter, iFlagFilter, iOrder, bCanGrowCache )
-  local units = FindUnitsInRadius(DOTA_TEAM_NEUTRALS,
-    location,
-    nil,
-    800,
-    DOTA_UNIT_TARGET_TEAM_FRIENDLY,
-    DOTA_UNIT_TARGET_CREEP,
-    DOTA_UNIT_TARGET_FLAG_NONE,
-    FIND_ANY_ORDER,
-    false)
+  -- local units = FindUnitsInRadius(DOTA_TEAM_NEUTRALS,
+  --   location,
+  --   nil,
+  --   800,
+  --   DOTA_UNIT_TARGET_TEAM_FRIENDLY,
+  --   DOTA_UNIT_TARGET_CREEP,
+  --   DOTA_UNIT_TARGET_FLAG_NONE,
+  --   FIND_ANY_ORDER,
+  --   false)
 
   creepProperties = CreepCamps:AdjustCreepPropertiesByPowerLevel( creepProperties, CreepPowerLevel )
 
-  if (maximumUnits and maximumUnits <= #units)
+  if (maximumUnits and maximumUnits <= self.LivingCreepsTable[locationString].count)
   then
     -- DebugPrint('[creeps/spawner] Too many creeps in camp, not spawning more')
-    for _,unit in pairs(units) do
-      local unitProperties = CreepCamps:GetCreepProperties(unit)
-      local distributedScale = 1.0 / maximumUnits
+    for key,unit in pairs(self.LivingCreepsTable[locationString]) do
+      if not (key == "count") then
+        local unitProperties = CreepCamps:GetCreepProperties(unit)
+        local distributedScale = 1.0 / maximumUnits
 
-      unitProperties = CreepCamps:AddCreepPropertiesWithScale(unitProperties, 1.0, creepProperties, distributedScale)
-      CreepCamps:SetCreepPropertiesOnHandle(unit, unitProperties)
+        unitProperties = CreepCamps:AddCreepPropertiesWithScale(unitProperties, 1.0, creepProperties, distributedScale)
+        CreepCamps:SetCreepPropertiesOnHandle(unit, unitProperties)
+      end
     end
     return false
   end
@@ -107,18 +117,27 @@ function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
   if creepHandle ~= nil then
     CreepCamps:SetCreepPropertiesOnHandle(creepHandle, creepProperties)
     creepHandle.Is_ItemDropEnabled = true
-    table.insert(units, creepHandle)
-  end
+    table.insert(self.LivingCreepsTable[locationString], creepHandle)
+    local currentUnitIndex = #self.LivingCreepsTable[locationString]
+    self.LivingCreepsTable[locationString].count = self.LivingCreepsTable[locationString].count + 1
 
-  -- Increment spawn counter for camp
-  local locationString = location.x .. "," .. location.y
-  if not self.NumberOfSpawnsTable[locationString] then
-    self.NumberOfSpawnsTable[locationString] = 0
-  end
-  self.NumberOfSpawnsTable[locationString] = self.NumberOfSpawnsTable[locationString] + 1
+    -- Set OnDeath event to clear creep from LivingCreepsTable
+    creepHandle:OnDeath(function ()
+      self.LivingCreepsTable[locationString][currentUnitIndex] = nil
+      self.LivingCreepsTable[locationString].count = self.LivingCreepsTable[locationString].count - 1
+    end)
 
-  -- Add per spawn drops
-  CreepItemDrop:AddFixedDropsToCamp(units, self.NumberOfSpawnsTable[locationString])
+    print(locationString .. ":" .. self.LivingCreepsTable[locationString].count)
+
+    -- Increment spawn counter for camp
+    if not self.NumberOfSpawnsTable[locationString] then
+      self.NumberOfSpawnsTable[locationString] = 0
+    end
+    self.NumberOfSpawnsTable[locationString] = self.NumberOfSpawnsTable[locationString] + 1
+
+    -- Add per spawn drops
+    CreepItemDrop:AddFixedDropsToCamp(self.LivingCreepsTable[locationString], self.NumberOfSpawnsTable[locationString])
+  end
 
   return true
 end

--- a/game/scripts/vscripts/modifiers/modifier_creep_camp_tracker.lua
+++ b/game/scripts/vscripts/modifiers/modifier_creep_camp_tracker.lua
@@ -1,0 +1,69 @@
+-- Modifier to handle removing creeps from the table tracking creeps in camps
+-- and redistribution of loot when creeps are dominated
+modifier_creep_camp_tracker = class({})
+
+function modifier_creep_camp_tracker:IsHidden()
+  return true
+end
+
+function modifier_creep_camp_tracker:IsPurgable()
+  return false
+end
+
+function modifier_creep_camp_tracker:IsPurgeException()
+  return false
+end
+
+function modifier_creep_camp_tracker:DeclareFunctions()
+  return {
+    MODIFIER_EVENT_ON_DOMINATED
+  }
+end
+
+function modifier_creep_camp_tracker:OnCreated(keys)
+  if IsServer() then
+    self.locationString = keys.locationString
+    self.creepIndex = keys.creepIndex
+  end
+end
+
+function modifier_creep_camp_tracker:OnDestroy()
+  if IsServer() then
+    -- Remove entry of parent from LivingCreepsTable
+    CreepCamps.LivingCreepsTable[self.locationString][self.creepIndex] = nil
+    CreepCamps.LivingCreepsTable[self.locationString].count = CreepCamps.LivingCreepsTable[self.locationString].count - 1
+
+    local parent = self:GetParent()
+    if parent and not parent:IsNull() and parent:IsAlive() then
+      local function IsNotNumber(value)
+        return not (type(value) == "number")
+      end
+
+      local lootModifiers = parent:FindAllModifiersByName("modifier_creep_loot")
+      local creeps = CreepCamps.LivingCreepsTable[self.locationString]
+      -- creeps table is not a sequence and has a count property
+      -- so we filter out the numeric count property and form the rest of the data into a sequence
+      local sequencedCreeps = totable(filter(IsNotNumber, pairs(creeps)))
+
+      local function MoveLootModifier(modifier)
+        local creepIndex = RandomInt(1, #sequencedCreeps)
+        local selectedCreep = sequencedCreeps[creepIndex]
+        if #sequencedCreeps > 0 and selectedCreep then
+          modifier:CopyToUnit(selectedCreep)
+        end
+        modifier:Destroy()
+      end
+
+      -- Redistribute loot modifiers to other creeps in camp
+      foreach(MoveLootModifier, lootModifiers)
+    end
+  end
+end
+
+function modifier_creep_camp_tracker:OnDominated(keys)
+  Debug.EnabledModules["modifiers:modifier_creep_camp_tracker"] = true
+  -- DebugPrintTable(keys)
+  if keys.unit and keys.unit == self:GetParent() then
+    self:Destroy()
+  end
+end

--- a/game/scripts/vscripts/modifiers/modifier_creep_camp_tracker.lua
+++ b/game/scripts/vscripts/modifiers/modifier_creep_camp_tracker.lua
@@ -61,8 +61,6 @@ function modifier_creep_camp_tracker:OnDestroy()
 end
 
 function modifier_creep_camp_tracker:OnDominated(keys)
-  Debug.EnabledModules["modifiers:modifier_creep_camp_tracker"] = true
-  -- DebugPrintTable(keys)
   if keys.unit and keys.unit == self:GetParent() then
     self:Destroy()
   end

--- a/game/scripts/vscripts/modifiers/modifier_creep_loot.lua
+++ b/game/scripts/vscripts/modifiers/modifier_creep_loot.lua
@@ -23,11 +23,24 @@ function modifier_creep_loot:OnCreated(keys)
   self.drop = keys.drop
 end
 
-function modifier_creep_loot:OnDestroy()
-  local deathLocation = self:GetParent():GetAbsOrigin()
-  local function DropItem(itemName)
-    CreepItemDrop:CreateDrop(itemName, deathLocation)
-  end
+function modifier_creep_loot:CopyToUnit(unit)
+  unit:AddNewModifier(self:GetCaster(), self:GetAbility(), self:GetName(), {drop = self.drop})
+end
 
-  DropItem(self.drop)
+function modifier_creep_loot:DeclareFunctions()
+  return {
+    MODIFIER_EVENT_ON_DEATH
+  }
+end
+
+function modifier_creep_loot:OnDeath(keys)
+  local parent = self:GetParent()
+  if keys.unit == parent then
+    local deathLocation = parent:GetAbsOrigin()
+    local function DropItem(itemName)
+      CreepItemDrop:CreateDrop(itemName, deathLocation)
+    end
+
+    DropItem(self.drop)
+  end
 end

--- a/game/scripts/vscripts/modifiers/modifier_creep_loot.lua
+++ b/game/scripts/vscripts/modifiers/modifier_creep_loot.lua
@@ -1,0 +1,33 @@
+-- Modifier that will drop items on parent dea
+-- Dropped items are passed in as parameters on creation
+
+modifier_creep_loot = class({})
+
+function modifier_creep_loot:GetAttributes()
+  return MODIFIER_ATTRIBUTE_MULTIPLE
+end
+
+function modifier_creep_loot:IsHidden()
+  return false
+end
+
+function modifier_creep_loot:IsPurgable()
+  return false
+end
+
+function modifier_creep_loot:IsPurgeException()
+  return false
+end
+
+function modifier_creep_loot:OnCreated(keys)
+  self.drop = keys.drop
+end
+
+function modifier_creep_loot:OnDestroy()
+  local deathLocation = self:GetParent():GetAbsOrigin()
+  local function DropItem(itemName)
+    CreepItemDrop:CreateDrop(itemName, deathLocation)
+  end
+
+  DropItem(self.drop)
+end

--- a/game/scripts/vscripts/modifiers/modifier_creep_loot.lua
+++ b/game/scripts/vscripts/modifiers/modifier_creep_loot.lua
@@ -8,7 +8,7 @@ function modifier_creep_loot:GetAttributes()
 end
 
 function modifier_creep_loot:IsHidden()
-  return false
+  return true
 end
 
 function modifier_creep_loot:IsPurgable()


### PR DESCRIPTION
Added a system for per creep spawn drops and made Bottles drop 1 for every 4 creeps spawned in a camp. 

Also changed the creep spawner to track creeps in a camp rather than doing a unit search in the camp. This could potentially break under some circumstances. I've done some testing, but I don't think it was particularly comprehensive. I also don't know if this is really desirable in the first place. The motivation for this was that, with the new map, a few of the camps are so close to each other that doing a unit search could potentially make the spawner think that creeps in another camp belong to a different camp (this messes with the max creep spawn and power/bounty distribution logic, though total bounty is unaffected). With the current range of 1000, it's actually doing that with the creeps just in their idle position. Simply reducing the range would work, but I think we would need to either accept that camps can still overlap sometimes if they're aggro'd into the correct spots, or that camps can be "stacked", though the only advantage of that would be causing more creeps rather than stronger ones.