### PR TITLE
Martyr's Mail fixes

### DIFF
--- a/game/scripts/vscripts/items/martyrs_mail.lua
+++ b/game/scripts/vscripts/items/martyrs_mail.lua
@@ -112,15 +112,11 @@ end
 function modifier_item_martyrs_mail_martyr_active:OnTakeDamage( kv )
 	if IsServer() then
 		local hCaster = self:GetParent()
+    local shouldNotReflect = kv.attacker == hCaster or -- Prevent reflecting self-damage
+      bit.band(kv.damage_flags, DOTA_DAMAGE_FLAG_REFLECTION) == DOTA_DAMAGE_FLAG_REFLECTION -- Prevent reflecting damage with no-reflect flag
 
-    -- Prevent reflecting self-damage
-    if kv.attacker == hCaster then
+    if shouldNotReflect then
       return
-    end
-
-    --Prevent reflecting damage with no-reflect flag
-    if bit.band(kv.damage_flags, DOTA_DAMAGE_FLAG_REFLECTION) == DOTA_DAMAGE_FLAG_REFLECTION then
-	    return
     end
 
 		if kv.unit == hCaster then

--- a/game/scripts/vscripts/items/martyrs_mail.lua
+++ b/game/scripts/vscripts/items/martyrs_mail.lua
@@ -123,8 +123,8 @@ function modifier_item_martyrs_mail_martyr_active:OnTakeDamage( kv )
 			local damageTable = {
 				victim = kv.attacker,
 				attacker = hCaster,
-				damage_flag = bit.bor(DOTA_DAMAGE_FLAG_REFLECTION, DOTA_DAMAGE_FLAG_NO_DAMAGE_MULTIPLIERS),
 				damage = kv.original_damage,
+				damage_flag = bit.bor(kv.damage_flags, DOTA_DAMAGE_FLAG_REFLECTION, DOTA_DAMAGE_FLAG_NO_DAMAGE_MULTIPLIERS),
 				damage_type = kv.damage_type
 			}
 

--- a/game/scripts/vscripts/items/martyrs_mail.lua
+++ b/game/scripts/vscripts/items/martyrs_mail.lua
@@ -129,7 +129,7 @@ function modifier_item_martyrs_mail_martyr_active:OnTakeDamage( kv )
 			}
 
 			ApplyDamage( damageTable )
-			EmitSoundOn( "DOTA_Item.BladeMail.Damage", kv.attacker )
+			EmitSoundOnClient( "DOTA_Item.BladeMail.Damage", kv.attacker:GetPlayerOwner() )
 
 			local martyr_heal_aoe = self:GetAbility():GetSpecialValueFor( "martyr_heal_aoe" )
 			local martyr_heal_percent = self:GetAbility():GetSpecialValueFor( "martyr_heal_percent" )

--- a/game/scripts/vscripts/items/martyrs_mail.lua
+++ b/game/scripts/vscripts/items/martyrs_mail.lua
@@ -123,8 +123,8 @@ function modifier_item_martyrs_mail_martyr_active:OnTakeDamage( kv )
 			local damageTable = {
 				victim = kv.attacker,
 				attacker = hCaster,
-				damage = kv.damage,
 				damage_flag = bit.bor(DOTA_DAMAGE_FLAG_REFLECTION, DOTA_DAMAGE_FLAG_NO_DAMAGE_MULTIPLIERS),
+				damage = kv.original_damage,
 				damage_type = kv.damage_type
 			}
 


### PR DESCRIPTION
The return damage sound was playing for everyone when it should only play for the player getting return damage. Martyr's Mail was also reflecting damage after reductions, which made it incredibly weak at reflecting damage.

Question: Should Martyr's Mail heal for damage before or after reduction?