### PR TITLE
Potential up preduel time w/o upping farm time

### DIFF
--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -1,4 +1,3 @@
-
 -- Taken from bb template
 if CreepCamps == nil then
     Debug.EnabledModules['creeps:*'] = false
@@ -36,7 +35,7 @@ function CreepCamps:SetPowerLevel (powerLevel)
 end
 
 function CreepCamps:CreepSpawnTimer ()
-  if (10 > CDOTAGamerules:GetDOTATime(false, false)) then
+  if (10 > GameRules:GetDOTATime(false, false)) then
     return 30
   end
   -- scan for creep camps and spawn them
@@ -49,7 +48,7 @@ function CreepCamps:CreepSpawnTimer ()
   CreepCamps:UpgradeCreeps()
 
 
-  if (50 > CDOTAGamerules:GetDOTATime(false, false)) then
+  if (50 > GameRules:GetDOTATime(false, false)) then
     return 30
   end
   return CreepSpawnInterval

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -36,6 +36,9 @@ function CreepCamps:SetPowerLevel (powerLevel)
 end
 
 function CreepCamps:CreepSpawnTimer ()
+  if (10 > CDOTAGamerules:GetDOTATime(false, false)) then
+    return 30
+  end
   -- scan for creep camps and spawn them
   -- DebugPrint('[creeps/spawner] Spawning creeps')
   local camps = Entities:FindAllByName('creep_camp')
@@ -45,6 +48,10 @@ function CreepCamps:CreepSpawnTimer ()
 
   CreepCamps:UpgradeCreeps()
 
+
+  if (50 > CDOTAGamerules:GetDOTATime(false, false)) then
+    return 30
+  end
   return CreepSpawnInterval
 end
 

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -7,7 +7,7 @@ ALLOW_SAME_HERO_SELECTION = false       -- Should we let people select the same 
 
 CUSTOM_GAME_SETUP_TIME = 30.0           -- How long to show custom game setup? 0 disables
 HERO_SELECTION_TIME = 30.0              -- How long should we let people select their hero?
-PRE_GAME_TIME = 5.0                     -- How long after people select their heroes should the horn blow and the game start?
+PRE_GAME_TIME = 10.0                     -- How long after people select their heroes should the horn blow and the game start?
 POST_GAME_TIME = 60.0                   -- How long should we let people look at the scoreboard before closing the server automatically?
 TREE_REGROW_TIME = 60.0                 -- How long should it take individual trees to respawn after being cut down/destroyed?
 


### PR DESCRIPTION
Attempting to cause the first creep spawn to occur at 30 seconds
Keeping the second at 60
Then continuing at every minute from then on.

Also, move the starting time 5 seconds sooner so you have more time before duel to buy items