### PR TITLE
Fix overlapping of gameinfo

### DIFF
--- a/content/panorama/layout/custom_game/custom_ui_manifest.xml
+++ b/content/panorama/layout/custom_game/custom_ui_manifest.xml
@@ -7,7 +7,6 @@
     <include src="file://{resources}/scripts/custom_game/abilitylevels.js" />
     <include src="file://{resources}/scripts/custom_game/leveldots.js" />
     <include src="file://{resources}/scripts/custom_game/huderrors.js" />
-    <include src="file://{resources}/scripts/custom_game/game_info.js" />
     <include src="file://{resources}/scripts/custom_game/health_mana.js" />
   </scripts>
   <script>

--- a/content/panorama/layout/custom_game/oaa_game_info.xml
+++ b/content/panorama/layout/custom_game/oaa_game_info.xml
@@ -3,6 +3,10 @@
     <include src="file://{resources}/styles/dotastyles.css" />
 		<include src="file://{resources}/styles/custom_game/oaa_game_info.css" />
 	</styles>
+  <scripts>
+    <include src="file://{resources}/scripts/util.js" />
+    <include src="file://{resources}/scripts/custom_game/game_info.js" />
+  </scripts>
 	<Panel class="OAAGameInfo">
 		<Panel id="Title">
 			<Label id="TitleName" text="#addon_game_name" />

--- a/content/panorama/scripts/custom_game/game_info.js
+++ b/content/panorama/scripts/custom_game/game_info.js
@@ -1,13 +1,9 @@
 /* global FindDotaHudElement GameEvents Game */
 
 (function () {
-  if (Game.GetLocalPlayerID() !== -1) {
-    GameEvents.Subscribe('game_rules_state_change', MoveGameInfo);
+  if (Game.GetLocalPlayerID() === -1) {
+    FindDotaHudElement('GameInfoButton').GetParent().RemoveAndDeleteChildren();
   } else {
-    $.GetContextPanel().FindChildTraverse('GameInfoButton').GetParent().RemoveAndDeleteChildren();
+    FindDotaHudElement('GameInfoButton').style.transform = 'translateY(50%)';
   }
 }());
-
-function MoveGameInfo () {
-  FindDotaHudElement('GameInfoButton').style.transform = 'translateY(20%)';
-}


### PR DESCRIPTION
Soory, made a mistake at last pull, this fixes it, now 100% tested.
Gameinfo button used to overlap CS