### PR TITLE
Make Stoneskin a fake toggle so that it respects cooldown

### DIFF
--- a/game/scripts/npc/items/item_stoneskin.txt
+++ b/game/scripts/npc/items/item_stoneskin.txt
@@ -29,7 +29,7 @@
     "ID"                                                  "3246"       // unique ID
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/stoneskin.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_TOGGLE | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL"
     "AbilityTextureName"                                  "custom/stoneskin"
     // Stats
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/item_stoneskin_2.txt
+++ b/game/scripts/npc/items/item_stoneskin_2.txt
@@ -23,7 +23,7 @@
     "ID"                                                  "3247"      // unique ID
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/stoneskin.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_TOGGLE | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL"
     "AbilityTextureName"                                  "custom/stoneskin_2"
     // Stats
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/vscripts/items/stoneskin.lua
+++ b/game/scripts/vscripts/items/stoneskin.lua
@@ -23,10 +23,13 @@ function item_stoneskin:GetAbilityTextureName()
   end
 end
 
-function item_stoneskin:OnToggle()
+function item_stoneskin:OnSpellStart()
   local activationDelay = self:GetSpecialValueFor("start_delay")
   local cooldownAfterDelay = self:GetSpecialValueFor("cooldown_after_delay")
   local caster = self:GetCaster()
+
+  -- Toggle state
+  self.serverStoneskinState = not self.serverStoneskinState
 
   if self:GetToggleState() then
     self:StartCooldown(activationDelay + cooldownAfterDelay)
@@ -41,6 +44,12 @@ function item_stoneskin:OnToggle()
   end
 end
 
+function item_stoneskin:GetToggleState()
+  if self.serverStoneskinState == nil then
+    self.serverStoneskinState = false
+  end
+  return self.serverStoneskinState
+end
 function item_stoneskin:ApplyStoneskin()
   local caster = self:GetCaster()
   caster:AddNewModifier(caster, self, "modifier_item_stoneskin_stone_armor", {})

--- a/game/scripts/vscripts/items/stoneskin.lua
+++ b/game/scripts/vscripts/items/stoneskin.lua
@@ -50,6 +50,30 @@ function item_stoneskin:GetToggleState()
   end
   return self.serverStoneskinState
 end
+
+-- Set no mana cost for toggle off
+function item_stoneskin:GetManaCost(level)
+  local baseManaCost = self.BaseClass.GetManaCost(self, level)
+  if IsServer() then
+    if self:GetToggleState() then
+      return 0
+    else
+      return baseManaCost
+    end
+  elseif IsClient() then
+    -- Update state based on stacks of the intrinsic modifier
+    if self.intrinsicModifier and not self.intrinsicModifier:IsNull() then
+      self.stoneskinState = self.intrinsicModifier:GetStackCount()
+    end
+
+    if self.stoneskinState == 2 then
+      return 0
+    else
+      return baseManaCost
+    end
+  end
+end
+
 function item_stoneskin:ApplyStoneskin()
   local caster = self:GetCaster()
   caster:AddNewModifier(caster, self, "modifier_item_stoneskin_stone_armor", {})


### PR DESCRIPTION
Closes #907.
No toggle off mana cost is how it worked before as well, so nothing actually changed there, aside from the UI now not showing a mana cost when the item is active.