### PR TITLE
Moved the Info Panel Button again

### DIFF
--- a/content/panorama/scripts/custom_game/game_info.js
+++ b/content/panorama/scripts/custom_game/game_info.js
@@ -5,5 +5,5 @@
 }());
 
 function MoveGameInfo () {
-  FindDotaHudElement('GameInfoButton').style.transform = 'translateY(50%)';
+  FindDotaHudElement('GameInfoButton').style.transform = 'translateY(20%)';
 }


### PR DESCRIPTION
Info Panel was moved away from the KDA display. However this put it where players didn't ever notice it. Moving it up like this makes it more noticeable while not covering any important UI.

![Changed to 20% from 50%](https://cloud.githubusercontent.com/assets/13878439/26536284/71df08ee-4403-11e7-911d-088ea734a879.png)
