### PR TITLE
Satanic Core tweaks and fixes

### DIFF
--- a/game/scripts/vscripts/items/satanic_core.lua
+++ b/game/scripts/vscripts/items/satanic_core.lua
@@ -1,6 +1,5 @@
 LinkLuaModifier( "modifier_octarine_vampirism_buff", "modifiers/modifier_octarine_vampirism_buff.lua", LUA_MODIFIER_MOTION_NONE )
 LinkLuaModifier( "modifier_item_satanic_core", "items/satanic_core.lua", LUA_MODIFIER_MOTION_NONE )
-LinkLuaModifier( "modifier_item_satanic_unholy", LUA_MODIFIER_MOTION_NONE )
 
 --------------------------------------------------------------------------------
 

--- a/game/scripts/vscripts/items/satanic_core.lua
+++ b/game/scripts/vscripts/items/satanic_core.lua
@@ -115,7 +115,10 @@ function modifier_item_satanic_core:OnTakeDamage( kv )
         heal_percent = self.lifesteal_percent + self.unholy_lifesteal_percent
       end
       ParticleManager:CreateParticle( "particles/generic_gameplay/generic_lifesteal.vpcf", PATTACH_ABSORIGIN_FOLLOW, hCaster )
-      hCaster:Heal( kv.damage * heal_percent / 100, hCaster)
+      local healAmount = kv.damage * heal_percent / 100
+      if healAmount > 0 then
+        hCaster:Heal( healAmount, hCaster)
+      end
     end
   end
 end

--- a/game/scripts/vscripts/items/satanic_core.lua
+++ b/game/scripts/vscripts/items/satanic_core.lua
@@ -80,7 +80,7 @@ function modifier_item_satanic_core:DeclareFunctions()
     MODIFIER_PROPERTY_HEALTH_BONUS,
     MODIFIER_PROPERTY_MANA_BONUS,
     MODIFIER_PROPERTY_COOLDOWN_PERCENTAGE,
-    MODIFIER_EVENT_ON_ATTACK_LANDED,
+    MODIFIER_EVENT_ON_TAKEDAMAGE,
   }
   return funcs
 end
@@ -105,13 +105,14 @@ function modifier_item_satanic_core:GetModifierPercentageCooldown()
   return self:GetAbility():GetSpecialValueFor( "bonus_cooldown" )
 end
 
-function modifier_item_satanic_core:OnAttackLanded( kv )
+function modifier_item_satanic_core:OnTakeDamage( kv )
   if IsServer() then
     local hCaster = self:GetParent()
-    if kv.attacker == hCaster then
+    -- Assume that no inflictor means damage was dealth from attack
+    if not kv.inflictor and kv.attacker == hCaster then
       local heal_percent = self.lifesteal_percent;
       if hCaster:HasModifier("modifier_item_satanic_unholy") then
-        heal_percent = self.unholy_lifesteal_percent
+        heal_percent = self.lifesteal_percent + self.unholy_lifesteal_percent
       end
       ParticleManager:CreateParticle( "particles/generic_gameplay/generic_lifesteal.vpcf", PATTACH_ABSORIGIN_FOLLOW, hCaster )
       hCaster:Heal( kv.damage * heal_percent / 100, hCaster)

--- a/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_applier.lua
+++ b/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_applier.lua
@@ -87,9 +87,6 @@ end
 
 function modifier_octarine_vampirism_applier:OnCreated( kv )
   self.aura_radius = self:GetAbility():GetSpecialValueFor( "radius" )
-  if IsServer() and self:GetParent() ~= self:GetCaster() then
-    self:StartIntervalThink( 0.5 )
-  end
 end
 
 --------------------------------------------------------------------------------

--- a/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_buff.lua
+++ b/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_buff.lua
@@ -60,8 +60,8 @@ function modifier_octarine_vampirism_buff:OnTakeDamage(params)
   local nCreepHeal = self.creep_lifesteal / 100
 
   if self.hero_spellsteal_unholy and hero:HasModifier("modifier_item_satanic_unholy") and hero:HasModifier("modifier_item_satanic_core") then
-    nHeroHeal = self.hero_spellsteal_unholy / 100
-    nCreepHeal = self.creep_spellsteal_unholy / 100
+    nHeroHeal = (self.hero_lifesteal + self.hero_spellsteal_unholy) / 100
+    nCreepHeal = (self.creep_lifesteal + self.creep_spellsteal_unholy) / 100
   end
 
   if params.inflictor then

--- a/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_buff.lua
+++ b/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_buff.lua
@@ -74,7 +74,7 @@ function modifier_octarine_vampirism_buff:OnTakeDamage(params)
         heal_amount = dmg * nHeroHeal
         end
       end
-      if heal_amount > 0 and hero:GetHealth() ~= hero:GetMaxHealth() then
+      if heal_amount > 0 then
         local healthCalculated = hero:GetHealth() + heal_amount
         hero:Heal(heal_amount, self:GetAbility())
         ParticleManager:CreateParticle("particles/items3_fx/octarine_core_lifesteal.vpcf",PATTACH_ABSORIGIN_FOLLOW, hero)


### PR DESCRIPTION
Fixed Satanic Core lifestealing off pre-reduction damage. Fixed Satanic Core active lifesteal and spell lifesteal using wrong values (effectively buffs Satanic Core active).

Was also going to remove the use of auras to apply `modifier_octarine_vampirism_buff`, but I realised that doing so would require some significant work to make the spell lifesteal not stack. Interesting note is that Octarine 1 spell lifesteal stacks with all the other custom Octarine items, including Octarine 2 due to still using the in-built code.