### PR TITLE
Make PlayerResource:RandomHeroForPlayersWithoutHero() only try to random for connected players

### DIFF
--- a/game/scripts/vscripts/libraries/playerresource.lua
+++ b/game/scripts/vscripts/libraries/playerresource.lua
@@ -38,6 +38,6 @@ function CDOTA_PlayerResource:RandomHeroForPlayersWithoutHero()
   function ForceRandomHero(playerID)
     self:GetPlayer(playerID):MakeRandomHeroSelection()
   end
-  local playerIDsWithoutHero = filter(HasNotSelectedHero, self:GetAllTeamPlayerIDs())
+  local playerIDsWithoutHero = filter(HasNotSelectedHero, self:GetConnectedTeamPlayerIDs())
   foreach(ForceRandomHero, playerIDsWithoutHero)
 end


### PR DESCRIPTION
Should fix black screens after hero pick due to disconnected players. Will need some other handling for reconnection if we still want them to be force-randomed if they reconnect after pick stage.