### PR TITLE
Make a bunch of ability and item sounds respect visibility

### DIFF
--- a/game/scripts/vscripts/abilities/oaa_bristleback.lua
+++ b/game/scripts/vscripts/abilities/oaa_bristleback.lua
@@ -64,7 +64,7 @@ function bristleback_takedamage(params)
         -- This is the actual "damage reduction".
         params.unit:SetHealth((params.Damage * back_reduction_percentage) + params.unit:GetHealth())
         -- Play the sound on Bristleback.
-        EmitSoundOn(params.sound, params.unit)
+        params.unit:EmitSound(params.sound)
         -- Create the back particle effect.
         local back_damage_particle = ParticleManager:CreateParticle(params.back_particle, PATTACH_ABSORIGIN_FOLLOW, params.unit)
         -- Set Control Point 1 for the back damage particle; this controls where it's positioned in the world. In this case, it should be positioned on Bristleback.
@@ -78,7 +78,7 @@ function bristleback_takedamage(params)
         -- This is the actual "damage reduction".
         params.unit:SetHealth((params.Damage * side_reduction_percentage) + params.unit:GetHealth())
         -- Play the sound on Bristleback.
-        EmitSoundOn(params.sound, params.unit)
+        params.unit:EmitSound(params.sound)
         -- Create the side particle effect.
         local side_damage_particle = ParticleManager:CreateParticle(params.side_particle, PATTACH_ABSORIGIN_FOLLOW, params.unit)
         -- Set Control Point 1 for the side damage particle; same stuff as the back damage particle.

--- a/game/scripts/vscripts/abilities/oaa_call_of_the_wild_boar.lua
+++ b/game/scripts/vscripts/abilities/oaa_call_of_the_wild_boar.lua
@@ -36,7 +36,7 @@ function beastmaster_call_of_the_wild_boar:OnSpellStart()
   end
   foreach(SpawnBoar, range(spawnCount))
 
-  EmitSoundOn("Hero_Beastmaster.Call.Boar", caster)
+  caster:EmitSound("Hero_Beastmaster.Call.Boar")
 end
 
 function beastmaster_call_of_the_wild_boar:OnUpgrade()

--- a/game/scripts/vscripts/abilities/oaa_call_of_the_wild_hawk.lua
+++ b/game/scripts/vscripts/abilities/oaa_call_of_the_wild_hawk.lua
@@ -21,7 +21,7 @@ function beastmaster_call_of_the_wild:OnSpellStart()
   ParticleManager:SetParticleControl(particle1, 0, hawk:GetOrigin())
   ParticleManager:ReleaseParticleIndex(particle1)
 
-  EmitSoundOn("Hero_Beastmaster.Call.Hawk", caster)
+  caster:EmitSound("Hero_Beastmaster.Call.Hawk")
 end
 
 function beastmaster_call_of_the_wild:OnUpgrade()

--- a/game/scripts/vscripts/abilities/oaa_demonic_conversion.lua
+++ b/game/scripts/vscripts/abilities/oaa_demonic_conversion.lua
@@ -36,7 +36,7 @@ function enigma_demonic_conversion:OnSpellStart()
     eidolon:AddNewModifier(caster, self, "modifier_demonic_conversion", {duration = duration, allowsplit = splitAttackCount})
   end
 
-  EmitSoundOn("Hero_Enigma.Demonic_Conversion", target)
+  target:EmitSound("Hero_Enigma.Demonic_Conversion")
 end
 
 -- Add the filter to disallow use on big creeps (level >= 5)

--- a/game/scripts/vscripts/abilities/oaa_rearm.lua
+++ b/game/scripts/vscripts/abilities/oaa_rearm.lua
@@ -3,7 +3,7 @@ oaa_rearm = class(AbilityBaseClass)
 function oaa_rearm:OnSpellStart()
   local caster = self:GetCaster()
 
-  EmitSoundOn("Hero_Tinker.Rearm", caster)
+  caster:EmitSound("Hero_Tinker.Rearm")
   local particleName = "particles/units/heroes/hero_tinker/tinker_rearm.vpcf"
   self.particle = ParticleManager:CreateParticle(particleName, PATTACH_ABSORIGIN_FOLLOW, caster)
   ParticleManager:SetParticleControlEnt(self.particle, 0, caster, PATTACH_POINT_FOLLOW, "attach_attack2", caster:GetOrigin(), true)
@@ -22,7 +22,7 @@ function oaa_rearm:OnChannelFinish(bInterrupted)
   ParticleManager:ReleaseParticleIndex(self.particle)
   self.particle = nil
 
-  StopSoundOn("Hero_Tinker.Rearm", caster)
+  caster:StopSound("Hero_Tinker.Rearm")
 
   -- Put ability exemption in here
   local exempt_ability_table = {

--- a/game/scripts/vscripts/items/bottle.lua
+++ b/game/scripts/vscripts/items/bottle.lua
@@ -8,8 +8,7 @@ function item_infinite_bottle:OnSpellStart()
   local restore_time = self:GetSpecialValueFor("restore_time")
   local caster = self:GetCaster()
 
-  -- TODO: This needs testing if executing on Clients only fixed the 'ghost bottle' issue
-  EmitSoundOn("Bottle.Drink", caster)
+  EmitSoundOnClient("Bottle.Drink", caster:GetPlayerOwner())
 
   caster:AddNewModifier(caster, self, "modifier_bottle_regeneration", { duration = restore_time })
 

--- a/game/scripts/vscripts/items/charge_bkb.lua
+++ b/game/scripts/vscripts/items/charge_bkb.lua
@@ -32,7 +32,7 @@ function item_charge_bkb:OnSpellStart()
   caster:Purge(RemovePositiveBuffs, RemoveDebuffs, BuffsCreatedThisFrameOnly, RemoveStuns, RemoveExceptions)
 
   caster:AddNewModifier(caster, self, "modifier_black_king_bar_immune", {duration = modifier_duration})
-  EmitSoundOn("DOTA_Item.BlackKingBar.Activate", caster)
+  caster:EmitSound("DOTA_Item.BlackKingBar.Activate")
 
   local modified_cooldown = self:GetSpecialValueFor("cooldown_time_per_charge") * self:GetCurrentCharges() + self:GetCooldown(self:GetLevel())
   self:SetCurrentCharges(0)

--- a/game/scripts/vscripts/items/farming/greater_arcane_boots.lua
+++ b/game/scripts/vscripts/items/farming/greater_arcane_boots.lua
@@ -47,7 +47,7 @@ function item_greater_arcane_boots:OnSpellStart()
   local particleArcaneActivateName = "particles/items_fx/arcane_boots.vpcf"
   local particleArcaneActivate = ParticleManager:CreateParticle(particleArcaneActivateName, PATTACH_ABSORIGIN_FOLLOW, caster)
 
-  EmitSoundOn("DOTA_Item.ArcaneBoots.Activate", caster)
+  caster:EmitSound("DOTA_Item.ArcaneBoots.Activate")
 end
 
 function item_greater_arcane_boots:GetIntrinsicModifierName()

--- a/game/scripts/vscripts/items/farming/greater_guardian_greaves.lua
+++ b/game/scripts/vscripts/items/farming/greater_guardian_greaves.lua
@@ -76,7 +76,7 @@ function item_greater_guardian_greaves:OnSpellStart()
       ParticleManager:ReleaseParticleIndex(particleHealNonHero)
     end
 
-    EmitSoundOn("Item.GuardianGreaves.Target", hero)
+    hero:EmitSound("Item.GuardianGreaves.Target")
   end
 
   heroes = iter(heroes)
@@ -88,7 +88,7 @@ function item_greater_guardian_greaves:OnSpellStart()
   local particleCastName = "particles/items3_fx/warmage.vpcf"
   local particleCast = ParticleManager:CreateParticle(particleCastName, PATTACH_ABSORIGIN, caster)
   ParticleManager:ReleaseParticleIndex(particleCast)
-  EmitSoundOn("Item.GuardianGreaves.Activate", caster)
+  caster:EmitSound("Item.GuardianGreaves.Activate")
 end
 
 function item_greater_guardian_greaves:GetIntrinsicModifierName()

--- a/game/scripts/vscripts/items/farming/greater_travel_boots.lua
+++ b/game/scripts/vscripts/items/farming/greater_travel_boots.lua
@@ -69,8 +69,8 @@ function item_greater_travel_boots:OnSpellStart()
   hCaster:StartGesture(ACT_DOTA_TELEPORT)
 
   -- Teleport sounds
-  EmitSoundOn("Portal.Loop_Disappear", hCaster)
-  EmitSoundOn("Portal.Loop_Appear", hTarget)
+  hCaster:EmitSound("Portal.Loop_Disappear")
+  hTarget:EmitSound("Portal.Loop_Appear")
 
   -- Particle effects
   local teleportFromEffectName = "particles/items2_fx/teleport_start.vpcf"
@@ -118,7 +118,7 @@ function item_greater_travel_boots:OnChannelFinish(wasInterupted)
   hCaster:StartGesture(ACT_DOTA_TELEPORT_END)
 
   EmitSoundOnLocationWithCaster(hCaster:GetOrigin(), "Portal.Hero_Disappear", hCaster)
-  EmitSoundOn("Portal.Hero_Appear", self.targetEntity)
+  self.targetEntity:EmitSound("Portal.Hero_Appear")
 
   FindClearSpaceForUnit(self:GetCaster(), self.targetEntity:GetAbsOrigin(), true)
 end

--- a/game/scripts/vscripts/items/hand_of_midas.lua
+++ b/game/scripts/vscripts/items/hand_of_midas.lua
@@ -34,7 +34,7 @@ function item_hand_of_midas:OnSpellStart()
   if caster.AddExperience then
     caster:AddExperience(target:GetDeathXP() * xpMult, false, false)
   end
-  EmitSoundOn("DOTA_Item.Hand_Of_Midas", target)
+  target:EmitSound("DOTA_Item.Hand_Of_Midas")
   local midas_particle = ParticleManager:CreateParticle("particles/items2_fx/hand_of_midas.vpcf", PATTACH_ABSORIGIN_FOLLOW, target)
   ParticleManager:SetParticleControlEnt(midas_particle, 1, caster, PATTACH_POINT_FOLLOW, "attach_hitloc", caster:GetAbsOrigin(), false)
 

--- a/game/scripts/vscripts/items/martyrs_mail.lua
+++ b/game/scripts/vscripts/items/martyrs_mail.lua
@@ -14,7 +14,7 @@ function item_martyrs_mail:OnSpellStart()
 	local hCaster = self:GetCaster()
 	local martyr_duration = self:GetSpecialValueFor( "martyr_duration" )
 
-	EmitSoundOn( "DOTA_Item.BladeMail.Activate", hCaster )
+	hCaster:EmitSound( "DOTA_Item.BladeMail.Activate" )
 	hCaster:AddNewModifier( hCaster, self, "modifier_item_martyrs_mail_martyr_active", { duration = martyr_duration } )
 end
 

--- a/game/scripts/vscripts/items/reflex/postactive.lua
+++ b/game/scripts/vscripts/items/reflex/postactive.lua
@@ -37,7 +37,7 @@ function item_postactive:OnSpellStart()
   local purgableDebuffs = filter(IsPurgableDebuff, iter(modifiers))
 
   -- Audiovisual effects
-  EmitSoundOn("Hero_Abaddon.AphoticShield.Cast", caster)
+  caster:EmitSound("Hero_Abaddon.AphoticShield.Cast")
   local particleName1 = "particles/items3_fx/lotus_orb_shell_shield_cast.vpcf"
   local particle1 = ParticleManager:CreateParticle(particleName1, PATTACH_ABSORIGIN_FOLLOW, caster)
   ParticleManager:ReleaseParticleIndex(particle1)

--- a/game/scripts/vscripts/items/reflex/postactive_invisibility.lua
+++ b/game/scripts/vscripts/items/reflex/postactive_invisibility.lua
@@ -12,5 +12,5 @@ function item_postactive_2a:OnSpellStart()
   local shroud_duration = self:GetSpecialValueFor( "duration" )
 
   caster:AddNewModifier( caster, self, "modifier_item_glimmer_cape_fade", { duration = shroud_duration } )
-  EmitSoundOn( "Item.GlimmerCape.Activate", caster )
+  caster:EmitSound( "Item.GlimmerCape.Activate" )
 end

--- a/game/scripts/vscripts/items/reflex/preemptive_bubble.lua
+++ b/game/scripts/vscripts/items/reflex/preemptive_bubble.lua
@@ -225,5 +225,5 @@ function modifier_item_preemptive_bubble_block:PlayBlockEffect()
   local blockEffect = ParticleManager:CreateParticle(blockEffectName, PATTACH_POINT_FOLLOW, parent)
   ParticleManager:ReleaseParticleIndex(blockEffect)
 
-  EmitSoundOn("DOTA_Item.LinkensSphere.Activate", parent)
+  parent:EmitSound("DOTA_Item.LinkensSphere.Activate")
 end

--- a/game/scripts/vscripts/items/reflex/reactive_block_blink.lua
+++ b/game/scripts/vscripts/items/reflex/reactive_block_blink.lua
@@ -69,7 +69,7 @@ function modifier_item_reactive_2b:GetAbsorbSpell()
   local endParticle = ParticleManager:CreateParticle(endParticleName, PATTACH_ABSORIGIN, caster)
   ParticleManager:ReleaseParticleIndex(endParticle)
 
-  EmitSoundOn("DOTA_Item.BlinkDagger.Activate", caster)
+  caster:EmitSound("DOTA_Item.BlinkDagger.Activate")
 
   return 1
 end

--- a/game/scripts/vscripts/items/satanic_core.lua
+++ b/game/scripts/vscripts/items/satanic_core.lua
@@ -22,7 +22,7 @@ function item_satanic_core:OnSpellStart()
   local hCaster = self:GetCaster()
   local unholy_duration = self:GetSpecialValueFor( "unholy_duration" )
 
-  EmitSoundOn( "DOTA_Item.Satanic.Activate", hCaster )
+  hCaster:EmitSound( "DOTA_Item.Satanic.Activate" )
   hCaster:AddNewModifier( hCaster, self, "modifier_satanic_core_unholy", { duration = unholy_duration } )
 end
 

--- a/game/scripts/vscripts/items/shivas_cuirass.lua
+++ b/game/scripts/vscripts/items/shivas_cuirass.lua
@@ -13,7 +13,7 @@ end
 function item_shivas_cuirass:OnSpellStart()
 	local hCaster = self:GetCaster()
 
-	EmitSoundOn( "DOTA_Item.ShivasGuard.Activate", hCaster )
+	hCaster:EmitSound( "DOTA_Item.ShivasGuard.Activate" )
 	CreateModifierThinker( hCaster, self, "modifier_item_shivas_guard_thinker", nil, hCaster:GetAbsOrigin(), hCaster:GetTeamNumber(), false )
 end
 

--- a/game/scripts/vscripts/items/shroud.lua
+++ b/game/scripts/vscripts/items/shroud.lua
@@ -14,7 +14,7 @@ function item_shroud:OnSpellStart()
   local hTarget = self:GetCursorTarget()
   local shroud_duration = self:GetSpecialValueFor( "duration" )
 
-  EmitSoundOn( "Item.GlimmerCape.Activate", hTarget )
+  hTarget:EmitSound( "Item.GlimmerCape.Activate" )
   hTarget:AddNewModifier( hTarget, self, "modifier_ghost_state", { duration = shroud_duration } )
   hTarget:AddNewModifier( hTarget, self, "modifier_item_glimmer_cape_fade", { duration = shroud_duration } )
 end

--- a/game/scripts/vscripts/items/stoneskin.lua
+++ b/game/scripts/vscripts/items/stoneskin.lua
@@ -35,7 +35,7 @@ function item_stoneskin:OnSpellStart()
     self:StartCooldown(activationDelay + cooldownAfterDelay)
     self.intrinsicModifier:SetStackCount(2)
 
-    EmitSoundOn("Hero_EarthSpirit.RollingBoulder.Loop", caster)
+    caster:EmitSound("Hero_EarthSpirit.RollingBoulder.Loop")
     Timers:CreateTimer(activationDelay, function()
       self:ApplyStoneskin()
     end)
@@ -77,8 +77,8 @@ end
 function item_stoneskin:ApplyStoneskin()
   local caster = self:GetCaster()
   caster:AddNewModifier(caster, self, "modifier_item_stoneskin_stone_armor", {})
-  StopSoundOn("Hero_EarthSpirit.RollingBoulder.Loop", caster)
-  EmitSoundOn("Hero_EarthSpirit.Petrify", caster)
+  caster:StopSound("Hero_EarthSpirit.RollingBoulder.Loop")
+  caster:EmitSound("Hero_EarthSpirit.Petrify")
   self.intrinsicModifier:SetStackCount(2)
 end
 


### PR DESCRIPTION
I discovered while working on Glaives of Wisdom that `EmitSoundOn` doesn't seem to respect visibility. Hence why Bottle drinking sounds could be heard through Fog of War. In the first place, the Bottle drinking sound should only play for the player using the Bottle, so that was changed to do that. The others were just changed to use `entity:EmitSound` instead, which seems to respect visibility for when the sound can be heard.

List of items and abilities modified by this:
- Bristleback
- Call of the Wild (both boar and hawk)
- Demonic Conversion
- Rearm
- Charge BKB
- Hand of Midas
- Martyr's Mail
- Satanic Core
- Shiva's Cuirass (though that code isn't currently used anymore)
- Shroud of Shadows
- Stoneskin Armor
- Greater Arcane Boots
- Greater Guardain Greaves
- Greater Boots of Travel
- Enrage Crystal
- Invisibility Crystal
- Bubble Orb
- Teleportation Shard
- Infinity Bottle