### PR TITLE
Refactor calls to math.random to use Dota API random functions instead

### DIFF
--- a/game/scripts/vscripts/abilities/stopfightingyourself/dupe_heroes.lua
+++ b/game/scripts/vscripts/abilities/stopfightingyourself/dupe_heroes.lua
@@ -143,7 +143,7 @@ function boss_stopfightingyourself_dupe_heroes:OnSpellStart()
 
       -- Randomly play sound to player (10% chance)
       -- NOTE this doesn't seem to work
-      if math.random(100) <= 10 then
+      if RandomFloat(0, 1) < 0.1 then
         --EmitAnnouncerSoundForPlayer('sounds/vo/announcer_dlc_rick_and_morty/generic_illusion_based_hero_02.vsnd', unit:GetPlayerID())
         illusion:EmitSound('sounds/vo/announcer_dlc_rick_and_morty/generic_illusion_based_hero_02.vsnd')
       end

--- a/game/scripts/vscripts/components/boss/ngp.lua
+++ b/game/scripts/vscripts/components/boss/ngp.lua
@@ -78,14 +78,14 @@ function NGP:FinishVoting (item)
 
   if #needVotes > 0 then
     -- someone voted need! decide between them...
-    local winningPlayer = needVotes[math.random(1, #needVotes)]
+    local winningPlayer = needVotes[RandomInt(1, #needVotes)]
     DebugPrint(winningPlayer .. ' won!!')
     NGP:GiveItemToPlayer(item, winningPlayer)
     return
   end
   if #greedVotes > 0 then
     -- someone voted need! decide between them...
-    local winningPlayer = greedVotes[math.random(1, #greedVotes)]
+    local winningPlayer = greedVotes[RandomInt(1, #greedVotes)]
     DebugPrint(winningPlayer .. ' won!!')
     NGP:GiveItemToPlayer(item, winningPlayer)
     return

--- a/game/scripts/vscripts/components/boss/spawn.lua
+++ b/game/scripts/vscripts/components/boss/spawn.lua
@@ -69,7 +69,7 @@ function BossSpawner:SpawnBossAtPit (pit)
     -- it was never broken
     -- 1/3 * 1/3 * 1/3 * 1/3 * 1/3 * 1/3 * 1/3 * 1/3 * 1/2 * 1/2 * 1/3 * 1/3 oods
     -- DebugPrint('There are ' .. #bossName .. 'options for this boss')
-    bossName = bossName[math.random(#bossName)]
+    bossName = bossName[RandomInt(1, #bossName)]
   end
   local isProtected = bossList == 1 and pit.killCount == 1
 

--- a/game/scripts/vscripts/components/cave/cave.lua
+++ b/game/scripts/vscripts/components/cave/cave.lua
@@ -75,7 +75,7 @@ function CaveHandler:SpawnRoom (teamID, roomID)
 
   local cave = self.caves[teamID]
   local room = cave.rooms[roomID]
-  local creepList = CaveTypes[roomID][math.random(#CaveTypes[roomID])]
+  local creepList = CaveTypes[roomID][RandomInt(1, #CaveTypes[roomID])]
 
   for _, creep in ipairs(creepList.units) do -- spawn all creeps in list
     -- get properties for the creep

--- a/game/scripts/vscripts/components/creeps/item_drop.lua
+++ b/game/scripts/vscripts/components/creeps/item_drop.lua
@@ -92,7 +92,7 @@ function CreepItemDrop:RandomDropItemName(campLocationString)
   local CampPRDCounters = CreepCamps.CampPRDCounters
 
   --first we need to check against the drop percentage.
-  if math.random() > math.min(1, PRD_C * CampPRDCounters[campLocationString]) then
+  if RandomFloat(0, 1) > math.min(1, PRD_C * CampPRDCounters[campLocationString]) then
     -- Increment PRD counter if nothing was dropped
     CampPRDCounters[campLocationString] = CampPRDCounters[campLocationString] + 1
     return ""
@@ -114,7 +114,7 @@ function CreepItemDrop:RandomDropItemName(campLocationString)
   end
 
   local passedItemsCumulativeChance = 0.0
-  local dropChance = math.random() * totalChancePool
+  local dropChance = RandomFloat(0, 1) * totalChancePool
 
   for i=1, #filteredItemTable do
     passedItemsCumulativeChance = passedItemsCumulativeChance + 1.0 / filteredItemTable[i][RARITY_ENUM]

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -63,7 +63,7 @@ end
 
 function CreepCamps:DoSpawn (location, difficulty, maximumUnits)
   local creepCategory = CreepTypes[difficulty]
-  local creepGroup = creepCategory[math.random(#creepCategory)]
+  local creepGroup = creepCategory[RandomInt(1, #creepCategory)]
   for i=1, #creepGroup do
     self:SpawnCreepInCamp (location, creepGroup[i], maximumUnits)
   end

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -231,12 +231,12 @@ function Duels:ActuallyStartDuel (options)
     return
   end
 
-  local playerSplitOffset = math.random(0, maxPlayers)
+  local playerSplitOffset = RandomInt(0, maxPlayers)
   if options.players then
     playerSplitOffset = math.min(options.players, maxPlayers)
   end
   -- local playerSplitOffset = maxPlayers
-  local spawnLocations = math.random(0, 1) == 1
+  local spawnLocations = RandomInt(0, 1) == 1
   local spawn1 = Entities:FindByName(nil, 'duel_1_spawn_1'):GetAbsOrigin()
   local spawn2 = Entities:FindByName(nil, 'duel_1_spawn_2'):GetAbsOrigin()
 
@@ -368,7 +368,7 @@ end
 
 function Duels:GetUnassignedPlayer (group, max)
   while true do
-    local playerIndex = math.random(1, max)
+    local playerIndex = RandomInt(1, max)
     if group[playerIndex].assignable and group[playerIndex].assigned == nil then
       group[playerIndex].assigned = true
       return group[playerIndex]

--- a/game/scripts/vscripts/libraries/fun.lua
+++ b/game/scripts/vscripts/libraries/fun.lua
@@ -266,11 +266,11 @@ end
 exports.ones = ones
 
 local rands_gen = function(param_x, _state_x)
-  return 0, math.random(param_x[1], param_x[2])
+  return 0, RandomInt(param_x[1], param_x[2])
 end
 
 local rands_nil_gen = function(_param_x, _state_x)
-  return 0, math.random()
+  return 0, RandomFloat(0, 1)
 end
 
 local rands = function(n, m)

--- a/game/scripts/vscripts/modifiers/modifier_ward_invisibility.lua
+++ b/game/scripts/vscripts/modifiers/modifier_ward_invisibility.lua
@@ -9,11 +9,11 @@ end
 
 function modifier_ward_invisibility:OnCreated()
   self.isInvis = true
-  self.id = "ward_" .. tostring(math.random())
+  self.id = DoUniqueString("ward_")
 end
 function modifier_ward_invisibility:OnRefresh()
   self.isInvis = true
-  self.id = "ward_" .. tostring(math.random())
+  self.id = DoUniqueString("ward_")
 end
 
 function modifier_ward_invisibility:CheckState()

--- a/game/scripts/vscripts/units/charger.lua
+++ b/game/scripts/vscripts/units/charger.lua
@@ -37,7 +37,7 @@ local function CheckPillars ()
   local towerLocation = Vector(0,0,0)
   while towerLocation:Length() < 700 do
     -- sometimes rng fails us
-    towerLocation = RandomVector(1):Normalized() * 800
+    towerLocation = RandomVector(1):Normalized() * RandomFloat(700, 800)
   end
 
   towerLocation = towerLocation + GLOBAL_origin

--- a/game/scripts/vscripts/units/charger.lua
+++ b/game/scripts/vscripts/units/charger.lua
@@ -37,7 +37,7 @@ local function CheckPillars ()
   local towerLocation = Vector(0,0,0)
   while towerLocation:Length() < 700 do
     -- sometimes rng fails us
-    towerLocation = Vector(math.random(-1,1), math.random(-1,1), 0):Normalized() * 800
+    towerLocation = RandomVector(1):Normalized() * 800
   end
 
   towerLocation = towerLocation + GLOBAL_origin

--- a/game/scripts/vscripts/units/stopfightingyourself.lua
+++ b/game/scripts/vscripts/units/stopfightingyourself.lua
@@ -144,12 +144,12 @@ local function Think(state, target)
   end
 
   if thisEntity:IsIdle() and IsHeroInRange(thisEntity:GetAbsOrigin(), 900) then
-    local dice = math.random(100)
+    local dice = RandomFloat(0, 1)
     local healthpct = thisEntity:GetMaxHealth() / thisEntity:GetHealth()
-    if dice <= 33 and healthpct <= 33 then
+    if dice <= 0.33 and healthpct <= 33 then
       UseRandomItem()
       return 0.5
-    elseif dice <= 66 and healthpct <= 66 then
+    elseif dice <= 0.66 and healthpct <= 66 then
       IllusionsCast()
       return 1
     end


### PR DESCRIPTION
If I did this right, most of this should be largely inconsequential. The main exceptions being the Charger tower locations, which looks like it was using math.random in such a way that the location vector could only be 1 of 9 (or 8 rather, since one of the possible vectors was (0,0), which would get rejected) locations, and ward_invisiblity which was using math.random in a way it's not really meant to be used.