### PR TITLE
Refresher Core and modifier_octarine_vampirism_applier fixes

### DIFF
--- a/game/scripts/vscripts/items/refresher_core.lua
+++ b/game/scripts/vscripts/items/refresher_core.lua
@@ -1,14 +1,32 @@
 
 LinkLuaModifier( "modifier_octarine_vampirism_applier", "modifiers/modifier_octarine_vampirism_applier.lua", LUA_MODIFIER_MOTION_NONE )
 LinkLuaModifier( "modifier_octarine_vampirism_buff", "modifiers/modifier_octarine_vampirism_buff.lua", LUA_MODIFIER_MOTION_NONE )
+LinkLuaModifier( "modifier_intrinsic_multiplexer", "modifiers/modifier_intrinsic_multiplexer.lua", LUA_MODIFIER_MOTION_NONE )
+LinkLuaModifier( "modifier_item_refresher_core", "items/refresher_core.lua", LUA_MODIFIER_MOTION_NONE )
 
 item_octarine_core_2 = class(ItemBaseClass)
 
 function item_octarine_core_2:GetIntrinsicModifierName()
-  return "modifier_octarine_vampirism_applier"
+  return "modifier_intrinsic_multiplexer"
 end
 
-item_refresher_core = item_octarine_core_2
+function item_octarine_core_2:GetIntrinsicModifierNames()
+  return {
+    "modifier_octarine_vampirism_applier",
+    "modifier_item_octarine_core"
+  }
+end
+
+--------------------------------------------------------------------------------
+
+item_refresher_core = class(item_octarine_core_2)
+
+function item_refresher_core:GetIntrinsicModifierNames()
+  return {
+    "modifier_octarine_vampirism_applier",
+    "modifier_item_refresher_core"
+  }
+end
 
 function item_refresher_core:OnSpellStart()
   local caster = self:GetCaster()
@@ -67,3 +85,54 @@ end
 
 item_refresher_core_2 = item_refresher_core --luacheck: ignore item_refresher_core_2
 item_refresher_core_3 = item_refresher_core --luacheck: ignore item_refresher_core_3
+
+--------------------------------------------------------------------------------
+
+modifier_item_refresher_core = class({})
+
+function modifier_item_refresher_core:IsHidden()
+  return true
+end
+
+function modifier_item_refresher_core:IsPurgable()
+  return false
+end
+
+function modifier_item_refresher_core:GetAttributes()
+  return MODIFIER_ATTRIBUTE_MULTIPLE
+end
+
+function modifier_item_refresher_core:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_STATS_INTELLECT_BONUS,
+    MODIFIER_PROPERTY_HEALTH_BONUS,
+    MODIFIER_PROPERTY_MANA_BONUS,
+    MODIFIER_PROPERTY_COOLDOWN_PERCENTAGE,
+    MODIFIER_PROPERTY_MANA_REGEN_PERCENTAGE,
+    MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT
+  }
+end
+
+function modifier_item_refresher_core:GetModifierConstantHealthRegen()
+  return self:GetAbility():GetSpecialValueFor('bonus_health_regen')
+end
+
+function modifier_item_refresher_core:GetModifierPercentageManaRegen()
+  return self:GetAbility():GetSpecialValueFor('bonus_mana_regen')
+end
+
+function modifier_item_refresher_core:GetModifierBonusStats_Intellect()
+  return self:GetAbility():GetSpecialValueFor('bonus_intelligence')
+end
+
+function modifier_item_refresher_core:GetModifierHealthBonus()
+  return self:GetAbility():GetSpecialValueFor('bonus_health')
+end
+
+function modifier_item_refresher_core:GetModifierManaBonus()
+  return self:GetAbility():GetSpecialValueFor('bonus_mana')
+end
+
+function modifier_item_refresher_core:GetModifierPercentageCooldown()
+  return self:GetAbility():GetSpecialValueFor('bonus_cooldown')
+end

--- a/game/scripts/vscripts/items/refresher_core.lua
+++ b/game/scripts/vscripts/items/refresher_core.lua
@@ -1,6 +1,5 @@
 
 LinkLuaModifier( "modifier_octarine_vampirism_applier", "modifiers/modifier_octarine_vampirism_applier.lua", LUA_MODIFIER_MOTION_NONE )
-LinkLuaModifier( "modifier_octarine_vampirism_buff", "modifiers/modifier_octarine_vampirism_buff.lua", LUA_MODIFIER_MOTION_NONE )
 LinkLuaModifier( "modifier_intrinsic_multiplexer", "modifiers/modifier_intrinsic_multiplexer.lua", LUA_MODIFIER_MOTION_NONE )
 LinkLuaModifier( "modifier_item_refresher_core", "items/refresher_core.lua", LUA_MODIFIER_MOTION_NONE )
 

--- a/game/scripts/vscripts/items/refresher_core.lua
+++ b/game/scripts/vscripts/items/refresher_core.lua
@@ -102,6 +102,16 @@ function modifier_item_refresher_core:GetAttributes()
   return MODIFIER_ATTRIBUTE_MULTIPLE
 end
 
+function modifier_item_refresher_core:OnCreated()
+  if IsServer() then
+    local caster = self:GetCaster()
+    local ability = self:GetAbility()
+    if caster:IsTempestDouble() then
+      ability:StartCooldown(ability:GetCooldown(ability:GetLevel()))
+    end
+  end
+end
+
 function modifier_item_refresher_core:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_STATS_INTELLECT_BONUS,

--- a/game/scripts/vscripts/modifiers/modifier_intrinsic_multiplexer.lua
+++ b/game/scripts/vscripts/modifiers/modifier_intrinsic_multiplexer.lua
@@ -33,6 +33,11 @@ function modifier_intrinsic_multiplexer:OnDestroy()
 end
 
 function modifier_intrinsic_multiplexer:CreateModifiers()
+  -- Exit if self has been deleted because for some reason this happens with Tempest Double
+  if self:IsNull() then
+    return
+  end
+
   local hero = self:GetParent()
   if not hero or not hero.AddNewModifier then
     return

--- a/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_applier.lua
+++ b/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_applier.lua
@@ -1,5 +1,7 @@
 -- thanks darklord
 
+LinkLuaModifier( "modifier_octarine_vampirism_buff", "modifiers/modifier_octarine_vampirism_buff.lua", LUA_MODIFIER_MOTION_NONE )
+
 modifier_octarine_vampirism_applier = class(ModifierBaseClass)
 
 function modifier_octarine_vampirism_applier:IsHidden()

--- a/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_applier.lua
+++ b/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_applier.lua
@@ -47,19 +47,19 @@ end
 --------------------------------------------------------------------------------
 
 function modifier_octarine_vampirism_applier:GetAuraRadius()
-  return self.aura_radius
+  return 0
 end
 
 --------------------------------------------------------------------------------
 
 function modifier_octarine_vampirism_applier:OnCreated( kv )
-  self.aura_radius = self:GetAbility():GetSpecialValueFor( "radius" )
+  --self.aura_radius = self:GetAbility():GetSpecialValueFor( "radius" )
 end
 
 --------------------------------------------------------------------------------
 
 function modifier_octarine_vampirism_applier:OnRefresh( kv )
-  self.aura_radius = self:GetAbility():GetSpecialValueFor( "radius" )
+  --self.aura_radius = self:GetAbility():GetSpecialValueFor( "radius" )
 end
 
 --------------------------------------------------------------------------------

--- a/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_applier.lua
+++ b/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_applier.lua
@@ -6,6 +6,10 @@ function modifier_octarine_vampirism_applier:IsHidden()
   return true
 end
 
+function modifier_octarine_vampirism_applier:GetAttributes()
+  return MODIFIER_ATTRIBUTE_MULTIPLE
+end
+
 --------------------------------------------------------------------------------
 
 function modifier_octarine_vampirism_applier:IsAura()

--- a/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_applier.lua
+++ b/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_applier.lua
@@ -54,6 +54,13 @@ end
 
 function modifier_octarine_vampirism_applier:OnCreated( kv )
   --self.aura_radius = self:GetAbility():GetSpecialValueFor( "radius" )
+  local parent = self:GetParent()
+  parent:RemoveModifierByName(self:GetModifierAura())
+end
+
+function modifier_octarine_vampirism_applier:OnDestroy()
+  local parent = self:GetParent()
+  parent:RemoveModifierByName(self:GetModifierAura())
 end
 
 --------------------------------------------------------------------------------

--- a/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_applier.lua
+++ b/game/scripts/vscripts/modifiers/modifier_octarine_vampirism_applier.lua
@@ -2,43 +2,6 @@
 
 modifier_octarine_vampirism_applier = class(ModifierBaseClass)
 
-function modifier_octarine_vampirism_applier:DeclareFunctions()
-  return {
-    MODIFIER_PROPERTY_STATS_INTELLECT_BONUS,
-    MODIFIER_PROPERTY_HEALTH_BONUS,
-    MODIFIER_PROPERTY_MANA_BONUS,
-    MODIFIER_PROPERTY_COOLDOWN_PERCENTAGE,
-    MODIFIER_PROPERTY_MANA_REGEN_PERCENTAGE,
-    MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT
-  }
-end
-
-function modifier_octarine_vampirism_applier:GetModifierConstantHealthRegen()
-  return self:GetAbility():GetSpecialValueFor('bonus_health_regen')
-end
-
-function modifier_octarine_vampirism_applier:GetModifierPercentageManaRegen()
-  return self:GetAbility():GetSpecialValueFor('bonus_mana_regen')
-end
-
-function modifier_octarine_vampirism_applier:GetModifierBonusStats_Intellect()
-  return self:GetAbility():GetSpecialValueFor('bonus_intelligence')
-end
-
-function modifier_octarine_vampirism_applier:GetModifierHealthBonus()
-  return self:GetAbility():GetSpecialValueFor('bonus_health')
-end
-
-function modifier_octarine_vampirism_applier:GetModifierManaBonus()
-  return self:GetAbility():GetSpecialValueFor('bonus_mana')
-end
-
-function modifier_octarine_vampirism_applier:GetModifierPercentageCooldown()
-  return self:GetAbility():GetSpecialValueFor('bonus_cooldown')
-end
-
---------------------------------------------------------------------------------
-
 function modifier_octarine_vampirism_applier:IsHidden()
   return true
 end


### PR DESCRIPTION
Fixes #1072.
Some restructuring of `modifier_octarine_vampirism_applier`. Also made it do the typical force refresh I've been putting on practically every aura modifier to prevent spell lifesteal possibly not upgrading properly.