### PR TITLE
Reduce existing creep search range for creep spawner

### DIFF
--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -76,7 +76,7 @@ function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
   local units = FindUnitsInRadius(DOTA_TEAM_NEUTRALS,
     location,
     nil,
-    1000,
+    800,
     DOTA_UNIT_TARGET_TEAM_FRIENDLY,
     DOTA_UNIT_TARGET_CREEP,
     DOTA_UNIT_TARGET_FLAG_NONE,


### PR DESCRIPTION
Close if #817 is merged first.

The current search range is causing creeps in some camps nearby to each other to be considered as part of both camps for max creep count and power/bounty redistribution when the camps are standing in their idle spots.

#817 contains a possibly more robust solution, but would very subtly (not enough to even really matter, in my opinion) alter creep spawn mechanics.