### PR TITLE
Fix a bunch of modifiers being purgable when they shouldn't be

### DIFF
--- a/game/scripts/vscripts/items/lucience.lua
+++ b/game/scripts/vscripts/items/lucience.lua
@@ -64,6 +64,10 @@ function modifier_item_lucience_aura_handler:IsHidden()
   return true
 end
 
+function modifier_item_lucience_aura_handler:IsPurgable()
+  return false
+end
+
 function modifier_item_lucience_aura_handler:GetAttributes()
   return MODIFIER_ATTRIBUTE_MULTIPLE
 end

--- a/game/scripts/vscripts/items/martyrs_mail.lua
+++ b/game/scripts/vscripts/items/martyrs_mail.lua
@@ -42,6 +42,10 @@ function modifier_item_martyrs_mail_passive:IsHidden()
 	return true
 end
 
+function modifier_item_martyrs_mail_passive:IsPurgable()
+  return false
+end
+
 function modifier_item_martyrs_mail_passive:OnCreated()
 	self.bonus_damage = self:GetAbility():GetSpecialValueFor( "bonus_damage" )
 	self.bonus_armor = self:GetAbility():GetSpecialValueFor( "bonus_armor" )
@@ -76,6 +80,10 @@ modifier_item_martyrs_mail_martyr_active = class({})
 
 function modifier_item_martyrs_mail_martyr_active:IsAura()
 	return true
+end
+
+function modifier_item_martyrs_mail_martyr_active:IsPurgable()
+  return false
 end
 
 function modifier_item_martyrs_mail_martyr_active:GetModifierAura()

--- a/game/scripts/vscripts/items/shivas_cuirass.lua
+++ b/game/scripts/vscripts/items/shivas_cuirass.lua
@@ -41,6 +41,10 @@ function modifier_item_shivas_cuirass:IsAura()
 	return true
 end
 
+function modifier_item_shivas_cuirass:IsPurgable()
+  return false
+end
+
 function modifier_item_shivas_cuirass:GetAuraRadius()
 	return self.aura_radius
 end

--- a/game/scripts/vscripts/items/shroud.lua
+++ b/game/scripts/vscripts/items/shroud.lua
@@ -31,6 +31,10 @@ function modifier_item_shroud_passive:IsHidden()
 	return true
 end
 
+function modifier_item_shroud_passive:IsPurgable()
+  return false
+end
+
 function modifier_item_shroud_passive:OnCreated()
 	self.bonus_all_stats = self:GetAbility():GetSpecialValueFor( "bonus_all_stats" )
 	self.bonus_attack_speed = self:GetAbility():GetSpecialValueFor( "bonus_attack_speed" )

--- a/game/scripts/vscripts/items/stoneskin.lua
+++ b/game/scripts/vscripts/items/stoneskin.lua
@@ -98,6 +98,10 @@ function modifier_item_stoneskin:IsHidden()
   return true
 end
 
+function modifier_item_stoneskin:IsPurgable()
+  return false
+end
+
 function modifier_item_stoneskin:GetAttributes()
   return MODIFIER_ATTRIBUTE_MULTIPLE
 end
@@ -130,6 +134,10 @@ function modifier_item_stoneskin_stone_armor:GetTexture()
     local baseIconName = ability.BaseClass.GetAbilityTextureName(ability)
     return baseIconName
   end
+end
+
+function modifier_item_stoneskin_stone_armor:IsPurgable()
+  return false
 end
 
 function modifier_item_stoneskin_stone_armor:GetStatusEffectName()

--- a/game/scripts/vscripts/items/trumps_fists.lua
+++ b/game/scripts/vscripts/items/trumps_fists.lua
@@ -23,6 +23,10 @@ function modifier_item_trumps_fists_passive:IsHidden()
   return true
 end
 
+function modifier_item_trumps_fists_passive:IsPurgable()
+  return false
+end
+
 function modifier_item_trumps_fists_passive:OnCreated()
   self.bonus_all_stats = self:GetAbility():GetSpecialValueFor( "bonus_all_stats" )
   self.bonus_damage = self:GetAbility():GetSpecialValueFor( "bonus_damage" )

--- a/game/scripts/vscripts/modifiers/modifier_boss_phase_controller.lua
+++ b/game/scripts/vscripts/modifiers/modifier_boss_phase_controller.lua
@@ -20,6 +20,10 @@ function modifier_boss_phase_controller:OnCreated (keys)
   self:StartIntervalThink( 0.5 )
 end
 
+function modifier_boss_phase_controller:IsPurgable()
+  return false
+end
+
 function modifier_boss_phase_controller:SetPhases (phases)
   self.phases = iter(phases)
 end


### PR DESCRIPTION
List includes:
- lucience_aura_handler
- martyrs_mail_passive
- martyrs_mail_martyr_active
- shivas_cuirass
- shroud_passive
- stoneskin
- stoneskin_stone_armor
- trumps_fists_passive
- boss_phase_controller

Closes #880.
I might have missed something. Would be good if someone can check through the modifiers. If there is no `IsPurgable` method on a modifier with a `return false`, then the modifier is purgable.