### PR TITLE
Fixed exception when players or some other state

### DIFF
--- a/game/scripts/vscripts/components/progression/hero_progression.lua
+++ b/game/scripts/vscripts/components/progression/hero_progression.lua
@@ -160,5 +160,5 @@ end
 function HeroProgression:ExperienceFilter(keys)
   local playerID = keys.player_id_const
 
-  return PlayerResource:GetConnectionState(playerID) ~= DOTA_CONNECTION_STATE_DISCONNECTED
+  return PlayerResource:GetConnectionState(playerID) == DOTA_CONNECTION_STATE_CONNECTED
 end


### PR DESCRIPTION
>Should have looked at this sooner, but anyway, I think this should be == DOTA_CONNECTION_STATE_CONNECTED because players could also be abandoned or some other state.

--  Trildar