### PR TITLE
Rewrite Elder Dragon Form

### DIFF
--- a/game/resource/English/ability/units/tooltip_dragon_knight_elder_dragon_form.txt
+++ b/game/resource/English/ability/units/tooltip_dragon_knight_elder_dragon_form.txt
@@ -1,0 +1,14 @@
+//=============================================================================
+// Dragon Knight Elder Dragon Form
+//=============================================================================
+
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa"							"Elder Dragon Form"
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Description"				"Dragon Knight takes the form of one of three powerful elder dragons, increasing his speed, and Dragon Tail's range, while granting him new powers.\n<font color=\"#9acd32\">LEVEL 1 Green Dragon</font> - Corrosive Breath: attacks deal 20 poison damage per second for 5 seconds. Works on structures.\n<font color=\"#ff0000\">LEVEL 2 Red Dragon</font> - Splash Attack: attacks damage all enemy units in a 300 radius, with Corrosive Breath added to the targets.\n<font color=\"#87ceeb\">LEVEL 3 Blue Dragon</font> - Frost Breath: slows movement speed by 30%% and attack speed by 30 of enemy units in Splash Attack range for 3 seconds, with Corrosive Breath added to the targets.\n<font color=\"#87ceeb\">LEVEL 5 Emperor King Blue Dragon</font> - Draconic Rebirth: Elder Dragon Form becomes permanent, and Dragon Knight transforms automatically."
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Lore"						"The dormant dragon power springs forth from within Davion, combining the powers of a legendary knight with a legendary Eldwurm."
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Note0"					"Corrosive Breath poison damage is lethal."
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Note1"					"Splash Attack deals 100/75/50% damage in a 150/225/300 radius. Splash damage does not affect buildings."
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Note2"					"Frost Breath stacks with Unique Attack Modifiers."
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Note3"					"Manta Style's cooldown time will be based on whether Dragon Knight was in his ranged or melee form when the item was used."
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_duration"					"DURATION:"
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_bonus_movement_speed"		"BONUS MOVE SPEED:"
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_bonus_attack_range"		"BONUS ATTACK RANGE:"

--- a/game/scripts/npc/abilities/dragon_knight_elder_dragon_form_oaa.txt
+++ b/game/scripts/npc/abilities/dragon_knight_elder_dragon_form_oaa.txt
@@ -1,0 +1,100 @@
+"DOTAAbilities"
+{
+  //=================================================================================================================
+  // Dragon Knight: Elder Dragon Form
+  //=================================================================================================================
+  "dragon_knight_elder_dragon_form_oaa"
+  {
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "ID"                                                  "85229"              // unique ID number for this ability.  Do not change this once established or it will invalidate collected stats.
+    "BaseClass"                                           "ability_lua"
+    "ScriptFile"                                          "abilities/oaa_elder_dragon_form.lua"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+    "AbilityType"                                         "DOTA_ABILITY_TYPE_ULTIMATE"
+    "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_YES"
+    "SpellDispellableType"                                "SPELL_DISPELLABLE_NO"
+    "AbilityTextureName"                                  "dragon_knight_elder_dragon_form"
+    "FightRecapLevel"                                     "2"
+    "MaxLevel"                                            "5"
+
+    // Time    
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCooldown"                                     "115.0"
+
+    // Cost
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityManaCost"                                     "50"    
+
+    // Stats
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityModifierSupportValue"                         "0.35"  // Attacks are primarily about the damage
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "duration"                                        "60.0"
+      }
+      "02"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_movement_speed"                            "25 25 25 25 25"
+      }
+      "03"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_attack_range"                              "350"
+      }
+      "04"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_attack_damage"                             "0"
+      }
+      "05"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "corrosive_breath_damage"                         "20 20 20 20 20"
+      }
+      "06"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "corrosive_breath_duration"                       "5.0 5.0 5.0 5.0 5.0"
+      }
+      "07"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "splash_radius"                                   "150 225 300 350 375"
+      }
+      "08"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "splash_damage_percent"                           "100 75 50 50 50"
+      }
+      "09"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "frost_bonus_movement_speed"                      "-30"
+      }
+      "10"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "frost_bonus_attack_speed"                        "-30"
+      }
+      "11"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "frost_duration"                                  "3.0 3.0 3.0 3.0 3.0"
+      }
+      "12"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "frost_aoe"                                       "300"
+      }
+      
+    }
+  }
+}

--- a/game/scripts/npc/heroes/dragon_knight.txt
+++ b/game/scripts/npc/heroes/dragon_knight.txt
@@ -7,6 +7,7 @@
   {
     // Abilities
     //-------------------------------------------------------------------------------------------------------------
+    "Ability4"                                            "dragon_knight_elder_dragon_form_oaa"
     "Ability10"                                           "special_bonus_strength_10"
     "Ability11"                                           "special_bonus_attack_speed_30"
     "Ability12"                                           "special_bonus_cast_range_150"    //OAA

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -4,6 +4,7 @@
 #base "abilities/faceless_void_time_lock_oaa.txt"
 #base "abilities/silencer_glaives_of_wisdom_oaa.txt"
 #base "abilities/slardar_bash_oaa.txt"
+#base "abilities/dragon_knight_elder_dragon_form_oaa.txt"
 
 #base "abilities/boss/boss_great_cleave.txt"
 #base "abilities/boss/boss_geostrike.txt"


### PR DESCRIPTION
Now it actually adds its dragon bonuses on levels 4 and 5.

Speaking of level 5, since the intention seems to be to just plain allow
Dragon Knight to maintain EDF permanently, I made it so that it becomes
a passive that transforms him automatically on level 5.