### PR TITLE
Implement pseudo-random Bottle drops

### DIFF
--- a/docs/chatcommands.md
+++ b/docs/chatcommands.md
@@ -20,7 +20,7 @@ Commands to be used for debugging and testing purposes, currently requires the g
 <br>
 -dagger - Gives global blink dagger.
 <br>
--devdagon - Gives insta-kill dagon.
+-dagon - Gives insta-kill dagon.
 <br>
 -core x - Can be used to give upgrade cores, core 1, core 2, core 3, core 4, -core by itself gives core level 1.
 <br>
@@ -43,3 +43,7 @@ Commands to be used for debugging and testing purposes, currently requires the g
 -print_modifiers - Prints names of all modifiers on user's hero to console.
 <br>
 -tptest - Teleports all heroes to the middle of the map. Used for testing the Duel teleportation code.
+<br>
+-lazer - Gives the user the HP/Mana drain laser ability that the Fountain uses.
+<br>
+-spawncamps - Forces neutral creep camps to spawn

--- a/game/scripts/vscripts/components/creeps/item_drop.lua
+++ b/game/scripts/vscripts/components/creeps/item_drop.lua
@@ -9,7 +9,12 @@ end
 local ItemPowerLevel = 1.0
 
 --define how often items drop from creeps. min = 0 (0%), max = 1 (100%)
-local DROP_CHANCE = 0.25
+--local DROP_CHANCE = 0.25
+
+-- The C initial chance parameter for the pseudo-random distribution function
+-- Set for average chance of 25%. Functions for calculation and a bunch of pre-calculated values can be found here:
+-- https://gaming.stackexchange.com/questions/161430/calculating-the-constant-c-in-dota-2-pseudo-random-distribution
+PRD_C = 0.084744091852316990275274806
 
 --creep properties enumerations
 local NAME_ENUM = 1
@@ -36,7 +41,7 @@ function CreepItemDrop:Init ()
   DebugPrint ( '[creeps/item_drop] Initialize' )
   CreepItemDrop = self
 
-  ListenToGameEvent("entity_killed", CreepItemDrop.OnEntityKilled, self)
+  --ListenToGameEvent("entity_killed", CreepItemDrop.OnEntityKilled, self)
   Timers:CreateTimer(Dynamic_Wrap(self, 'ItemDropUpgradeTimer'), self)
 end
 
@@ -70,23 +75,26 @@ function CreepItemDrop:CreateDrop (itemName, pos)
   end)
 end
 
-function CreepItemDrop:OnEntityKilled (event)
-  local killedEntity = EntIndexToHScript(event.entindex_killed)
+-- function CreepItemDrop:OnEntityKilled (event)
+--   local killedEntity = EntIndexToHScript(event.entindex_killed)
 
-  if killedEntity ~= nil then
-    if killedEntity.Is_ItemDropEnabled then
-      local itemToDrop = CreepItemDrop:RandomDropItemName()
-      if itemToDrop ~= "" and itemToDrop ~= nil then
-        CreepItemDrop:CreateDrop(itemToDrop, killedEntity:GetAbsOrigin())
-      end
-    end
-  end
-end
+--   if killedEntity ~= nil then
+--     if killedEntity.Is_ItemDropEnabled then
+--       local itemToDrop = CreepItemDrop:RandomDropItemName()
+--       if itemToDrop ~= "" and itemToDrop ~= nil then
+--         CreepItemDrop:CreateDrop(itemToDrop, killedEntity:GetAbsOrigin())
+--       end
+--     end
+--   end
+-- end
 
-function CreepItemDrop:RandomDropItemName( property_enum, powerLevel )
+function CreepItemDrop:RandomDropItemName(campLocationString)
+  local CampPRDCounters = CreepCamps.CampPRDCounters
 
   --first we need to check against the drop percentage.
-  if math.random() > DROP_CHANCE then
+  if math.random() > math.min(1, PRD_C * CampPRDCounters[campLocationString]) then
+    -- Increment PRD counter if nothing was dropped
+    CampPRDCounters[campLocationString] = CampPRDCounters[campLocationString] + 1
     return ""
   end
 
@@ -111,6 +119,8 @@ function CreepItemDrop:RandomDropItemName( property_enum, powerLevel )
   for i=1, #filteredItemTable do
     passedItemsCumulativeChance = passedItemsCumulativeChance + 1.0 / filteredItemTable[i][RARITY_ENUM]
     if passedItemsCumulativeChance >= dropChance then
+      -- Reset PRD counter on successful drop roll
+      CampPRDCounters[campLocationString] = 1
       return filteredItemTable[i][NAME_ENUM]
     end
   end

--- a/game/scripts/vscripts/components/creeps/item_drop.lua
+++ b/game/scripts/vscripts/components/creeps/item_drop.lua
@@ -37,7 +37,7 @@ function CreepItemDrop:Init ()
   CreepItemDrop = self
 
   ListenToGameEvent("entity_killed", CreepItemDrop.OnEntityKilled, self)
-  Timers:CreateTimer(Dynamic_Wrap(CreepItemDrop, 'ItemDropUpgradeTimer'))
+  Timers:CreateTimer(Dynamic_Wrap(self, 'ItemDropUpgradeTimer'), self)
 end
 
 function CreepItemDrop:SetPowerLevel (powerLevel)
@@ -46,7 +46,7 @@ end
 
 function CreepItemDrop:ItemDropUpgradeTimer ()
   -- upgrade creeps power level every time it triggers
-  CreepItemDrop:SetPowerLevel(ItemPowerLevel + 1)
+  self:SetPowerLevel(ItemPowerLevel + 1)
 
   return 10.0
 end

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -27,7 +27,11 @@ function CreepCamps:Init ()
   DebugPrint ( 'Initializing.' )
   CreepCamps = self
   self.CampPRDCounters = {}
-  Timers:CreateTimer(Dynamic_Wrap(self, 'CreepSpawnTimer'), self)
+  if not SKIP_TEAM_SETUP then
+    Timers:CreateTimer(INITIAL_CREEP_DELAY, Dynamic_Wrap(self, 'CreepSpawnTimer'), self)
+  else
+    Timers:CreateTimer(Dynamic_Wrap(self, 'CreepSpawnTimer'), self)
+  end
   ChatCommand:LinkCommand("-spawncamps", Dynamic_Wrap(self, 'CreepSpawnTimer'), self)
 end
 
@@ -36,12 +40,6 @@ function CreepCamps:SetPowerLevel (powerLevel)
 end
 
 function CreepCamps:CreepSpawnTimer ()
-  if not self.hasSpawnedFirstWave then
-    self.hasSpawnedFirstWave = true
-    if not SKIP_TEAM_SETUP then
-      return INITIAL_CREEP_DELAY
-    end
-  end
   -- scan for creep camps and spawn them
   -- DebugPrint('[creeps/spawner] Spawning creeps')
   local camps = Entities:FindAllByName('creep_camp')

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -26,6 +26,7 @@ function CreepCamps:Init ()
   CreepCamps = self
   Timers:CreateTimer(Dynamic_Wrap(CreepCamps, 'CreepSpawnTimer'))
   Timers:CreateTimer(Dynamic_Wrap(self, 'CreepSpawnTimer'), self)
+  ChatCommand:LinkCommand("-spawncamps", Dynamic_Wrap(self, 'CreepSpawnTimer'), self)
 end
 
 function CreepCamps:SetPowerLevel (powerLevel)

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -5,6 +5,8 @@ if CreepCamps == nil then
     CreepCamps = class({})
 end
 
+LinkLuaModifier("modifier_creep_loot", "modifiers/modifier_creep_loot.lua", LUA_MODIFIER_MOTION_NONE)
+
 --creep power level is from CREEP_POWER_LEVEL_MIN to CREEP_POWER_LEVEL_MAX
 local CreepPowerLevel = 0.0
 
@@ -24,7 +26,7 @@ local EXP_BOUNTY_ENUM = 7
 function CreepCamps:Init ()
   DebugPrint ( 'Initializing.' )
   CreepCamps = self
-  Timers:CreateTimer(Dynamic_Wrap(CreepCamps, 'CreepSpawnTimer'))
+  self.CampPRDCounters = {}
   Timers:CreateTimer(Dynamic_Wrap(self, 'CreepSpawnTimer'), self)
   ChatCommand:LinkCommand("-spawncamps", Dynamic_Wrap(self, 'CreepSpawnTimer'), self)
 end
@@ -100,10 +102,15 @@ function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
   end
 
   local creepHandle = CreateUnitByName(creepProperties[NAME_ENUM], location, true, nil, nil, DOTA_TEAM_NEUTRALS)
+  local locationString = location.x .. "," .. location.y
+
+  if not self.CampPRDCounters[locationString] then
+    self.CampPRDCounters[locationString] = 1
+  end
 
   if creepHandle ~= nil then
-    creepHandle.Is_ItemDropEnabled = true
     self:SetCreepPropertiesOnHandle(creepHandle, creepProperties)
+    creepHandle:AddNewModifier(nil, nil, "modifier_creep_loot", {locationString = locationString})
   end
 
   return true

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -25,6 +25,7 @@ function CreepCamps:Init ()
   DebugPrint ( 'Initializing.' )
   CreepCamps = self
   Timers:CreateTimer(Dynamic_Wrap(CreepCamps, 'CreepSpawnTimer'))
+  Timers:CreateTimer(Dynamic_Wrap(self, 'CreepSpawnTimer'), self)
 end
 
 function CreepCamps:SetPowerLevel (powerLevel)
@@ -32,8 +33,8 @@ function CreepCamps:SetPowerLevel (powerLevel)
 end
 
 function CreepCamps:CreepSpawnTimer ()
-  if not CreepCamps.hasSpawnedFirstWave then
-    CreepCamps.hasSpawnedFirstWave = true
+  if not self.hasSpawnedFirstWave then
+    self.hasSpawnedFirstWave = true
     if not SKIP_TEAM_SETUP then
       return INITIAL_CREEP_DELAY
     end
@@ -42,10 +43,10 @@ function CreepCamps:CreepSpawnTimer ()
   -- DebugPrint('[creeps/spawner] Spawning creeps')
   local camps = Entities:FindAllByName('creep_camp')
   for _,camp in pairs(camps) do
-    CreepCamps:DoSpawn(camp:GetAbsOrigin(), camp:GetIntAttr('CreepType'), camp:GetIntAttr('CreepMax'))
+    self:DoSpawn(camp:GetAbsOrigin(), camp:GetIntAttr('CreepType'), camp:GetIntAttr('CreepMax'))
   end
 
-  CreepCamps:UpgradeCreeps()
+  self:UpgradeCreeps()
 
 
   if GameRules:GetDOTATime(false, false) < CREEP_SPAWN_INTERVAL then
@@ -56,14 +57,14 @@ end
 
 function CreepCamps:UpgradeCreeps ()
   -- upgrade creeps power level every time it triggers
-  CreepCamps:SetPowerLevel(CreepPowerLevel + 1)
+  self:SetPowerLevel(CreepPowerLevel + 1)
 end
 
 function CreepCamps:DoSpawn (location, difficulty, maximumUnits)
   local creepCategory = CreepTypes[difficulty]
   local creepGroup = creepCategory[math.random(#creepCategory)]
   for i=1, #creepGroup do
-    CreepCamps:SpawnCreepInCamp (location, creepGroup[i], maximumUnits)
+    self:SpawnCreepInCamp (location, creepGroup[i], maximumUnits)
   end
 end
 function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
@@ -83,17 +84,16 @@ function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
     FIND_ANY_ORDER,
     false)
 
-  creepProperties = CreepCamps:AdjustCreepPropertiesByPowerLevel( creepProperties, CreepPowerLevel )
+  creepProperties = self:AdjustCreepPropertiesByPowerLevel( creepProperties, CreepPowerLevel )
 
-  if (maximumUnits and maximumUnits <= #units)
-  then
+  if (maximumUnits and maximumUnits <= #units) then
     -- DebugPrint('[creeps/spawner] Too many creeps in camp, not spawning more')
     for _,unit in pairs(units) do
-      local unitProperties = CreepCamps:GetCreepProperties(unit)
+      local unitProperties = self:GetCreepProperties(unit)
       local distributedScale = 1.0 / maximumUnits
 
-      unitProperties = CreepCamps:AddCreepPropertiesWithScale(unitProperties, 1.0, creepProperties, distributedScale)
-      CreepCamps:SetCreepPropertiesOnHandle(unit, unitProperties)
+      unitProperties = self:AddCreepPropertiesWithScale(unitProperties, 1.0, creepProperties, distributedScale)
+      self:SetCreepPropertiesOnHandle(unit, unitProperties)
     end
     return false
   end
@@ -101,8 +101,8 @@ function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
   local creepHandle = CreateUnitByName(creepProperties[NAME_ENUM], location, true, nil, nil, DOTA_TEAM_NEUTRALS)
 
   if creepHandle ~= nil then
-    CreepCamps:SetCreepPropertiesOnHandle(creepHandle, creepProperties)
     creepHandle.Is_ItemDropEnabled = true
+    self:SetCreepPropertiesOnHandle(creepHandle, creepProperties)
   end
 
   return true

--- a/game/scripts/vscripts/components/devcheats/commands.lua
+++ b/game/scripts/vscripts/components/devcheats/commands.lua
@@ -43,7 +43,7 @@ end
 function DevCheats:Help(keys)
   GameRules:SendCustomMessage("-nofog, -fog, -god, -disarm, -dagger, -core 1-4, -duel, -end_duel, -addbots", 0, 0)
   GameRules:SendCustomMessage("-addability x, -give x y, -fixspawn, -kill_limit x, -switchhero x, -loadout x, -scepter [1-5]", 0, 0)
-  GameRules:SendCustomMessage("-addpoints, -print_modifiers, -dagon, -lazer", 0, 0)
+  GameRules:SendCustomMessage("-addpoints, -print_modifiers, -dagon, -lazer, -spawncamps", 0, 0)
 end
 
 -- Populate game with bots

--- a/game/scripts/vscripts/modifiers/modifier_creep_loot.lua
+++ b/game/scripts/vscripts/modifiers/modifier_creep_loot.lua
@@ -1,0 +1,38 @@
+modifier_creep_loot = class(ModifierBaseClass)
+
+function modifier_creep_loot:OnCreated(keys)
+  self.locationString = keys.locationString
+end
+
+function modifier_creep_loot:IsHidden()
+  return true
+end
+
+function modifier_creep_loot:IsPurgable()
+  return false
+end
+
+function modifier_creep_loot:DeclareFunctions()
+  return {
+    MODIFIER_EVENT_ON_DEATH,
+    MODIFIER_EVENT_ON_DOMINATED
+  }
+end
+
+function modifier_creep_loot:OnDeath(keys)
+  local parent = self:GetParent()
+  if keys.unit == parent then
+    local itemToDrop = CreepItemDrop:RandomDropItemName(self.locationString)
+    if itemToDrop ~= "" and itemToDrop ~= nil then
+      CreepItemDrop:CreateDrop(itemToDrop, parent:GetAbsOrigin())
+    end
+  end
+end
+
+function modifier_creep_loot:OnDominated(keys)
+  local parent = self:GetParent()
+  if keys.unit == parent then
+    -- Remove self when creeps are dominated
+    self:Destroy()
+  end
+end


### PR DESCRIPTION
Also add a -spawncamps command and clean up the spawner and item_drop components a little.

PRD counters are per-camp. Item drop selection still uses the old method, so no PRD there, but we'll probably only ever have Bottle drops anyway.