### PR TITLE
Make Martyr's Mail respect the no-reflect and no damage mult flag

### DIFF
--- a/game/scripts/vscripts/items/martyrs_mail.lua
+++ b/game/scripts/vscripts/items/martyrs_mail.lua
@@ -126,6 +126,11 @@ function modifier_item_martyrs_mail_martyr_active:OnTakeDamage( kv )
       return
     end
 
+    --Prevent reflecting damage with no-reflect flag
+    if bit.band(kv.damage_flag, DOTA_DAMAGE_FLAG_REFLECTION) == DOTA_DAMAGE_FLAG_REFLECTION then
+	    return
+    end
+
 		if kv.unit == hCaster then
 			local damageTable = {
 				victim = kv.attacker,

--- a/game/scripts/vscripts/items/martyrs_mail.lua
+++ b/game/scripts/vscripts/items/martyrs_mail.lua
@@ -131,6 +131,7 @@ function modifier_item_martyrs_mail_martyr_active:OnTakeDamage( kv )
 				victim = kv.attacker,
 				attacker = hCaster,
 				damage = kv.damage,
+				damage_flag = bit.bor(DOTA_DAMAGE_FLAG_REFLECTION, DOTA_DAMAGE_FLAG_NO_DAMAGE_MULTIPLIERS),
 				damage_type = kv.damage_type
 			}
 


### PR DESCRIPTION
Make MM respect no-reflect flag and no damage multipliers flag. Should prevent Dota from crashing when two people with MM face off.