### PR TITLE
Fix boken shield due to boss resisitance

### DIFF
--- a/game/scripts/npc/abilities/shielder/boss_shielder_shield.txt
+++ b/game/scripts/npc/abilities/shielder/boss_shielder_shield.txt
@@ -24,7 +24,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "percent_damage_reduce"                           "15"
+        "percent_damage_reduce"                           "100"
       }
       "02"
       {


### PR DESCRIPTION
I tried to do this through my local and remote and had a lot of problems and it is only one line so ya. 

Effectively we used damage block which is different from this shield. Because of this values no longer stack so the %DR needs to be 100 not 15.