### PR TITLE
Fix disconnect win triggering with no existing players on team

### DIFF
--- a/game/scripts/vscripts/components/player/connection.lua
+++ b/game/scripts/vscripts/components/player/connection.lua
@@ -18,7 +18,10 @@ function PlayerConnection:Think()
   local emptyTeam = nil
   local otherTeam = nil
 
-  if goodTeamPlayerCount == 0 and badTeamPlayerCount == 0 then
+  -- First check that players exist on both teams and don't start countdown if either team has no players
+  if PlayerResource:GetPlayerCountForTeam(DOTA_TEAM_GOODGUYS) == 0 or PlayerResource:GetPlayerCountForTeam(DOTA_TEAM_BADGUYS) == 0 then
+    -- Don't do anything
+  elseif goodTeamPlayerCount == 0 and badTeamPlayerCount == 0 then
     PointsManager:SetWinner(DOTA_TEAM_NEUTRALS)
   elseif goodTeamPlayerCount == 0 then
     emptyTeam = DOTA_TEAM_GOODGUYS

--- a/game/scripts/vscripts/components/player/connection.lua
+++ b/game/scripts/vscripts/components/player/connection.lua
@@ -40,10 +40,17 @@ function PlayerConnection:Think()
 
   if self.countdown and self.countdown > 0 then
     -- TODO: Show Nice Message
-    Notifications:TopToAll({
-      text=self.countdown .. " seconds until " .. GetTeamName(otherTeam) .. " will win",
-      duration=1
-    })
+    if otherTeam == DOTA_TEAM_GOODGUYS then
+      Notifications:TopToAll({
+        text=self.countdown .. " seconds until Radiant will win",
+        duration=1
+      })
+    elseif otherTeam == DOTA_TEAM_BADGUYS then
+      Notifications:TopToAll({
+        text=self.countdown .. " seconds until Dire will win",
+        duration=1
+      })
+    end
     self.countdown = self.countdown - 1
   elseif self.countdown == 0 then
     PointsManager:SetWinner(otherTeam)

--- a/game/scripts/vscripts/components/player/connection.lua
+++ b/game/scripts/vscripts/components/player/connection.lua
@@ -20,7 +20,7 @@ function PlayerConnection:Think()
 
   -- First check that players exist on both teams and don't start countdown if either team has no players
   if PlayerResource:GetPlayerCountForTeam(DOTA_TEAM_GOODGUYS) == 0 or PlayerResource:GetPlayerCountForTeam(DOTA_TEAM_BADGUYS) == 0 then
-    -- Don't do anything
+    return 1-- Don't do anything
   elseif goodTeamPlayerCount == 0 and badTeamPlayerCount == 0 then
     PointsManager:SetWinner(DOTA_TEAM_NEUTRALS)
   elseif goodTeamPlayerCount == 0 then

--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -179,7 +179,7 @@ function GameMode:OnGameInProgress()
   InitModule(BottleCounter)
   InitModule(DuelRunes)
   InitModule(FinalDuel)
-  -- InitModule(PlayerConnection)
+  InitModule(PlayerConnection)
 end
 
 function InitModule(myModule)

--- a/game/scripts/vscripts/libraries/playerresource.lua
+++ b/game/scripts/vscripts/libraries/playerresource.lua
@@ -14,13 +14,16 @@
 
 -PlayerResource:RandomHeroForPlayersWithoutHero()
   Forcibly randoms a hero for any player that has not yet picked a hero
+
+-PlayerResource:IsBotOrPlayerConnected(int id)
+  Returns true if the given player ID is a connected bot or player
 ]]
 function CDOTA_PlayerResource:GetAllTeamPlayerIDs()
   return filter(partial(self.IsValidPlayerID, self), range(0, self:GetPlayerCount()))
 end
 
 function CDOTA_PlayerResource:GetConnectedTeamPlayerIDs()
-  return filter(function(id) return self:GetConnectionState(id) == 2 end, self:GetAllTeamPlayerIDs())
+  return filter(partial(self.IsBotOrPlayerConnected, self), self:GetAllTeamPlayerIDs())
 end
 
 function CDOTA_PlayerResource:GetPlayerIDsForTeam(team)
@@ -28,7 +31,7 @@ function CDOTA_PlayerResource:GetPlayerIDsForTeam(team)
 end
 
 function CDOTA_PlayerResource:GetConnectedTeamPlayerIDsForTeam(team)
-  return filter(function(id) return self:GetConnectionState(id) == 2 end, self:GetPlayerIDsForTeam(team))
+  return filter(partial(self.IsBotOrPlayerConnected, self), self:GetPlayerIDsForTeam(team))
 end
 
 function CDOTA_PlayerResource:RandomHeroForPlayersWithoutHero()
@@ -40,4 +43,9 @@ function CDOTA_PlayerResource:RandomHeroForPlayersWithoutHero()
   end
   local playerIDsWithoutHero = filter(HasNotSelectedHero, self:GetConnectedTeamPlayerIDs())
   foreach(ForceRandomHero, playerIDsWithoutHero)
+end
+
+function CDOTA_PlayerResource:IsBotOrPlayerConnected(id)
+  local connectionState = self:GetConnectionState(id)
+  return connectionState == 2 or connectionState == 1
 end


### PR DESCRIPTION
Tested with bots locally using console `kick` command. Seemed to work fine.