### PR TITLE
Shiva's Cuirass Nerf

### DIFF
--- a/game/scripts/npc/items/item_shivas_cuirass.txt
+++ b/game/scripts/npc/items/item_shivas_cuirass.txt
@@ -70,12 +70,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "75 80"
+        "bonus_intellect"                                 "70 80"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "40 45"
+        "bonus_armor"                                     "35 40"
       }
       "03"
       {
@@ -105,7 +105,7 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "blast_radius"                                    "900 1100"
+        "blast_radius"                                    "650 1000"
       }
       "09"
       {
@@ -121,17 +121,17 @@
       "11"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_negative_armor"                             "-15 -20"
+        "aura_negative_armor"                             "-7 -11"
       }
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_attack_speed_bonus"                         "35 45"
+        "aura_attack_speed_bonus"                         "35 40"
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_positive_armor"                             "15 20"
+        "aura_positive_armor"                             "7 11"
       }
     }
   }

--- a/game/scripts/npc/items/item_shivas_cuirass.txt
+++ b/game/scripts/npc/items/item_shivas_cuirass.txt
@@ -75,7 +75,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "35 40"
+        "bonus_armor"                                     "30 35"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_shivas_cuirass_2.txt
+++ b/game/scripts/npc/items/item_shivas_cuirass_2.txt
@@ -58,12 +58,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "75 80"
+        "bonus_intellect"                                 "70 80"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "40 45"
+        "bonus_armor"                                     "35 40"
       }
       "03"
       {
@@ -93,7 +93,7 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "blast_radius"                                    "900 1100"
+        "blast_radius"                                    "650 1000"
       }
       "09"
       {
@@ -109,17 +109,17 @@
       "11"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_negative_armor"                             "-15 -20"
+        "aura_negative_armor"                             "-7 -11"
       }
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_attack_speed_bonus"                         "35 45"
+        "aura_attack_speed_bonus"                         "35 40"
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_positive_armor"                             "15 20"
+        "aura_positive_armor"                             "7 11"
       }
     }
   }

--- a/game/scripts/npc/items/item_shivas_cuirass_2.txt
+++ b/game/scripts/npc/items/item_shivas_cuirass_2.txt
@@ -63,7 +63,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "35 40"
+        "bonus_armor"                                     "30 35"
       }
       "03"
       {


### PR DESCRIPTION
SC Suggestion:
Not a downgrade to it's individual parts
19 less armour total at level 5
weaker aura

We don't know exactly what to do with Shivas Cuirass. We do know that it is to strong. So for now here's a nerf that's still worth upgrading.