### PR TITLE
Rework ChatCommand component

### DIFF
--- a/docs/chatcommands.md
+++ b/docs/chatcommands.md
@@ -2,28 +2,42 @@
 Commands to be used for debugging and testing purposes, currently requires the game to either be in tools mode or have sv_cheats 1 enabled. To use these types them into the chat prompt like you would messaging allies. <b>As for now, there is a bug that prevents the chat listener from working on workshop mode, and thus none of these commands will work in upload versions, only in tools mode.</b>
 <br>
 <br>
--list/-help - Displays a list of all available chat commands
+-list/-help - Displays a list of all available chat commands.
 <br>
--addbots - Adds Bots (not the same bots that RamonNZ added)
+-addbots - Adds Bots (not the same bots that RamonNZ added).
 <br>
--nofog - Removes fog of war revealing everything
+-nofog - Removes fog of war revealing everything.
 <br>
--fog - Re-adds fog of war
+-fog - Re-adds fog of war.
 <br>
--startduel - Forces duel start
+-duel - Forces duel start.
 <br>
--endduel - Ends a duel
+-end_duel - Ends a duel.
 <br>
--god - Gives invunerability
+-god - Toggles invunerability.
 <br>
--disarm - Disarms player
+-disarm - Toggles disarm on player.
 <br>
--dagger - Gives global blink dagger
+-dagger - Gives global blink dagger.
 <br>
--core x - Can be used to give upgrade cores, core 1, core 2, core 3, core 4, -core by itself gives core level 1 
+-devdagon - Gives insta-kill dagon.
 <br>
--add x - Give abilities. Accepts partial names. -add fury_swipes will give Ursa's fury swipes, it uses the technical name for abilities, so some names may not work -add greevils will not add greevils greed because its tehnical name is goblins greed
+-core x - Can be used to give upgrade cores, core 1, core 2, core 3, core 4, -core by itself gives core level 1.
 <br>
--give x y - Gives Items. Accepts partial names. Does not give receipes, can be given a third input to specify a number, e.g. -give heart 3 gives a level 3 heart of Tarrasque .
+-addability x - Give abilities. Accepts partial names. -add fury_swipes will give Ursa's fury swipes, it uses the technical name for abilities, so some names may not work -add greevils will not add greevils greed because its tehnical name is goblins greed.
+<br>
+-give x y - Gives Items. Accepts partial names. Does not give receipes, can be given a third input to specify a number, e.g. -give heart 3 gives a level 3 heart of Tarrasque.
 <br>
 -fixspawn - This makes all heros teleport back to their fountain, this should be useful when bots or playres have bugged out and have become stuck in a strange part of the map.
+<br>
+-kill_limit x - Sets the kill limit win condition to the specified number.
+<br>
+-addpoints x - Adds specified number of points to the user's team. Adds 1 point if no number specified.
+<br>
+-switchhero x - Switch hero. Accepts partial names. Uses internal names, so -switchhero obsidian switches to Outworld Devourer, because his internal name is obsidian_destroyer.
+<br>
+-loadout x - Gives a pre-determined set of items. -loadout tank gives max level Heart, Stoneskin, and Satanic Core. -loadout damage gives max level Daedalus, Desolator, and Moon Shard.
+<br>
+-scepter x - Gives an Aghanim's Scepter of the specified level. Gives level 1 if no level specified.
+<br>
+-print_modifiers - Prints names of all modifiers on user's hero to console.

--- a/docs/chatcommands.md
+++ b/docs/chatcommands.md
@@ -41,3 +41,5 @@ Commands to be used for debugging and testing purposes, currently requires the g
 -scepter x - Gives an Aghanim's Scepter of the specified level. Gives level 1 if no level specified.
 <br>
 -print_modifiers - Prints names of all modifiers on user's hero to console.
+<br>
+-tptest - Teleports all heroes to the middle of the map. Used for testing the Duel teleportation code.

--- a/game/scripts/vscripts/components/devcheats/commands.lua
+++ b/game/scripts/vscripts/components/devcheats/commands.lua
@@ -1,0 +1,20 @@
+-- Component for various chat commands useful for testing
+-- Majority of original command code by Darklord
+
+DevCheats = class({})
+
+function DevCheats:Init()
+  ChatCommand:LinkCommand("-print_modifiers", "PrintModifiers", self)
+end
+
+function DevCheats:PrintModifiers(keys)
+  local playerID = keys.playerid
+  local hero = PlayerResource:GetSelectedHeroEntity(playerID)
+  local modifiers = hero:FindAllModifiers()
+
+  local function PrintModifier(modifier)
+    print(modifier:GetName())
+  end
+
+  foreach(PrintModifier, modifiers)
+end

--- a/game/scripts/vscripts/components/devcheats/commands.lua
+++ b/game/scripts/vscripts/components/devcheats/commands.lua
@@ -97,7 +97,7 @@ function DevCheats:TeleportHeroesToFountain(keys)
   PlayerResource:GetAllTeamPlayerIDs():each(function(playerID)
     local hero = PlayerResource:GetSelectedHeroEntity(playerID)
     if hero ~= nil and IsValidEntity(hero) then
-      hero:AddNewModifier(caster, ability, "modifier_chen_test_of_faith_teleport", {duration = 1})
+      hero:AddNewModifier(nil, nil, "modifier_chen_test_of_faith_teleport", {duration = 1})
     end
   end)
 end
@@ -258,7 +258,6 @@ function DevCheats:SwitchHero(keys)
   local text = string.lower(keys.text)
   local splitted = split(text, " ")
   local playerID = keys.playerid
-  local hero = PlayerResource:GetSelectedHeroEntity(playerID)
 
   if splitted[2] then
     local herolist = LoadKeyValues('scripts/npc/herolist.txt')

--- a/game/scripts/vscripts/components/devcheats/commands.lua
+++ b/game/scripts/vscripts/components/devcheats/commands.lua
@@ -228,7 +228,7 @@ function DevCheats:GiveLoadout(keys)
       local RemoveItem = function(handle) hero:RemoveItem(handle) end
       local GetItemInSlot = function(slot) return hero:GetItemInSlot(slot) end
       local AddItemByName = function(item) hero:AddItemByName(item) end
-      -- BUG: Items don't get removed
+
       each(RemoveItem, map(GetItemInSlot, range(DOTA_ITEM_SLOT_1, DOTA_ITEM_SLOT_6)))
       each(AddItemByName, iter(loadouts[splitted[2]]))
     end

--- a/game/scripts/vscripts/components/devcheats/commands.lua
+++ b/game/scripts/vscripts/components/devcheats/commands.lua
@@ -4,9 +4,28 @@
 DevCheats = class({})
 
 function DevCheats:Init()
-  ChatCommand:LinkCommand("-print_modifiers", "PrintModifiers", self)
+  ChatCommand:LinkCommand("-help", Dynamic_Wrap(DevCheats, "Help"), self)
+  ChatCommand:LinkCommand("-list", Dynamic_Wrap(DevCheats, "Help"), self)
+  ChatCommand:LinkCommand("-print_modifiers", Dynamic_Wrap(DevCheats, "PrintModifiers"), self)
+  ChatCommand:LinkCommand("-addbots", Dynamic_Wrap(DevCheats, "AddBots"), self)
+  ChatCommand:LinkCommand("-nofog", Dynamic_Wrap(DevCheats, "DisableFog"), self)
+  ChatCommand:LinkCommand("-fog", Dynamic_Wrap(DevCheats, "EnableFog"), self)
+  ChatCommand:LinkCommand("-fixspawn", Dynamic_Wrap(DevCheats, "TeleportHeroesToFountain"), self)
+  ChatCommand:LinkCommand("-getpos", Dynamic_Wrap(DevCheats, "PrintPosition"), self)
+  ChatCommand:LinkCommand("-god", Dynamic_Wrap(DevCheats, "GodMode"), self)
+  ChatCommand:LinkCommand("-disarm", Dynamic_Wrap(DevCheats, "ToggleDisarm"), self)
+  ChatCommand:LinkCommand("-dagger", Dynamic_Wrap(DevCheats, "GiveDevDagger"), self)
+  ChatCommand:LinkCommand("-core", Dynamic_Wrap(DevCheats, "GiveUpgradeCore"), self)
+  ChatCommand:LinkCommand("-addability", Dynamic_Wrap(DevCheats, "AddAbility"), self)
+  ChatCommand:LinkCommand("-give", Dynamic_Wrap(DevCheats, "GiveLevelledItem"), self)
+  ChatCommand:LinkCommand("-loadout", Dynamic_Wrap(DevCheats, "GiveLoadout"), self)
+  ChatCommand:LinkCommand("-scepter", Dynamic_Wrap(DevCheats, "GiveUltimateScepter"), self)
+  ChatCommand:LinkCommand("-devdagon", Dynamic_Wrap(DevCheats, "GiveDevDagon"), self)
+  ChatCommand:LinkCommand("-switchhero", Dynamic_Wrap(DevCheats, "SwitchHero"), self)
 end
 
+-- Print all modifiers on player's hero to console
+-- TODO: Allow printing modifiers on selected units if possible
 function DevCheats:PrintModifiers(keys)
   local playerID = keys.playerid
   local hero = PlayerResource:GetSelectedHeroEntity(playerID)
@@ -17,4 +36,240 @@ function DevCheats:PrintModifiers(keys)
   end
 
   foreach(PrintModifier, modifiers)
+end
+
+-- Print list of available commands to chat
+function DevCheats:Help(keys)
+  GameRules:SendCustomMessage("-nofog, -fog, -god, -disarm, -dagger, -core 1-4, -duel, -end_duel, -addbots", 0, 0)
+  GameRules:SendCustomMessage("-addability x, -give x y, -fixspawn, -kill_limit x, -switchhero x, -loadout x, -scepter [1-5]", 0, 0)
+  GameRules:SendCustomMessage("-addpoints, -print_modifiers, -devdagon", 0, 0)
+end
+
+-- Populate game with bots
+function DevCheats:AddBots(keys)
+  local numPlayers = PlayerResource:GetPlayerCount()
+
+  PlayerResource:RandomHeroForPlayersWithoutHero()
+
+  -- Eanble bots and fill empty slots
+  if IsServer() and GameRules:GetMaxTeamPlayers() - numPlayers > 0 then
+    -- Set bot difficulty
+    SendToServerConsole("dota_bot_set_difficulty 4")
+    SendToServerConsole("dota_bot_practice_difficulty 4")
+    -- Fill all empty slots with bots
+    SendToServerConsole("dota_bot_populate")
+  end
+
+  -- Don't think these settings are necessary
+  -- GameRules:GetGameModeEntity():SetBotThinkingEnabled(true)
+  -- GameRules:GetGameModeEntity():SetBotsInLateGame(true)
+
+  -- This applies the simple bot controller ability, which shouldn't be necessary since bots have a semi-proper AI by RamonNZ.
+  -- The AI probably doesn't quite work right due to all the map changes though. Don't think the bots know where all the camps are now.
+  -- Timers:CreateTimer(5,function()
+  --   PlayerResource:GetAllTeamPlayerIDs():each(function(playerID)
+  --     local hero = PlayerResource:GetSelectedHeroEntity(playerID)
+  --     if hero ~= nil and IsValidEntity(hero) and PlayerResource:GetSteamAccountID(playerID) == 0 then
+  --       hero:AddAbility("dev_bot_control")
+  --       local controller = hero:FindAbilityByName("dev_bot_control")
+  --       if controller then
+  --         controller:UpgradeAbility(false)
+  --         controller:SetHidden(true)
+  --       end
+  --     end
+  --   end)
+  -- end)
+end
+
+-- Remove fog of war on the map, revealing everything
+function DevCheats:DisableFog(keys)
+  GameRules:GetGameModeEntity():SetFogOfWarDisabled(true)
+end
+
+-- Bring the back fog of war
+-- BUG?: Re-enabling Fog of War after disabling causes a blue overlay to mark all areas seen since re-enabling Fog of War
+function DevCheats:EnableFog(keys)
+  GameRules:GetGameModeEntity():SetFogOfWarDisabled(false)
+end
+
+-- Teleport all heroes to their fountain
+function DevCheats:TeleportHeroesToFountain(keys)
+  PlayerResource:GetAllTeamPlayerIDs():each(function(playerID)
+    local hero = PlayerResource:GetSelectedHeroEntity(playerID)
+    if hero ~= nil and IsValidEntity(hero) then
+      hero:AddNewModifier(caster, ability, "modifier_chen_test_of_faith_teleport", {duration = 1})
+    end
+  end)
+end
+
+-- Print vector of current position of hero to console and chat
+function DevCheats:PrintPosition(keys)
+  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
+
+  print(hero:GetAbsOrigin())
+  GameRules:SendCustomMessage(tostring(hero:GetAbsOrigin()), 0, 0)
+end
+
+-- Toggle invulnerability on player hero
+function DevCheats:GodMode(keys)
+  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
+  local godMode = hero:FindModifierByName("modifier_invulnerable")
+  if godMode then
+    hero:RemoveModifierByName("modifier_invulnerable")
+  else
+    hero:AddNewModifier(hero, nil, "modifier_invulnerable", {})
+  end
+end
+
+-- Toggle disarm on player hero
+function DevCheats:ToggleDisarm(keys)
+  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
+  local disarmModifier = hero:FindModifierByName("modifier_disarmed")
+  if disarmModifier then
+    hero:RemoveModifierByName("modifier_disarmed")
+  else
+    hero:AddNewModifier(hero, nil, "modifier_disarmed", {})
+  end
+end
+
+-- Give player global Blink Dagger
+function DevCheats:GiveDevDagger(keys)
+  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
+  hero:AddItemByName('item_devDagger')
+end
+
+-- Give player specified level of upgrade core
+function DevCheats:GiveUpgradeCore(keys)
+  -- Give user lvl 1 core, unless they specify a number after
+  local level = 1
+  local text = string.lower(keys.text)
+  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
+  local splitted = split(text, " ")
+  if splitted[2] and tonumber(splitted[2]) then
+    level = tonumber(splitted[2])
+  end
+
+  if level == 1 then
+    hero:AddItemByName("item_upgrade_core")
+  elseif level == 2 then
+    hero:AddItemByName("item_upgrade_core_2")
+  elseif level == 3 then
+    hero:AddItemByName("item_upgrade_core_3")
+  elseif level == 4 then
+    hero:AddItemByName("item_upgrade_core_4")
+  end
+end
+
+-- Adds an ability, if partial name given, gives the last ability it finds matching that string
+function DevCheats:AddAbility(keys)
+  local text = string.lower(keys.text)
+  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
+  local splitted = split(text, " ")
+  if splitted[2] then
+    local absCustom = LoadKeyValues('scripts/npc/npc_abilities_override.txt')
+    for k,v in pairs(absCustom) do
+      --print(k)
+      if string.find(k, splitted[2]) then
+        splitted[2] = k
+      end
+    end
+    hero:AddAbility(splitted[2])
+
+    -- Not sure what this is for. Seems to remove Talents for some reason?
+    -- for i = 0, 23 do
+    --   if hero:GetAbilityByIndex(i) then
+    --     local ability = hero:GetAbilityByIndex(i)
+    --     if ability and string.match(ability:GetName(), "special_bonus_") then
+    --       local abName = ability:GetName()
+    --       hero:RemoveAbility(abName)
+    --     end
+    --   end
+    -- end
+  end
+end
+
+-- Give items. If you put a number after the name of the item, it will look for that level, e.g. "-give heart 3" gives lvl 3 heart
+-- NOTE: Partial item name matching is a little funny, e.g. "-give heart" gives item_heart_transplant. Not sure this is fixable
+function DevCheats:GiveLevelledItem(keys)
+  local text = string.lower(keys.text)
+  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
+  local level = nil
+  local splitted = split(text, " ")
+
+  if splitted[3] and tonumber(splitted[3]) then
+    level = tonumber(splitted[3])
+  end
+  if splitted[2] then
+    local absCustom = LoadKeyValues('scripts/npc/npc_items_custom.txt')
+    for k,v in pairs(absCustom) do
+      if string.find(k, splitted[2]) and not string.find(k, "recipe") then
+        if not splitted[3] or string.find(k, splitted[3]) then
+          splitted[2] = k
+          break
+        end
+      end
+    end
+
+    hero:AddItemByName(splitted[2])
+  end
+end
+
+-- Set player inventory to pre-defined loadouts
+function DevCheats:GiveLoadout(keys)
+  local loadouts = {
+    ['tank'] = {"item_heart_5", "item_stoneskin_2", "item_satanic_core_3"},
+    ['damage'] = {"item_greater_crit_5", "item_desolator_5", "item_moon_shard"},
+  }
+  local text = string.lower(keys.text)
+  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
+  local splitted = split(text, " ")
+  if splitted[2] then
+    if loadouts[splitted[2]] then
+      local RemoveItem = function(handle) hero:RemoveItem(handle) end
+      local GetItemInSlot = function(slot) return hero:GetItemInSlot(slot) end
+      local AddItemByName = function(item) hero:AddItemByName(item) end
+      -- BUG: Items don't get removed
+      each(RemoveItem, map(GetItemInSlot, range(DOTA_ITEM_SLOT_1, DOTA_ITEM_SLOT_6)))
+      each(AddItemByName, iter(loadouts[splitted[2]]))
+    end
+  end
+end
+
+-- Give player Aghanim's Scepter of given level or level 1 if no level given
+function DevCheats:GiveUltimateScepter(keys)
+  local text = string.lower(keys.text)
+  local splitted = split(text, " ")
+  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
+  local name = "item_ultimate_scepter"
+  if splitted[2] then
+    name = name .. "_" .. splitted[2]
+  end
+  hero:AddItemByName(name)
+end
+
+-- Give player Dev Dagon
+function DevCheats:GiveDevDagon(keys)
+  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
+  hero:AddItemByName("item_devDagon")
+end
+
+-- Switch player's hero to given hero
+function DevCheats:SwitchHero(keys)
+  local text = string.lower(keys.text)
+  local splitted = split(text, " ")
+  local playerID = keys.playerid
+  local hero = PlayerResource:GetSelectedHeroEntity(playerID)
+
+  if splitted[2] then
+    local herolist = LoadKeyValues('scripts/npc/herolist.txt')
+    for hero,_ in pairs(herolist) do
+      if string.find(hero, splitted[2]) then
+        PrecacheUnitByNameAsync(hero, function()
+          PlayerResource:ReplaceHeroWith(playerID, hero, Gold:GetGold(playerID), PlayerResource:GetTotalEarnedXP(playerID))
+        end)
+      end
+    end
+  else
+    GameRules:SendCustomMessage("Usage is -switchhero X, where X is the name of the hero to switch to", 0, 0)
+  end
 end

--- a/game/scripts/vscripts/components/devcheats/index.lua
+++ b/game/scripts/vscripts/components/devcheats/index.lua
@@ -1,0 +1,1 @@
+require('components/devcheats/commands')

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -3,9 +3,6 @@ if Duels == nil then
   DebugPrint ( 'Creating new Duels object.' )
   Duels = class({})
   Debug.EnabledModules['duels:duels'] = true
-
-  ChatCommand:LinkCommand("-duel", Dynamic_Wrap(Duels, "StartDuel"), Duels)
-  ChatCommand:LinkCommand("-end_duel", Dynamic_Wrap(Duels, "EndDuel"), Duels)
 end
 
 --[[
@@ -60,6 +57,10 @@ function Duels:Init ()
   Timers:CreateTimer(1, function ()
     Duels:StartDuel()
   end)
+
+  ChatCommand:LinkCommand("-duel", Dynamic_Wrap(Duels, "StartDuel"), Duels)
+  ChatCommand:LinkCommand("-end_duel", Dynamic_Wrap(Duels, "EndDuel"), Duels)
+  ChatCommand:LinkCommand("-tptest", Dynamic_Wrap(Duels, "TestSafeTeleport"), Duels)
 end
 
 local DUEL_IS_STARTING = 21
@@ -514,4 +515,10 @@ function Duels:SafeTeleport(unit, location, maxDistance)
       self:SafeTeleport(unit, location, maxDistance)
     end)
   end
+end
+
+-- Test Duels:SafeTeleport function
+function Duels:TestSafeTeleport(keys)
+  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
+  self:SafeTeleportAll(hero, Vector(0, 0, 0), 150)
 end

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -4,8 +4,8 @@ if Duels == nil then
   Duels = class({})
   Debug.EnabledModules['duels:duels'] = true
 
-  ChatCommand:LinkCommand("-duel", "StartDuel", Duels)
-  ChatCommand:LinkCommand("-end_duel", "EndDuel", Duels)
+  ChatCommand:LinkCommand("-duel", Dynamic_Wrap(Duels, "StartDuel"), Duels)
+  ChatCommand:LinkCommand("-end_duel", Dynamic_Wrap(Duels, "EndDuel"), Duels)
 end
 
 --[[

--- a/game/scripts/vscripts/components/index.lua
+++ b/game/scripts/vscripts/components/index.lua
@@ -15,3 +15,4 @@ require('components/courier/index')
 require('components/cave/index') -- must be after creeps
 require('components/doors/index')
 require('components/glyph/index')
+require('components/devcheats/index')

--- a/game/scripts/vscripts/components/points/points.lua
+++ b/game/scripts/vscripts/components/points/points.lua
@@ -22,6 +22,10 @@ function PointsManager:Init ()
       self:AddPoints(keys.killer:GetTeam())
     end
   end)
+
+  -- Register chat commands
+  ChatCommand:LinkCommand("-addpoints", Dynamic_Wrap(PointsManager, "AddPointsCommand"), self)
+  ChatCommand:LinkCommand("-kill_limit", Dynamic_Wrap(PointsManager, "SetLimitCommand"), self)
 end
 
 function PointsManager:CheckWinCondition(teamID, points)
@@ -83,4 +87,27 @@ end
 
 function PointsManager:GetLimit()
   return CustomNetTables:GetTableValue('team_scores', 'limit').value
+end
+
+function PointsManager:SetLimit(killLimit)
+  CustomNetTables:SetTableValue('team_scores', 'limit', {value = killLimit})
+end
+
+function PointsManager:AddPointsCommand(keys)
+  local text = string.lower(keys.text)
+  local splitted = split(text, " ")
+  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
+  local teamID = hero:GetTeamNumber()
+  local pointsToAdd = tonumber(splitted[2]) or 1
+  self:AddPoints(teamID, pointsToAdd)
+end
+
+function PointsManager:SetLimitCommand(keys)
+  local text = string.lower(keys.text)
+  local splitted = split(text, " ")
+  if splitted[2] and tonumber(splitted[2]) then
+    self:SetLimit(tonumber(splitted[2]))
+  else
+    GameRules:SendCustomMessage("Usage is -kill_limit X, where X is the kill limit to set", 0, 0)
+  end
 end

--- a/game/scripts/vscripts/components/progression/hero_progression.lua
+++ b/game/scripts/vscripts/components/progression/hero_progression.lua
@@ -1,8 +1,6 @@
 if HeroProgression == nil then
     HeroProgression = class({})
     Debug.EnabledModules['progression:*'] = false
-
-    ChatCommand:LinkCommand("-levelup", "OnLevelUpChatCmd", HeroProgression)
 end
 
 GameEvents:OnPlayerLevelUp(function(keys)
@@ -149,12 +147,6 @@ function HeroProgression:ProcessAbilityPointGain(hero, level)
     DebugPrint('...taken it away! (had ' .. hero:GetAbilityPoints() .. ' ability points)')
     hero:SetAbilityPoints(hero:GetAbilityPoints() - 1)
   end
-end
-
-function HeroProgression:OnLevelUpChatCmd(keys)
-  local hero = PlayerResource:GetSelectedHeroEntity(keys.playerid)
-  DebugPrint('Levelling up ' .. hero:GetName() .. ' now at level ' .. hero:GetLevel())
-  hero:HeroLevelUp(true)
 end
 
 function HeroProgression:ExperienceFilter(keys)

--- a/game/scripts/vscripts/components/zonecontrol/test.lua
+++ b/game/scripts/vscripts/components/zonecontrol/test.lua
@@ -48,9 +48,9 @@ function ZoneControlTest:Init ()
   ZoneControl:DisableZone(ZoneControlTest.lockIn)
   -- ZoneControl:DisableZone(ZoneControlTest.lockOut)
 
-  ChatCommand:LinkCommand("-enable_lock_in", "EnableLockIn", ZoneControlTest)
+  ChatCommand:LinkCommand("-enable_lock_in", Dynamic_Wrap(ZoneControlTest, "EnableLockIn"), ZoneControlTest)
 
-  ChatCommand:LinkCommand("-enable_lock_out", "EnableLockOut", ZoneControlTest)
+  ChatCommand:LinkCommand("-enable_lock_out", Dynamic_Wrap(ZoneControlTest, "EnableLockOut"), ZoneControlTest)
 end
 
 function ZoneControlTest:EnableLockIn ()

--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -49,6 +49,8 @@ require('libraries/chatcommand')
 require('libraries/playerresource')
 -- Extensions to CDOTA_BaseNPC
 require('libraries/basenpc')
+-- extension functions to GameRules
+require('libraries/gamerules')
 
 -- These internal libraries set up barebones's events and processes.  Feel free to inspect them/change them if you need to.
 require('internal/gamemode')

--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -190,6 +190,8 @@ function GameMode:InitGameMode()
   InitModule(FilterManager)
   InitModule(GameLengthVotes)
   InitModule(Courier)
+  InitModule(ChatCommand)
+  InitModule(DevCheats)
 
   -- Commands can be registered for debugging purposes or as functions that can be called by the custom Scaleform UI
   -- Convars:RegisterCommand( "command_example", Dynamic_Wrap(GameMode, 'ExampleConsoleCommand'), "A console command example", FCVAR_CHEAT )

--- a/game/scripts/vscripts/libraries/chatcommand.lua
+++ b/game/scripts/vscripts/libraries/chatcommand.lua
@@ -12,16 +12,9 @@ created by Zarnotox with a lot of constructive help from the mod data guys https
 
 ChatCommand = ChatCommand or {}
 
--- Begin Initialise
 function ChatCommand:Init()
-  self.initialised = true
   ListenToGameEvent("player_chat", Dynamic_Wrap(ChatCommand, 'OnPlayerChat'), self)
 end
-
-if not ChatCommand.initialised then
-    ChatCommand:Init()
-end
--- End Initialise
 
 -- Function to create the link
 function ChatCommand:LinkCommand(command, funcName, obj)
@@ -54,11 +47,11 @@ function ChatCommand:OnPlayerChat(keys)
     ----------------------------
     -- Debug/Cheat Commands
     ----------------------------
-  if IsInToolsMode() or Convars:GetBool("sv_cheats") then
+  if IsInToolsMode() or ConVars:GetBool("sv_cheats") then
 
     -- Test command to quickly test anything
     if string.find(text, "-list") or string.find(text, "-help") then
-      GameRules:SendCustomMessage("-nofog, -fog, -god, -disarm, -dagger, -core 1-4, -startduel, -endduel, -addbots", 0, 0)
+      GameRules:SendCustomMessage("-nofog, -fog, -god, -disarm, -dagger, -core 1-4, -duel, -end_duel, -addbots", 0, 0)
       GameRules:SendCustomMessage("-addability x, -give x y, -fixspawn, -noend, -switchhero x, -loadout x, -scepter [1-5]", 0, 0)
 
       -- Add bots to both teams
@@ -135,15 +128,6 @@ function ChatCommand:OnPlayerChat(keys)
           hero:AddNewModifier(caster, ability, "modifier_chen_test_of_faith_teleport", {duration = 1})
         end
       end
-
-
-    -- Force start of a duel
-    elseif string.find(text, "-startduel") then
-      Duels:StartDuel()
-
-    -- Force end of a duel
-    elseif string.find(text, "-endduel") then
-      Duels:EndDuel()
 
     -- Prints vector of current position of hero to console
     elseif string.find(text, "-getpos") then

--- a/game/scripts/vscripts/libraries/chatcommand.lua
+++ b/game/scripts/vscripts/libraries/chatcommand.lua
@@ -5,7 +5,7 @@ Does not break when using script_reload
 Usage:
   -Create a function MyFunction(keys)             OR     function SomeClass:SomeFunction(keys)
     keys are those delivered from the 'player_chat' event
-  -Use ChatCommand:LinkCommand("-MyTrigger", "MyFunction")   OR     ChatCommand:LinkCommand("-MyTrigger", "SomeFunction", SomeClass)
+  -Use ChatCommand:LinkCommand("-MyTrigger", MyFunction, context)
     Use this to call this function everytime someone's chat starts with -MyTrigger
 created by Zarnotox with a lot of constructive help from the mod data guys https://discord.gg/Z7eCcGT (THIS IS NOT THE OAA DISCORD, THIS IS THE MODDATA DISCORD. YOU DID NOT FIND THE SECRET. check it out!)
 ]]
@@ -17,9 +17,9 @@ function ChatCommand:Init()
 end
 
 -- Function to create the link
-function ChatCommand:LinkCommand(command, funcName, obj)
+function ChatCommand:LinkCommand(command, func, obj)
   self.commands = self.commands or {}
-  self.commands[command] = {funcName, obj}
+  self.commands[command] = {func, obj}
 end
 
 -- Function that's called when somebody chats
@@ -32,242 +32,15 @@ function ChatCommand:OnPlayerChat(keys)
 
   local splitted = split(text, " ")
 
-  if self.commands[splitted[1]] ~= nil then
+  if (IsInToolsMode() or GameRules:IsCheatMode()) and self.commands[splitted[1]] ~= nil then
     local location = self.commands[splitted[1]]
-    funcName = location[1]
+    local func = location[1]
+    local context = location[2]
 
-    if location[2] == nil then
-      _G[funcName](keys)
+    if context == nil then
+      func(keys)
     else
-      local obj = location[2]
-      obj[funcName](obj, keys)
-    end
-  end
-
-    ----------------------------
-    -- Debug/Cheat Commands
-    ----------------------------
-  if IsInToolsMode() or ConVars:GetBool("sv_cheats") then
-
-    -- Test command to quickly test anything
-    if string.find(text, "-list") or string.find(text, "-help") then
-      GameRules:SendCustomMessage("-nofog, -fog, -god, -disarm, -dagger, -core 1-4, -duel, -end_duel, -addbots", 0, 0)
-      GameRules:SendCustomMessage("-addability x, -give x y, -fixspawn, -noend, -switchhero x, -loadout x, -scepter [1-5]", 0, 0)
-
-      -- Add bots to both teams
-    elseif string.find(text, "-addbots") then
-      local num = 0
-      local used_hero_name = "npc_dota_hero_luna"
-
-      for i=0, DOTA_MAX_TEAM_PLAYERS do
-        if PlayerResource:IsValidPlayer(i) then
-          print(i)
-
-          -- Random heroes for people who have not picked
-          if PlayerResource:HasSelectedHero(i) == false then
-            --print("Randoming hero for:", i)
-
-            local player = PlayerResource:GetPlayer(i)
-            player:MakeRandomHeroSelection()
-
-            local hero_name = PlayerResource:GetSelectedHeroName(i)
-
-            --print("Randomed:", hero_name)
-          end
-
-          used_hero_name = PlayerResource:GetSelectedHeroName(i)
-          num = num + 1
-        end
-      end
-
-      self.numPlayers = num
-      --print("Number of players:", num)
-
-      -- Eanble bots and fill empty slots
-      if IsServer() == true and 10 - self.numPlayers > 0 then
-        --print("Adding bots in empty slots")
-
-        for i=1, 5 do
-          Tutorial:AddBot(used_hero_name, "", "unfair", true)
-          Tutorial:AddBot(used_hero_name, "", "unfair", false)
-        end
-
-      end
-
-      GameRules:GetGameModeEntity():SetBotThinkingEnabled(true)
-      Tutorial:StartTutorialMode()
-      GameRules:GetGameModeEntity():SetBotsInLateGame(true)
-
-      Timers:CreateTimer(5,function()
-      for playerID=0,24-1 do
-        local hero = PlayerResource:GetSelectedHeroEntity(playerID)
-        if hero ~= nil and IsValidEntity(hero) and PlayerResource:GetSteamAccountID(playerID) == 0 then
-          hero:AddAbility("dev_bot_control")
-          local controller = hero:FindAbilityByName("dev_bot_control")
-          if controller then
-            controller:UpgradeAbility(false)
-            controller:SetHidden(true)
-          end
-        end
-      end
-      end)
-
-    -- Remove fog of war on the map, revealing everything
-    elseif string.find(text, "-nofog") then
-      GameRules:GetGameModeEntity():SetFogOfWarDisabled(true)
-
-    -- Bring back the fog of war
-    elseif string.find(text, "-fog") then
-      GameRules:GetGameModeEntity():SetFogOfWarDisabled(false)
-
-    -- Bring back the fog of war
-    elseif string.find(text, "-fixspawn") then
-       for playerID=0,24-1 do
-        local hero = PlayerResource:GetSelectedHeroEntity(playerID)
-        if hero ~= nil and IsValidEntity(hero) then
-          hero:AddNewModifier(caster, ability, "modifier_chen_test_of_faith_teleport", {duration = 1})
-        end
-      end
-
-    -- Prints vector of current position of hero to console
-    elseif string.find(text, "-getpos") then
-      print(hero:GetAbsOrigin())
-      GameRules:SendCustomMessage(tostring(hero:GetAbsOrigin()), 0, 0)
-
-    -- Give Invulnerability
-    elseif string.find(text, "-god") then
-      local godMode = hero:FindModifierByName("modifier_invulnerable")
-      if godMode then
-        hero:RemoveModifierByName("modifier_invulnerable")
-      else
-        hero:AddNewModifier(hero,nil,"modifier_invulnerable",{duration = duration})
-      end
-
-    -- Disarms the hero, to prevent autoattack
-    elseif string.find(text, "-disarm") then
-      local godMode = hero:FindModifierByName("modifier_disarmed")
-      if godMode then
-        hero:RemoveModifierByName("modifier_disarmed")
-      else
-        hero:AddNewModifier(hero,nil,"modifier_disarmed",{duration = duration})
-      end
-
-    -- Give Global blink dagger
-    elseif string.find(text, "-dagger") then
-      hero:AddItemByName('item_devDagger')
-
-    -- Give upgrade core of level x
-    elseif string.find(text, "-core") then
-      -- Give user lvl 1 core, unless they specify a number after
-      local level = 1
-      local splitted = split(text, " ")
-      if splitted[2] and tonumber(splitted[2]) then
-        level = tonumber(splitted[2])
-      end
-
-      if level == 1 then
-        hero:AddItemByName("item_upgrade_core")
-      elseif level == 2 then
-        hero:AddItemByName("item_upgrade_core_2")
-      elseif level == 3 then
-        hero:AddItemByName("item_upgrade_core_3")
-      elseif level == 4 then
-        hero:AddItemByName("item_upgrade_core_4")
-      end
-
-    -- Adds an ability, if partial name given, gives the last ability it finds matching that string
-  elseif string.find(text, "-addability") then
-      local splitted = split(text, " ")
-      if splitted[2] then
-        local absCustom = LoadKeyValues('scripts/npc/npc_abilities_override.txt')
-        for k,v in pairs(absCustom) do
-          --print(k)
-          if string.find(k, splitted[2]) then
-            splitted[2] = k
-          end
-        end
-        hero:AddAbility(splitted[2])
-        for i = 0, 23 do
-          if hero:GetAbilityByIndex(i) then
-            local ability = hero:GetAbilityByIndex(i)
-            if ability and string.match(ability:GetName(), "special_bonus_") then
-              local abName = ability:GetName()
-              hero:RemoveAbility(abName)
-            end
-          end
-        end
-      end
-
-    -- Give items. If you put a number after the name of the item, it will look for that number, e.g. "-give heart 3" gives lvl 3 heart
-    elseif string.find(text, "-give") then
-      local level = nil
-      local splitted = split(text, " ")
-
-      if splitted[3] and tonumber(splitted[3]) then
-        level = tonumber(splitted[3])
-      end
-      if splitted[2] then
-        local absCustom = LoadKeyValues('scripts/npc/npc_items_custom.txt')
-        for k,v in pairs(absCustom) do
-          if string.find(k, splitted[2]) and not string.find(k, "recipe") then
-            if not splitted[3] or string.find(k, splitted[3]) then
-              splitted[2] = k
-            end
-          end
-        end
-
-        hero:AddItemByName(splitted[2])
-      end
-
-    elseif string.find(text, "-noend") then
-      CustomNetTables:SetTableValue('team_scores', 'limit', {value = 9999999})
-
-    elseif string.find(text, "-switchhero") then
-      local splitted = split(text, " ")
-
-      if splitted[2] then
-        local herolist = LoadKeyValues('scripts/npc/herolist.txt')
-        for hero,_ in pairs(herolist) do
-          if string.find(hero, splitted[2]) then
-            PrecacheUnitByNameSync(hero)
-            PlayerResource:ReplaceHeroWith(playerID, hero, Gold:GetGold(playerID), PlayerResource:GetTotalEarnedXP(playerID))
-          end
-        end
-      end
-
-    elseif string.find(text, "-loadout") then
-      local loadouts = {
-        ['tank']={"item_heart_5", "item_stoneskin_2", "item_satanic_core_3"},
-      }
-      local splitted = split(text, " ")
-      if splitted[2] then
-        if loadouts[splitted[2]] then
-          local RemoveItem = function(handle) hero:RemoveItem(handle) end
-          local GetItemInSlot = function(slot) hero:GetItemInSlot(slot) end
-          local AddItemByName = function(item) hero:AddItemByName(item) end
-          -- BUG: Items don't get removed
-          each(RemoveItem, map(GetItemInSlot, range(DOTA_ITEM_SLOT_1, DOTA_ITEM_SLOT_6)))
-          each(AddItemByName, iter(loadouts[splitted[2]]))
-        end
-      end
-
-    elseif string.find(text, "-scepter") then
-      local splitted = split(text, " ")
-      local name = "item_ultimate_scepter"
-      if splitted[2] then
-        name = name .. "_" .. splitted[2]
-      end
-      hero:AddItemByName(name)
-
-    elseif string.find(text, "-addpoints") then
-      local splitted = split(text, " ")
-      local teamID = hero:GetTeam()
-      local points = tonumber(splitted[2]) or 1
-      PointsManager:AddPoints(teamID, points)
-
-    elseif string.find(text, "-tptest") then
-      Duels:SafeTeleportAll(hero, Vector(0, 0, 0), 150)
-
+      func(context, keys)
     end
   end
 end

--- a/game/scripts/vscripts/libraries/gamerules.lua
+++ b/game/scripts/vscripts/libraries/gamerules.lua
@@ -1,0 +1,9 @@
+--[[ Extension functions for GameRules
+
+-GameRules:GetMaxTeamPlayers()
+  Returns the total number of non-spectator players the map allows
+]]
+
+function CDOTAGamerules:GetMaxTeamPlayers()
+  return sum(map(partial(self.GetCustomGameTeamMaxPlayers, self), range(DOTA_TEAM_FIRST, DOTA_TEAM_CUSTOM_MAX)))
+end


### PR DESCRIPTION
Moved all command code out of the ChatCommand component. Commands related to other components such as the PointManager and Duels were moved to those components while the rest has been moved to the DevCheats component. Commands should now work in Tools Mode and whenever cheats are enabled.

Some bits of the old command code were commented out. Reasoning in comments above the commented sections.