### PR TITLE
Fix Fountain auto-doom

### DIFF
--- a/game/resource/English/modifier/tooltip_modifier_hyper_doom.txt
+++ b/game/resource/English/modifier/tooltip_modifier_hyper_doom.txt
@@ -1,0 +1,2 @@
+"dota_tooltip_modifier_hyper_doom"                  "Hyper Doom"
+"dota_tooltip_modifier_hyper_doom_description"      "Disarmed, Silenced, Muted, Broken, Blinded, Block and Evasion disabled"

--- a/game/scripts/npc/abilities/fountain_auto_doom.txt
+++ b/game/scripts/npc/abilities/fountain_auto_doom.txt
@@ -5,35 +5,12 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "BaseClass"                                           "ability_datadriven"
+    "BaseClass"                                           "ability_lua"
+    "ScriptFile"                                          "abilities/fountain_auto_doom.lua"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
     "AbilityType"                                         "DOTA_ABILITY_TYPE_BASIC"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_ALL"
     "AbilityTextureName"                                  "doom_bringer_doom"
-
-    "OnUpgrade"
-    {
-      "ApplyModifier"
-      {
-        "ModifierName"                                    "modifier_auto_doom"
-        "TARGET"                                          "CASTER"
-      }
-    }
-
-    "Modifiers"
-    {
-      "modifier_auto_doom"
-      {
-        "OnAttack"
-        {
-          "ApplyModifier"
-          {
-            "ModifierName"                                "modifier_doom_bringer_doom"
-            "Target"                                      "TARGET"
-          }
-        }
-      }
-    }
   }
 }

--- a/game/scripts/vscripts/abilities/fountain_auto_doom.lua
+++ b/game/scripts/vscripts/abilities/fountain_auto_doom.lua
@@ -46,6 +46,10 @@ function modifier_hyper_doom:IsDebuff()
   return true
 end
 
+function modifier_hyper_doom:RemoveOnDeath()
+  return false
+end
+
 function modifier_hyper_doom:GetTexture()
   return "doom_bringer_doom"
 end

--- a/game/scripts/vscripts/abilities/fountain_auto_doom.lua
+++ b/game/scripts/vscripts/abilities/fountain_auto_doom.lua
@@ -1,0 +1,63 @@
+LinkLuaModifier("modifier_auto_doom", "abilities/fountain_auto_doom.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_hyper_doom", "abilities/fountain_auto_doom.lua", LUA_MODIFIER_MOTION_NONE)
+
+fountain_auto_doom = class({})
+
+function fountain_auto_doom:GetIntrinsicModifierName()
+  return "modifier_auto_doom"
+end
+
+------------------------------------------------------------------------
+
+modifier_auto_doom = class({})
+
+function modifier_auto_doom:IsHidden()
+  return true
+end
+
+function modifier_auto_doom:IsPurgable()
+  return false
+end
+
+function modifier_auto_doom:DeclareFunctions()
+  return {
+    MODIFIER_EVENT_ON_ATTACK
+  }
+end
+
+function modifier_auto_doom:OnAttack(keys)
+  local parent = self:GetParent()
+  -- Debug.EnabledModules["abilities:fountain_auto_doom"] = true
+  -- DebugPrintTable(keys)
+  if keys.attacker and not keys.attacker:IsNull() and keys.attacker == parent then
+    keys.target:AddNewModifier(parent, self, "modifier_hyper_doom", {duration = 1})
+  end
+end
+
+------------------------------------------------------------------------
+
+modifier_hyper_doom = class({})
+
+function modifier_hyper_doom:IsPurgable()
+  return false
+end
+
+function modifier_hyper_doom:IsDebuff()
+  return true
+end
+
+function modifier_hyper_doom:GetTexture()
+  return "doom_bringer_doom"
+end
+
+function modifier_hyper_doom:CheckState()
+  return {
+    [MODIFIER_STATE_DISARMED] = true,
+    [MODIFIER_STATE_SILENCED] = true,
+    [MODIFIER_STATE_MUTED] = true,
+    [MODIFIER_STATE_BLOCK_DISABLED] = true,
+    [MODIFIER_STATE_EVADE_DISABLED] = true,
+    [MODIFIER_STATE_PASSIVES_DISABLED] = true,
+    [MODIFIER_STATE_BLIND] = true
+  }
+end

--- a/game/scripts/vscripts/abilities/fountain_auto_doom.lua
+++ b/game/scripts/vscripts/abilities/fountain_auto_doom.lua
@@ -43,6 +43,10 @@ end
 
 modifier_hyper_doom = class({})
 
+function modifier_hyper_doom:IsHidden()
+  return false
+end
+
 function modifier_hyper_doom:IsPurgable()
   return false
 end

--- a/game/scripts/vscripts/abilities/fountain_auto_doom.lua
+++ b/game/scripts/vscripts/abilities/fountain_auto_doom.lua
@@ -21,17 +21,22 @@ end
 
 function modifier_auto_doom:DeclareFunctions()
   return {
-    MODIFIER_EVENT_ON_ATTACK
+    MODIFIER_EVENT_ON_ATTACK_LANDED
   }
 end
 
-function modifier_auto_doom:OnAttack(keys)
+function modifier_auto_doom:OnAttackLanded(keys)
   local parent = self:GetParent()
-  -- Debug.EnabledModules["abilities:fountain_auto_doom"] = true
-  -- DebugPrintTable(keys)
   if keys.attacker and not keys.attacker:IsNull() and keys.attacker == parent then
     keys.target:AddNewModifier(parent, self, "modifier_hyper_doom", {duration = 1})
+    --keys.target:Kill(self, parent)
   end
+end
+
+function modifier_auto_doom:CheckState()
+  return {
+    [MODIFIER_STATE_CANNOT_MISS] = true
+  }
 end
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Should now perform its intended purpose of disabling passives on heroes hit by Fountain. Also gave Fountain True Strike.

P.S. We should discuss whether we want the Fountain to outright kill everything. Including through things like Borrowed Time and Ghost Scepter.

P.P.S. Woo! #1000!