### PR TITLE
Make Health Regeneration of Heart Transplant not stack with other Heart-type percent health regen

### DIFF
--- a/game/scripts/vscripts/items/heart_transplant.lua
+++ b/game/scripts/vscripts/items/heart_transplant.lua
@@ -93,8 +93,11 @@ end
 function modifier_item_heart_transplant:GetModifierHealthRegenPercentage()
   local parent = self:GetParent()
   local heart = self:GetAbility()
+  local parentHasHeart = parent:HasModifier("modifier_item_heart")
+  local parentHasGivenHeartAway = parent:HasModifier("modifier_item_heart_transplant_debuff")
+  local isFirstHeartTransplantModifier = parent:FindModifierByName(self:GetName()) == self
 
-  if heart:IsCooldownReady() and not parent:IsIllusion() and not parent:HasModifier("modifier_item_heart_transplant_debuff") then
+  if heart:IsCooldownReady() and not parent:IsIllusion() and not parentHasGivenHeartAway and not parentHasHeart and isFirstHeartTransplantModifier then
     return heart:GetSpecialValueFor("health_regen_rate")
   else
     return 0


### PR DESCRIPTION
Transplanted Heart still stacks with other Heart-type items the Transplant target has, though you can't Transplant multiple Hearts into the same target (modifier doesn't stack).