### PR TITLE
Make Team win if opposing team has left

### DIFF
--- a/game/scripts/vscripts/events.lua
+++ b/game/scripts/vscripts/events.lua
@@ -11,10 +11,26 @@ function GameMode:OnDisconnect(keys)
   DebugPrintTable(keys)
 
   local name = keys.name
-  local networkid = keys.networkid
+  local networkID = keys.networkid
   local reason = keys.reason
-  local userid = keys.userid
+  local userID = keys.userid
+  local playerID = keys.playerid
+  local teamID = PlayerResource:GetTeam(playerID)
+  local opposingTeamID = DOTA_TEAM_GOODGUYS
+  if teamID == DOTA_TEAM_GOODGUYS then
+    opposingTeamID = DOTA_TEAM_BADGUYS
+  end
+  local teamConnectedPlayers = length(PlayerResource:GetConnectedTeamPlayerIDsForTeam(teamID))
 
+  if teamConnectedPlayers == 0 then
+    Timers:CreateTimer(300, function()
+      teamConnectedPlayers = length(PlayerResource:GetConnectedTeamPlayerIDsForTeam(teamID))
+
+      if teamConnectedPlayers == 0 then
+        PointsManager:SetWinner(opposingTeamID)
+      end
+    end)
+  end
 end
 -- The overall game state has changed
 -- game event object for OnGameRulesStateChange


### PR DESCRIPTION
Triggers on player disconnect
Checks 5 mins later if opposing team player count is still 0

It's not a very good solution, but someone kept asking for this