### PR TITLE
Add delay to modifier_intrinsic_multiplexer modifier creation OnCreated

### DIFF
--- a/game/scripts/vscripts/modifiers/modifier_intrinsic_multiplexer.lua
+++ b/game/scripts/vscripts/modifiers/modifier_intrinsic_multiplexer.lua
@@ -44,7 +44,6 @@ function modifier_intrinsic_multiplexer:CreateModifiers()
     return
   end
   local modifiers = ability:GetIntrinsicModifierNames(self)
-  --foreach(print, modifiers)
   iter(modifiers):each(function (modifierName)
     self.modifiers[modifierName] = hero:AddNewModifier(caster, ability, modifierName, {})
   end)

--- a/game/scripts/vscripts/modifiers/modifier_intrinsic_multiplexer.lua
+++ b/game/scripts/vscripts/modifiers/modifier_intrinsic_multiplexer.lua
@@ -16,7 +16,11 @@ end
 
 function modifier_intrinsic_multiplexer:OnCreated()
   self.modifiers = {}
-  self:CreateModifiers()
+  if IsServer() then
+    Timers:CreateTimer(0.1, function ()
+      self:CreateModifiers()
+    end)
+  end
 end
 
 function modifier_intrinsic_multiplexer:OnRefresh()
@@ -40,6 +44,7 @@ function modifier_intrinsic_multiplexer:CreateModifiers()
     return
   end
   local modifiers = ability:GetIntrinsicModifierNames(self)
+  --foreach(print, modifiers)
   iter(modifiers):each(function (modifierName)
     self.modifiers[modifierName] = hero:AddNewModifier(caster, ability, modifierName, {})
   end)


### PR DESCRIPTION
Was apparently getting into a race condition with the modifier destruction, causing issues with losing some of the modifiers when upgrading items.