### PR TITLE
Change Lucience and Stoneskin icon handling to not rely on OnStackCountChanged

### DIFF
--- a/game/scripts/vscripts/items/lucience.lua
+++ b/game/scripts/vscripts/items/lucience.lua
@@ -28,6 +28,12 @@ end
 
 function item_lucience:GetAbilityTextureName()
   local baseIconName = self.BaseClass.GetAbilityTextureName(self)
+
+  -- Update state based on stacks of the intrinsic modifier
+  if self.auraHandler and not self.auraHandler:IsNull() then
+    self.lucienceState = self.auraHandler:GetStackCount()
+  end
+
   if not self.lucienceState then
     return baseIconName
   elseif self.lucienceState == auraTypeRegen then
@@ -117,6 +123,12 @@ function modifier_item_lucience_aura_handler:OnDestroy()
     local currentRegenAura = parent:FindModifierByName(regenAuraName)
     local currentMovespeedAura = parent:FindModifierByName(movespeedAuraName)
 
+    if ability:GetToggleState() then
+      self:SetStackCount(auraTypeMovespeed)
+    else
+      self:SetStackCount(auraTypeRegen)
+    end
+
     -- If the owner has a higher level Lucience Aura then don't do anything
     if currentRegenAura and ability:GetLevel() < currentRegenAura:GetAbility():GetLevel() then
       return
@@ -134,13 +146,6 @@ function modifier_item_lucience_aura_handler:OnDestroy()
       local auraHandlers = parent:FindAllModifiersByName(self:GetName())
       foreach(RefreshHandler, auraHandlers)
     end
-  end
-end
-
-function modifier_item_lucience_aura_handler:OnStackCountChanged(numOldStacks)
-  if IsClient() then
-    local ability = self:GetAbility()
-    ability.lucienceState = self:GetStackCount()
   end
 end
 

--- a/game/scripts/vscripts/items/stoneskin.lua
+++ b/game/scripts/vscripts/items/stoneskin.lua
@@ -10,6 +10,12 @@ end
 
 function item_stoneskin:GetAbilityTextureName()
   local baseIconName = self.BaseClass.GetAbilityTextureName(self)
+
+  -- Update state based on stacks of the intrinsic modifier
+  if self.intrinsicModifier and not self.intrinsicModifier:IsNull() then
+    self.stoneskinState = self.intrinsicModifier:GetStackCount()
+  end
+
   if self.stoneskinState == 2 then
     return baseIconName .. "_active"
   else
@@ -24,7 +30,7 @@ function item_stoneskin:OnToggle()
 
   if self:GetToggleState() then
     self:StartCooldown(activationDelay + cooldownAfterDelay)
-    self.IntrinsicModifier:SetStackCount(2)
+    self.intrinsicModifier:SetStackCount(2)
 
     EmitSoundOn("Hero_EarthSpirit.RollingBoulder.Loop", caster)
     Timers:CreateTimer(activationDelay, function()
@@ -40,13 +46,13 @@ function item_stoneskin:ApplyStoneskin()
   caster:AddNewModifier(caster, self, "modifier_item_stoneskin_stone_armor", {})
   StopSoundOn("Hero_EarthSpirit.RollingBoulder.Loop", caster)
   EmitSoundOn("Hero_EarthSpirit.Petrify", caster)
-  self.IntrinsicModifier:SetStackCount(2)
+  self.intrinsicModifier:SetStackCount(2)
 end
 
 function item_stoneskin:RemoveStoneskin()
   local caster = self:GetCaster()
   caster:RemoveModifierByName("modifier_item_stoneskin_stone_armor")
-  self.IntrinsicModifier:SetStackCount(1)
+  self.intrinsicModifier:SetStackCount(1)
 end
 
 item_stoneskin_2 = class(item_stoneskin)
@@ -55,8 +61,8 @@ modifier_item_stoneskin = class({})
 
 function modifier_item_stoneskin:OnCreated()
   local ability = self:GetAbility()
+  ability.intrinsicModifier = self
   if IsServer() then
-    ability.IntrinsicModifier = self
 
     if ability:GetToggleState() then
       ability:ApplyStoneskin()
@@ -75,14 +81,14 @@ function modifier_item_stoneskin:OnDestroy()
   end
 end
 
-function modifier_item_stoneskin:OnStackCountChanged(numOldStacks)
-  -- Echo stack count to a property on the item so that it can be checked for
-  -- item icon purposes
-  if IsClient() then
-    local ability = self:GetAbility()
-    ability.stoneskinState = self:GetStackCount()
-  end
-end
+-- function modifier_item_stoneskin:OnStackCountChanged(numOldStacks)
+--   -- Echo stack count to a property on the item so that it can be checked for
+--   -- item icon purposes
+--   if IsClient() then
+--     local ability = self:GetAbility()
+--     ability.stoneskinState = self:GetStackCount()
+--   end
+-- end
 
 function modifier_item_stoneskin:DeclareFunctions()
   return {


### PR DESCRIPTION
OnStackCountChanged seems to not get consistently called on the client for some weird reason. So this is somewhat more reliable.