### PR TITLE
Hero Balance Suggestions

### DIFF
--- a/game/scripts/npc/abilities/obsidian_destroyer_arcane_orb.txt
+++ b/game/scripts/npc/abilities/obsidian_destroyer_arcane_orb.txt
@@ -12,7 +12,7 @@
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_NOT_ANCIENTS"
-    "AbilityUnitDamageType"                               "DAMAGE_TYPE_PHYSICAL"
+    "AbilityUnitDamageType"                               "DAMAGE_TYPE_PURE"
     "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_NO"
     "SpellDispellableType"                                "SPELL_DISPELLABLE_NO"
     "MaxLevel"                                            "6"

--- a/game/scripts/npc/abilities/shredder_reactive_armor.txt
+++ b/game/scripts/npc/abilities/shredder_reactive_armor.txt
@@ -23,12 +23,12 @@
       "01"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_armor"                                     "1 1.2 1.4 1.6 2.25 3.85"
+        "bonus_armor"                                     "1 1.2 1.4 1.6 2.0 2.6"
       }
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_hp_regen"                                  "1 1.2 1.4 1.6 2.25 3.85"
+        "bonus_hp_regen"                                  "1 1.2 1.4 1.6 2.0 2.6"
       }
       "03"
       {

--- a/game/scripts/npc/abilities/shredder_reactive_armor.txt
+++ b/game/scripts/npc/abilities/shredder_reactive_armor.txt
@@ -23,17 +23,17 @@
       "01"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_armor"                                     "1 1.2 1.4 1.6 1.8 2.2"
+        "bonus_armor"                                     "1 1.2 1.4 1.6 2.25 3.85"
       }
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_hp_regen"                                  "1 1.2 1.4 1.6 1.8 2.2"
+        "bonus_hp_regen"                                  "1 1.2 1.4 1.6 2.25 3.85"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "stack_limit"                                     "5 10 15 20 25 35"
+        "stack_limit"                                     "5 10 15 20 20 20"
       }
       "04"
       {

--- a/game/scripts/npc/abilities/silencer_glaives_of_wisdom.txt
+++ b/game/scripts/npc/abilities/silencer_glaives_of_wisdom.txt
@@ -12,7 +12,7 @@
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_NO"
-    "AbilityUnitDamageType"                               "DAMAGE_TYPE_PHYSICAL"
+    "AbilityUnitDamageType"                               "DAMAGE_TYPE_PURE"
     "HasScepterUpgrade"                                   "1"
 
 

--- a/game/scripts/npc/abilities/silencer_glaives_of_wisdom.txt
+++ b/game/scripts/npc/abilities/silencer_glaives_of_wisdom.txt
@@ -12,7 +12,7 @@
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_NO"
-    "AbilityUnitDamageType"                               "DAMAGE_TYPE_PURE"
+    "AbilityUnitDamageType"                               "DAMAGE_TYPE_PHYSICAL"
     "HasScepterUpgrade"                                   "1"
 
 

--- a/game/scripts/npc/abilities/treant_eyes_in_the_forest.txt
+++ b/game/scripts/npc/abilities/treant_eyes_in_the_forest.txt
@@ -36,17 +36,17 @@
       "01"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "vision_aoe"                                      "800 800 800 850 900"
+        "vision_aoe"                                      "800"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "overgrowth_aoe"                                  "800 800 800 850 900"
+        "overgrowth_aoe"                                  "800"
       }
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "damage"                                          "175 175 175 275 675"
+        "damage"                                          "175"
       }
     }
   }

--- a/game/scripts/npc/abilities/treant_leech_seed.txt
+++ b/game/scripts/npc/abilities/treant_leech_seed.txt
@@ -41,7 +41,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "leech_damage"                                    "15 30 45 60 90 210"
+        "leech_damage"                                    "15 30 45 60 120 270"
         "LinkedSpecialBonus"                              "special_bonus_unique_treant_2" 
       }
       "03"

--- a/game/scripts/npc/abilities/treant_living_armor.txt
+++ b/game/scripts/npc/abilities/treant_living_armor.txt
@@ -15,7 +15,7 @@
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
     "AbilityCastRange"                                    "0"
-    "AbilityCastPoint"                                    "0.5 0.5 0.5 0.5"
+    "AbilityCastPoint"                                    "0.5"
     "FightRecapLevel"                                     "1"
 
     "MaxLevel"                                            "6"
@@ -41,17 +41,17 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "health_regen"                                    "4 8 12 16 24 56"
+        "health_regen"                                    "4 8 12 16 32 96"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage_block"                                    "20 40 60 80 120 280"
+        "damage_block"                                    "20 40 60 80 160 380"
       }
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "duration"                                        "15.0 15.0 15.0 15.0 16.0 18.0"
+        "duration"                                        "15.0"
       }
 
     }


### PR DESCRIPTION
Treant
Leech Seed damage/heal increased from 15/30/45/60/90/210 to 15/30/45/60/120/270
Living Armor Regeneration increased from 4/8/12/16/24/56 to 4/8/12/16/32/96
Living Armor Damage Block increased from 20/40/60/80/120/280 to 20/40/60/80/160/380
Living Armor Duration reduced from 15/15/15/15/16/18 to 15 at all levels

Slight buff to his damage, overall buffed healing. Should make him much more useful as a support.
Removed the useless entries in the eyes of the forest kv as it is an ability that cannot be leveled.

Timbersaw
Reactive Armor armor/regen per stack increased from 1/1.2/1.4/1.6/1.8/2.2 to 1/1.2/1.4/1.6/2.0/2.6
Maximum stacks reduced from 20/20/20/20/25/35 to 20 at all levels

This will cause him to be tankier at less stacks but less tanky at full stacks. 35 stacks take too long to achieve to achieve and are unreasonably hard to hold. Timbersaw already has the damage he needs, this should be enough to make him competitive again.

Outworld Devourer
Changing the KV from pure to physical has no effect on the ability, it only changes the tooltip. Reverting the change as right now it is misleading and false.