### PR TITLE
Fix bug and typo

### DIFF
--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -595,7 +595,7 @@ function Duels:SafeTeleportAll(owner, location, maxDistance)
                                      nil,
                                      FIND_UNITS_EVERYWHERE,
                                      DOTA_UNIT_TARGET_TEAM_FRIENDLY,
-                                     DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC,
+                                     bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC),
                                      DOTA_UNIT_TARGET_FLAG_PLAYER_CONTROLLED,
                                      FIND_ANY_ORDER,
                                      false)

--- a/game/scripts/vscripts/items/manta.lua
+++ b/game/scripts/vscripts/items/manta.lua
@@ -180,7 +180,7 @@ function modifier_item_manta_splitted:OnDestroy()
       end
 
       --Recreate the caster's items for the image.
-      for itemSlot = DOTA_ITEM_SLOT_1, DOTA_ITEM_SLOT_5 do
+      for itemSlot = DOTA_ITEM_SLOT_1, DOTA_ITEM_SLOT_6 do
         local casterItem = caster:GetItemInSlot(itemSlot)
         if casterItem ~= nil then
           local imageItem = CreateItem(casterItem:GetName(), image, image)


### PR DESCRIPTION
fixed Manta typo so that all 6 item slots are copied over to illusions before Manta was copying only 5 items to illusions.
duels\duels code prevents people from loading oaa character selection (thanks Chrono :) ) also thanks Chris for helping me fix it.