### PR TITLE
Hotfix for the cave

### DIFF
--- a/game/scripts/vscripts/components/creeps/creep_power.lua
+++ b/game/scripts/vscripts/components/creeps/creep_power.lua
@@ -16,9 +16,9 @@ function CreepPower:GetPowerForMinute (minute)
     return {   0,        1.0,      1.0,      1.0,      1.0,      1.0,      1.0 * self.numPlayersXPFactor}
   end
 
-  if minute > ExponentialGrowthOnset[PointsManager:GetGameLength()] then
-    multFactor = 1.5 ^ (minute - ExponentialGrowthOnset[PointsManager:GetGameLength()])
-  end
+--  if minute > ExponentialGrowthOnset[PointsManager:GetGameLength()] then
+--    multFactor = 1.5 ^ (minute - ExponentialGrowthOnset[PointsManager:GetGameLength()])
+--  end
 
   return {
     minute,                                   -- minute


### PR DESCRIPTION
Should reimplement exponential experience as a separate thing cave won't hook into using clears, and reapply it to cave using minutes.