### PR TITLE
Update Highway to Hell

### DIFF
--- a/game/resource/English/ability/units/tooltip_abyssal_underlord_cancel_dark_rift_oaa.txt
+++ b/game/resource/English/ability/units/tooltip_abyssal_underlord_cancel_dark_rift_oaa.txt
@@ -1,0 +1,7 @@
+//=============================================================================
+// Underlord Hell Voyage Cancel
+//=============================================================================
+
+"DOTA_Tooltip_ability_abyssal_underlord_cancel_dark_rift_oaa"						"Close Highway"
+"DOTA_Tooltip_ability_abyssal_underlord_cancel_dark_rift_oaa_Description"			"Closes the portals prematurely."
+"DOTA_Tooltip_ability_abyssal_underlord_cancel_dark_rift_oaa_Note0"					"The oldest set of portals is closed first."

--- a/game/resource/English/modifier/units/tooltip_modifier_abyssal_underlord_dark_rift_timer.txt
+++ b/game/resource/English/modifier/units/tooltip_modifier_abyssal_underlord_dark_rift_timer.txt
@@ -1,0 +1,5 @@
+//=============================================================================
+// Highway to Hell
+//=============================================================================
+"DOTA_Tooltip_modifier_abyssal_underlord_dark_rift_oaa_timer"					"Highway to Hell"
+"DOTA_Tooltip_modifier_abyssal_underlord_dark_rift_oaa_timer_Description"		"Portals open"

--- a/game/scripts/npc/abilities/abyssal_underlord_cancel_dark_rift_oaa.txt
+++ b/game/scripts/npc/abilities/abyssal_underlord_cancel_dark_rift_oaa.txt
@@ -1,0 +1,22 @@
+"DOTAAbilities"
+{
+  //=================================================================================================================
+  // Abyssal Underlord: Cancel Dark Rift
+  //=================================================================================================================
+  "abyssal_underlord_cancel_dark_rift_oaa"
+  {
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "ID"                                                  "85617"
+    "BaseClass"                                           "ability_lua"
+    "ScriptFile"                                          "abilities/oaa_cancel_dark_rift.lua"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
+    "AbilityTextureName"                                  "abyssal_underlord_cancel_dark_rift"
+
+    "MaxLevel"                                            "1"
+
+    // Time
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCooldown"                                     "1"
+  }
+}

--- a/game/scripts/npc/abilities/abyssal_underlord_dark_rift_oaa.txt
+++ b/game/scripts/npc/abilities/abyssal_underlord_dark_rift_oaa.txt
@@ -15,13 +15,13 @@
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_CREEP"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_PLAYER_CONTROLLED"
-	"AbilityTextureName"                                  "abyssal_underlord_dark_rift"
+    "AbilityTextureName"                                  "abyssal_underlord_dark_rift"
 
     "MaxLevel"                                            "5"
     "RequiredLevel"                                       "6"
     "LevelsBetweenUpgrades"                               "6"
 
-    "AbilityCastRange"                                    "100000"
+    //"AbilityCastRange"                                    "100000"
     "AbilityCastPoint"                                    "0.6"
 
     // Time
@@ -35,11 +35,11 @@
 
     "AbilitySpecial"
     {
-      "01"
-      {
-        "var_type"                                        "FIELD_FLOAT"
-        "cast_range_tooltip"                              "100000"
-      }
+      //"01"
+      //{
+      //  "var_type"                                        "FIELD_FLOAT"
+      //  "cast_range_tooltip"                              "100000"
+      //}
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
@@ -61,6 +61,10 @@
         "minimum_range"                                   "900.0"
       }
     }
-  }
 
+    "Precache"
+    {
+      "particle"                                          "particles/units/heroes/heroes_underlord/abyssal_underlord_dark_rift_portal.vpcf"
+	}
+  }
 }

--- a/game/scripts/npc/heroes/abyssal_underlord.txt
+++ b/game/scripts/npc/heroes/abyssal_underlord.txt
@@ -7,7 +7,7 @@
   {
     // Abilities
     //-------------------------------------------------------------------------------------------------------------
-    "Ability4"                                            "abyssal_underlord_dark_rift_oaa"
-    "Ability5"                                            ""
+    "Ability4"                                            "abyssal_underlord_cancel_dark_rift_oaa"
+    "Ability5"                                            "abyssal_underlord_dark_rift_oaa"
   }
 }

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -7,6 +7,7 @@
 #base "abilities/slardar_bash_oaa.txt"
 #base "abilities/dragon_knight_elder_dragon_form_oaa.txt"
 #base "abilities/abyssal_underlord_dark_rift_oaa.txt"
+#base "abilities/abyssal_underlord_cancel_dark_rift_oaa.txt"
 
 #base "abilities/boss/boss_great_cleave.txt"
 #base "abilities/boss/boss_geostrike.txt"

--- a/game/scripts/vscripts/abilities/oaa_cancel_dark_rift.lua
+++ b/game/scripts/vscripts/abilities/oaa_cancel_dark_rift.lua
@@ -1,0 +1,25 @@
+abyssal_underlord_cancel_dark_rift_oaa = class( AbilityBaseClass )
+
+--------------------------------------------------------------------------------
+
+function abyssal_underlord_cancel_dark_rift_oaa:IsStealable()
+	return false
+end
+
+--------------------------------------------------------------------------------
+
+function abyssal_underlord_cancel_dark_rift_oaa:ProcsMagicStick()
+	return false
+end
+
+--------------------------------------------------------------------------------
+
+function abyssal_underlord_cancel_dark_rift_oaa:OnSpellStart()
+	local caster = self:GetCaster()
+
+	-- play modified gesture
+	caster:StartGesture( ACT_DOTA_OVERRIDE_ABILITY_4 )
+
+	-- remove the oldest timer modifier
+	caster:RemoveModifierByName( "modifier_abyssal_underlord_dark_rift_oaa_timer" )
+end

--- a/game/scripts/vscripts/abilities/oaa_dark_rift.lua
+++ b/game/scripts/vscripts/abilities/oaa_dark_rift.lua
@@ -25,9 +25,9 @@ end
 
 function abyssal_underlord_dark_rift_oaa:OnUpgrade()
 	local caster = self:GetCaster()
-	
+
 	local spell = caster:FindAbilityByName( self:GetAssociatedPrimaryAbilities() )
-	
+
 	if spell then
 		-- if the spell hasn't be upgraded yet
 		-- init the disabled state
@@ -110,7 +110,7 @@ if IsServer() then
 
 		local spell2 = caster:FindAbilityByName( spell:GetAssociatedPrimaryAbilities() )
 
-		-- activate the sub spell		
+		-- activate the sub spell
 		if spell2 then
 			spell2:SetActivated( true )
 		end


### PR DESCRIPTION
Precaches the portal particle so it properly shows up, as well as adds a
"Close Highway" subspell to prematurely close the portals.

As a result, there's now a status buff on Underlord that shows him the
duration of all his portals, and units are interrupted ( Nether Swap
style ) when they go through a portal.