### PR TITLE
Satanic Core tooltip cleanup

### DIFF
--- a/game/resource/English/modifier/items/modifier_satanic_core_unholy.txt
+++ b/game/resource/English/modifier/items/modifier_satanic_core_unholy.txt
@@ -1,0 +1,5 @@
+//=============================================================================
+// Satanic Core Unholy Rage
+//=============================================================================
+"DOTA_Tooltip_modifier_satanic_core_unholy"               "Unholy Rage"
+"DOTA_Tooltip_modifier_satanic_core_unholy_Description"   "Lifesteal increased to %dMODIFIER_PROPERTY_TOOLTIP%%%."

--- a/game/scripts/npc/items/item_satanic_core.txt
+++ b/game/scripts/npc/items/item_satanic_core.txt
@@ -106,7 +106,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_cooldown"                                  "25 25 25"
+        "bonus_cooldown"                                  "25"
       }
       "10"
       {

--- a/game/scripts/npc/items/item_satanic_core_2.txt
+++ b/game/scripts/npc/items/item_satanic_core_2.txt
@@ -94,7 +94,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_cooldown"                                  "25 25 25"
+        "bonus_cooldown"                                  "25"
       }
       "10"
       {

--- a/game/scripts/npc/items/item_satanic_core_3.txt
+++ b/game/scripts/npc/items/item_satanic_core_3.txt
@@ -93,7 +93,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_cooldown"                                  "25 25 25"
+        "bonus_cooldown"                                  "25"
       }
       "10"
       {

--- a/game/scripts/vscripts/items/satanic_core.lua
+++ b/game/scripts/vscripts/items/satanic_core.lua
@@ -1,5 +1,6 @@
 LinkLuaModifier( "modifier_octarine_vampirism_buff", "modifiers/modifier_octarine_vampirism_buff.lua", LUA_MODIFIER_MOTION_NONE )
 LinkLuaModifier( "modifier_item_satanic_core", "items/satanic_core.lua", LUA_MODIFIER_MOTION_NONE )
+LinkLuaModifier( "modifier_satanic_core_unholy", "items/satanic_core.lua", LUA_MODIFIER_MOTION_NONE )
 
 --------------------------------------------------------------------------------
 
@@ -14,7 +15,7 @@ function item_satanic_core:OnSpellStart()
   local unholy_duration = self:GetSpecialValueFor( "unholy_duration" )
 
   EmitSoundOn( "DOTA_Item.Satanic.Activate", hCaster )
-  hCaster:AddNewModifier( hCaster, self, "modifier_item_satanic_unholy", { duration = unholy_duration } )
+  hCaster:AddNewModifier( hCaster, self, "modifier_satanic_core_unholy", { duration = unholy_duration } )
 end
 
 --------------------------------------------------------------------------------
@@ -111,7 +112,7 @@ function modifier_item_satanic_core:OnTakeDamage( kv )
     -- Assume that no inflictor means damage was dealth from attack
     if not kv.inflictor and kv.attacker == hCaster then
       local heal_percent = self.lifesteal_percent;
-      if hCaster:HasModifier("modifier_item_satanic_unholy") then
+      if hCaster:HasModifier("modifier_satanic_core_unholy") then
         heal_percent = self.lifesteal_percent + self.unholy_lifesteal_percent
       end
       ParticleManager:CreateParticle( "particles/generic_gameplay/generic_lifesteal.vpcf", PATTACH_ABSORIGIN_FOLLOW, hCaster )
@@ -124,3 +125,23 @@ function modifier_item_satanic_core:OnTakeDamage( kv )
 end
 
 --------------------------------------------------------------------------------
+
+modifier_satanic_core_unholy = class({})
+
+function modifier_satanic_core_unholy:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_TOOLTIP
+  }
+end
+
+function modifier_satanic_core_unholy:OnTooltip()
+  return self:GetAbility():GetSpecialValueFor("unholy_lifesteal_total_tooltip")
+end
+
+function modifier_satanic_core_unholy:GetEffectName()
+  return "particles/items2_fx/satanic_buff.vpcf"
+end
+
+function modifier_satanic_core_unholy:GetEffectAttachType()
+  return PATTACH_ABSORIGIN_FOLLOW
+end

--- a/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_buff.lua
+++ b/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_buff.lua
@@ -59,7 +59,7 @@ function modifier_octarine_vampirism_buff:OnTakeDamage(params)
   local nHeroHeal = self.hero_lifesteal / 100
   local nCreepHeal = self.creep_lifesteal / 100
 
-  if self.hero_spellsteal_unholy and hero:HasModifier("modifier_item_satanic_unholy") and hero:HasModifier("modifier_item_satanic_core") then
+  if self.hero_spellsteal_unholy and hero:HasModifier("modifier_satanic_core_unholy") and hero:HasModifier("modifier_item_satanic_core") then
     nHeroHeal = (self.hero_lifesteal + self.hero_spellsteal_unholy) / 100
     nCreepHeal = (self.creep_lifesteal + self.creep_spellsteal_unholy) / 100
   end


### PR DESCRIPTION
Remove repeated CDR values in Satanic Core KV so that it doesn't say "25/25/25" in tooltip.

Make Satanic Core use its own modifier for active effect rather than the built-in modifier_item_satanic_unholy. Mainly so that the modifier tooltip can be changed.