### PR TITLE
Prevent Disconnected Heroes from gaining XP

### DIFF
--- a/game/scripts/vscripts/components/progression/hero_progression.lua
+++ b/game/scripts/vscripts/components/progression/hero_progression.lua
@@ -34,6 +34,7 @@ function HeroProgression:Init()
     "Intellect"
   }
 
+  FilterManager:AddFilter(FilterManager.ModifyExperience, self, Dynamic_Wrap(HeroProgression, "ExperienceFilter"))
   self:RegisterCustomLevellingPatterns()
 end
 
@@ -154,4 +155,10 @@ function HeroProgression:OnLevelUpChatCmd(keys)
   local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
   DebugPrint('Levelling up ' .. hero:GetName() .. ' now at level ' .. hero:GetLevel())
   hero:HeroLevelUp(true)
+end
+
+function HeroProgression:ExperienceFilter(keys)
+  local playerID = keys.player_id_const
+
+  return PlayerResource:GetConnectionState(playerID) ~= DOTA_CONNECTION_STATE_DISCONNECTED
 end


### PR DESCRIPTION
I haven't tested this, but  this should prevent dc'ed heroes from gaining xp