### PR TITLE
Comment out ItemSellable in Farming Core and add it to sell blacklist

### DIFF
--- a/game/scripts/npc/items/item_farming_core.txt
+++ b/game/scripts/npc/items/item_farming_core.txt
@@ -19,7 +19,7 @@
 
     "ItemCost"                                            "1500"
     "ItemPurchasable"                                     "0"
-    "ItemSellable"                                        "0"
+    //"ItemSellable"                                        "0"
     "ItemKillable"                                        "0"
 
     // Special

--- a/game/scripts/vscripts/components/filters/sellblacklist.lua
+++ b/game/scripts/vscripts/components/filters/sellblacklist.lua
@@ -6,7 +6,8 @@ end
 
 local ItemSellBlackList = {
   "item_upgrade_core",
-  "item_infinite_bottle"
+  "item_infinite_bottle",
+  "item_farming_core"
 }
 
 function SellBlackList:Init ()


### PR DESCRIPTION
Should fix the issue of there being no right-click menu on Farming Core.

Closes #1137.