### PR TITLE
Yet Another Cave Patch (aka Fuck Lich Chen Strat)

### DIFF
--- a/game/scripts/vscripts/components/cave/cave_types.lua
+++ b/game/scripts/vscripts/components/cave/cave_types.lua
@@ -103,8 +103,8 @@ CaveTypes = {
   [4] = { -- 4 "Roashes Everywhere"
     {                                         --HP    MANA  DMG   ARM   GOLD  EXP RESIST
       units = {
-        {"npc_dota_mini_roshan",               900,   0,    100,  1.5,  432,  180, 60},
-        {"npc_dota_mini_roshan",               900,   0,    100,  1.5,  432,  180, 60},
+        {"npc_dota_mini_roshan",              1000,   0,    100,  1.5,  432,  180, 60},
+        {"npc_dota_mini_roshan",               800,   0,    100,  1.5,  432,  180, 60},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, 10, CaveProgressionBuff), -- function (k) return 1 end,

--- a/game/scripts/vscripts/components/cave/cave_types.lua
+++ b/game/scripts/vscripts/components/cave/cave_types.lua
@@ -16,7 +16,7 @@ end
 
 local BaseCreepPowerMultiplier = 12
 local BaseCreepXPGOLDMultiplier = 12
-local CaveProgressionBuff = 6
+local CaveProgressionBuff = 4
 local CaveXPGOLDBuff = 2
 
 local BaseMultipliers = {


### PR DESCRIPTION
Originally wanted to make creeps behave as if clears came every 8 minutes again, but thought better of it. Made them weaker, as was apparently the intent.
Asymmetrical roshlings should prevent usage of Lich ult to cheese them.
Awaiting review.