### PR TITLE
Make item upgrades not disassemblable

### DIFF
--- a/game/scripts/npc/items/item_abyssal_blade_2.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_2.txt
@@ -57,7 +57,7 @@
     "ItemShopTags"                                        "damage;str;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "abyssal blade"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_abyssal_blade_3.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_3.txt
@@ -55,7 +55,7 @@
     "ItemShopTags"                                        "damage;str;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "abyssal blade"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_abyssal_blade_4.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_4.txt
@@ -54,7 +54,7 @@
     "ItemShopTags"                                        "damage;str;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "abyssal blade"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_abyssal_blade_5.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_5.txt
@@ -53,7 +53,7 @@
     "ItemShopTags"                                        "damage;str;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "abyssal blade"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_dragon_lance_2.txt
+++ b/game/scripts/npc/items/item_dragon_lance_2.txt
@@ -49,7 +49,7 @@
     "ItemShopTags"                                        "damage"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "dragon lance"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "2"
     "UpgradesItems"                                       "item_dragon_lance_2;item_dragon_lance_3;item_dragon_lance_4"

--- a/game/scripts/npc/items/item_dragon_lance_3.txt
+++ b/game/scripts/npc/items/item_dragon_lance_3.txt
@@ -48,7 +48,7 @@
     "ItemShopTags"                                        "damage"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "dragon lance"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "3"
     "UpgradesItems"                                       "item_dragon_lance_3;item_dragon_lance_4"

--- a/game/scripts/npc/items/item_dragon_lance_4.txt
+++ b/game/scripts/npc/items/item_dragon_lance_4.txt
@@ -47,7 +47,7 @@
     "ItemShopTags"                                        "damage"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "dragon lance"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "4"
     "UpgradesItems"                                       "item_dragon_lance_3;item_dragon_lance_4"

--- a/game/scripts/npc/items/item_dragon_lance_5.txt
+++ b/game/scripts/npc/items/item_dragon_lance_5.txt
@@ -46,7 +46,7 @@
     "ItemShopTags"                                        "damage"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "dragon lance"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "5"
     "UpgradesItems"                                       "item_dragon_lance_4"

--- a/game/scripts/npc/items/item_ethereal_blade_2.txt
+++ b/game/scripts/npc/items/item_ethereal_blade_2.txt
@@ -63,7 +63,7 @@
     "ItemCost"                                            "6200"
     "ItemShopTags"                                        "agi;str;int;hard_to_tag"
     "ItemQuality"                                         "epic"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemAliases"                                         "eb;ethereal blade"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
 

--- a/game/scripts/npc/items/item_ethereal_blade_3.txt
+++ b/game/scripts/npc/items/item_ethereal_blade_3.txt
@@ -62,7 +62,7 @@
     "ItemCost"                                            "9700"
     "ItemShopTags"                                        "agi;str;int;hard_to_tag"
     "ItemQuality"                                         "epic"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemAliases"                                         "eb;ethereal blade"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
 

--- a/game/scripts/npc/items/item_ethereal_blade_4.txt
+++ b/game/scripts/npc/items/item_ethereal_blade_4.txt
@@ -61,7 +61,7 @@
     "ItemCost"                                            "17700"
     "ItemShopTags"                                        "agi;str;int;hard_to_tag"
     "ItemQuality"                                         "epic"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemAliases"                                         "eb;ethereal blade"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
 

--- a/game/scripts/npc/items/item_ethereal_blade_5.txt
+++ b/game/scripts/npc/items/item_ethereal_blade_5.txt
@@ -59,7 +59,7 @@
     "ItemCost"                                            "37700"
     "ItemShopTags"                                        "agi;str;int;hard_to_tag"
     "ItemQuality"                                         "epic"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemAliases"                                         "eb;ethereal blade"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
 

--- a/game/scripts/npc/items/item_glimmer_cape_2.txt
+++ b/game/scripts/npc/items/item_glimmer_cape_2.txt
@@ -57,7 +57,7 @@
     "ItemShopTags"                ""
     "ItemQuality"                 "rare"
     "ItemAliases"                 "glimmer cape"
-    "ItemDisassembleRule"         "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"         "DOTA_ITEM_DISASSEMBLE_NEVER"
     "MaxUpgradeLevel"             "5"
     "ItemBaseLevel"               "2"
     

--- a/game/scripts/npc/items/item_glimmer_cape_3.txt
+++ b/game/scripts/npc/items/item_glimmer_cape_3.txt
@@ -56,7 +56,7 @@
     "ItemShopTags"                ""
     "ItemQuality"                 "rare"
     "ItemAliases"                 "glimmer cape"
-    "ItemDisassembleRule"         "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"         "DOTA_ITEM_DISASSEMBLE_NEVER"
     "MaxUpgradeLevel"             "5"
     "ItemBaseLevel"               "3"
     

--- a/game/scripts/npc/items/item_glimmer_cape_4.txt
+++ b/game/scripts/npc/items/item_glimmer_cape_4.txt
@@ -55,7 +55,7 @@
     "ItemShopTags"                ""
     "ItemQuality"                 "rare"
     "ItemAliases"                 "glimmer cape"
-    "ItemDisassembleRule"         "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"         "DOTA_ITEM_DISASSEMBLE_NEVER"
     "MaxUpgradeLevel"             "5"
     "ItemBaseLevel"               "4"
     

--- a/game/scripts/npc/items/item_glimmer_cape_5.txt
+++ b/game/scripts/npc/items/item_glimmer_cape_5.txt
@@ -54,7 +54,7 @@
     "ItemShopTags"                ""
     "ItemQuality"                 "rare"
     "ItemAliases"                 "glimmer cape"
-    "ItemDisassembleRule"         "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"         "DOTA_ITEM_DISASSEMBLE_NEVER"
     "MaxUpgradeLevel"             "5"
     "ItemBaseLevel"               "5"
     

--- a/game/scripts/npc/items/item_heart_transplant.txt
+++ b/game/scripts/npc/items/item_heart_transplant.txt
@@ -54,7 +54,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "25825"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemShopTags"                                        "armor;regen_mana;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "transplant"

--- a/game/scripts/npc/items/item_heart_transplant_2.txt
+++ b/game/scripts/npc/items/item_heart_transplant_2.txt
@@ -46,7 +46,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "45825"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemShopTags"                                        "armor;regen_mana;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "transplant2"

--- a/game/scripts/npc/items/item_heavens_halberd_2.txt
+++ b/game/scripts/npc/items/item_heavens_halberd_2.txt
@@ -57,7 +57,7 @@
     "ItemShopTags"                                        "str;damage;evasion"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "heaven's halberd 2"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "2"

--- a/game/scripts/npc/items/item_heavens_halberd_3.txt
+++ b/game/scripts/npc/items/item_heavens_halberd_3.txt
@@ -56,7 +56,7 @@
     "ItemShopTags"                                        "str;damage;evasion"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "heaven's halberd 3"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "3"

--- a/game/scripts/npc/items/item_heavens_halberd_4.txt
+++ b/game/scripts/npc/items/item_heavens_halberd_4.txt
@@ -55,7 +55,7 @@
     "ItemShopTags"                                        "str;damage;evasion"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "heaven's halberd 4"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "4"

--- a/game/scripts/npc/items/item_heavens_halberd_5.txt
+++ b/game/scripts/npc/items/item_heavens_halberd_5.txt
@@ -54,7 +54,7 @@
     "ItemShopTags"                                        "str;damage;evasion"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "heaven's halberd 5"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "5"

--- a/game/scripts/npc/items/item_lotus_orb_2.txt
+++ b/game/scripts/npc/items/item_lotus_orb_2.txt
@@ -59,7 +59,7 @@
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "ls;lotus orb"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/item_lotus_orb_3.txt
+++ b/game/scripts/npc/items/item_lotus_orb_3.txt
@@ -58,7 +58,7 @@
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "ls;lotus orb"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/item_lotus_orb_4.txt
+++ b/game/scripts/npc/items/item_lotus_orb_4.txt
@@ -57,7 +57,7 @@
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "ls;lotus orb"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/item_lotus_orb_5.txt
+++ b/game/scripts/npc/items/item_lotus_orb_5.txt
@@ -55,7 +55,7 @@
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "ls;lotus orb"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/item_lotus_sphere.txt
+++ b/game/scripts/npc/items/item_lotus_sphere.txt
@@ -59,7 +59,7 @@
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "funball"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/item_lotus_sphere_2.txt
+++ b/game/scripts/npc/items/item_lotus_sphere_2.txt
@@ -50,7 +50,7 @@
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "funball"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/item_manta_2.txt
+++ b/game/scripts/npc/items/item_manta_2.txt
@@ -52,7 +52,7 @@
     "ItemShopTags"                                        "agi;str;int;attack_speed;move_speed;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "manta style"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_manta_3.txt
+++ b/game/scripts/npc/items/item_manta_3.txt
@@ -51,7 +51,7 @@
     "ItemShopTags"                                        "agi;str;int;attack_speed;move_speed;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "manta style"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_manta_4.txt
+++ b/game/scripts/npc/items/item_manta_4.txt
@@ -50,7 +50,7 @@
     "ItemShopTags"                                        "agi;str;int;attack_speed;move_speed;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "manta style"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_manta_5.txt
+++ b/game/scripts/npc/items/item_manta_5.txt
@@ -49,7 +49,7 @@
     "ItemShopTags"                                        "agi;str;int;attack_speed;move_speed;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "manta style"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_mjollnir_2.txt
+++ b/game/scripts/npc/items/item_mjollnir_2.txt
@@ -62,7 +62,7 @@
     "ItemShopTags"                                        "damage;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "mjollnir"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_mjollnir_3.txt
+++ b/game/scripts/npc/items/item_mjollnir_3.txt
@@ -61,7 +61,7 @@
     "ItemShopTags"                                        "damage;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "mjollnir"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_mjollnir_4.txt
+++ b/game/scripts/npc/items/item_mjollnir_4.txt
@@ -60,7 +60,7 @@
     "ItemShopTags"                                        "damage;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "mjollnir"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_mjollnir_5.txt
+++ b/game/scripts/npc/items/item_mjollnir_5.txt
@@ -58,7 +58,7 @@
     "ItemShopTags"                                        "damage;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "mjollnir"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_octarine_core_2.txt
+++ b/game/scripts/npc/items/item_octarine_core_2.txt
@@ -41,7 +41,7 @@
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "mana;mb;octarine core"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     "MaxUpgradeLevel"                                     "2"
     "ItemBaseLevel"                                       "2"

--- a/game/scripts/npc/items/item_ring_of_aquila_2.txt
+++ b/game/scripts/npc/items/item_ring_of_aquila_2.txt
@@ -39,7 +39,7 @@
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "roa;ring of aquila"
     "ItemShareability"                                    ""
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     "MaxUpgradeLevel"                                     "3"
     "ItemBaseLevel"                                       "2"

--- a/game/scripts/npc/items/item_ring_of_aquila_3.txt
+++ b/game/scripts/npc/items/item_ring_of_aquila_3.txt
@@ -41,7 +41,7 @@
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "roa;ring of aquila"
     "ItemShareability"                                    ""
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     "MaxUpgradeLevel"                                     "3"
     "ItemBaseLevel"                                       "3"

--- a/game/scripts/npc/items/item_sange_and_yasha_2.txt
+++ b/game/scripts/npc/items/item_sange_and_yasha_2.txt
@@ -51,7 +51,7 @@
     "ItemShopTags"                                        "damage;str;agi;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "sny;s&y;sy;sange and yasha"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
 

--- a/game/scripts/npc/items/item_sange_and_yasha_3.txt
+++ b/game/scripts/npc/items/item_sange_and_yasha_3.txt
@@ -50,7 +50,7 @@
     "ItemShopTags"                                        "damage;str;agi;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "sny;s&y;sy;sange and yasha"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
 

--- a/game/scripts/npc/items/item_sange_and_yasha_4.txt
+++ b/game/scripts/npc/items/item_sange_and_yasha_4.txt
@@ -49,7 +49,7 @@
     "ItemShopTags"                                        "damage;str;agi;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "sny;s&y;sy;sange and yasha"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
 

--- a/game/scripts/npc/items/item_sange_and_yasha_5.txt
+++ b/game/scripts/npc/items/item_sange_and_yasha_5.txt
@@ -48,7 +48,7 @@
     "ItemShopTags"                                        "damage;str;agi;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "sny;s&y;sy;sange and yasha"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
 

--- a/game/scripts/npc/items/item_shivas_cuirass.txt
+++ b/game/scripts/npc/items/item_shivas_cuirass.txt
@@ -58,7 +58,7 @@
     "ItemShopTags"                                        "int;armor;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "shivas guard"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     "UpgradesItems"                                       "item_shivas_cuirass;item_shivas_cuirass_2;item_shivas_cuirass_3"

--- a/game/scripts/npc/items/item_shivas_cuirass_2.txt
+++ b/game/scripts/npc/items/item_shivas_cuirass_2.txt
@@ -48,7 +48,7 @@
     "ItemShopTags"                                        "int;armor;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "shivas guard"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_shivas_guard_2.txt
+++ b/game/scripts/npc/items/item_shivas_guard_2.txt
@@ -56,7 +56,7 @@
     "ItemShopTags"                                        "int;armor;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "shiva's guard"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     "UpgradesItems"                                       "item_shivas_guard_2;item_shivas_guard_3"

--- a/game/scripts/npc/items/item_shivas_guard_3.txt
+++ b/game/scripts/npc/items/item_shivas_guard_3.txt
@@ -55,7 +55,7 @@
     "ItemShopTags"                                        "int;armor;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "shiva's guard"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_shivas_guard_4.txt
+++ b/game/scripts/npc/items/item_shivas_guard_4.txt
@@ -54,7 +54,7 @@
     "ItemShopTags"                                        "int;armor;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "shiva's guard"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_shivas_guard_5.txt
+++ b/game/scripts/npc/items/item_shivas_guard_5.txt
@@ -53,7 +53,7 @@
     "ItemShopTags"                                        "int;armor;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "shiva's guard"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_shivas_rush.txt
+++ b/game/scripts/npc/items/item_shivas_rush.txt
@@ -56,7 +56,7 @@
     "ItemShopTags"                                        "int;armor;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "shivas rush"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     "UpgradesItems"                                       "item_shivas_rush"

--- a/game/scripts/npc/items/item_shivas_rush_2.txt
+++ b/game/scripts/npc/items/item_shivas_rush_2.txt
@@ -47,7 +47,7 @@
     "ItemShopTags"                                        "int;armor;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "shivas rush"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_siege_mode.txt
+++ b/game/scripts/npc/items/item_siege_mode.txt
@@ -55,7 +55,7 @@
     "ItemShopTags"                                        "damage"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "dragon lance"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "MaxUpgradeLevel"                                     "2"
     "ItemBaseLevel"                                       "1"
     "UpgradesItems"                                       "item_siege_mode"

--- a/game/scripts/npc/items/item_siege_mode_2.txt
+++ b/game/scripts/npc/items/item_siege_mode_2.txt
@@ -56,7 +56,7 @@
     "ItemShopTags"                                        "damage"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "dragon lance"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "MaxUpgradeLevel"                                     "2"
     "ItemBaseLevel"                                       "2"
 

--- a/game/scripts/npc/items/item_silver_edge_2.txt
+++ b/game/scripts/npc/items/item_silver_edge_2.txt
@@ -52,7 +52,7 @@
     "ItemShopTags"                                        "damage;attack_speed;movespeed;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "sb;invis;shadow blade"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_silver_edge_3.txt
+++ b/game/scripts/npc/items/item_silver_edge_3.txt
@@ -50,7 +50,7 @@
     "ItemShopTags"                                        "damage;attack_speed;movespeed;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "sb;invis;shadow blade"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_silver_edge_4.txt
+++ b/game/scripts/npc/items/item_silver_edge_4.txt
@@ -49,7 +49,7 @@
     "ItemShopTags"                                        "damage;attack_speed;movespeed;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "sb;invis;shadow blade"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_silver_edge_5.txt
+++ b/game/scripts/npc/items/item_silver_edge_5.txt
@@ -47,7 +47,7 @@
     "ItemShopTags"                                        "damage;attack_speed;movespeed;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "sb;invis;shadow blade"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_solar_crest_2.txt
+++ b/game/scripts/npc/items/item_solar_crest_2.txt
@@ -53,7 +53,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "4125"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemShopTags"                                        "armor;regen_mana;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "solar crest 2"

--- a/game/scripts/npc/items/item_solar_crest_3.txt
+++ b/game/scripts/npc/items/item_solar_crest_3.txt
@@ -52,7 +52,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "7625"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemShopTags"                                        "armor;regen_mana;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "solar crest 3"

--- a/game/scripts/npc/items/item_solar_crest_4.txt
+++ b/game/scripts/npc/items/item_solar_crest_4.txt
@@ -51,7 +51,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "15625"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemShopTags"                                        "armor;regen_mana;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "solar crest 4"

--- a/game/scripts/npc/items/item_solar_crest_5.txt
+++ b/game/scripts/npc/items/item_solar_crest_5.txt
@@ -50,7 +50,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "35625"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemShopTags"                                        "armor;regen_mana;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "solar crest 5"

--- a/game/scripts/npc/items/item_staff_of_confusion.txt
+++ b/game/scripts/npc/items/item_staff_of_confusion.txt
@@ -56,7 +56,7 @@
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "such confuse"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/item_stop_killing_yourself.txt
+++ b/game/scripts/npc/items/item_stop_killing_yourself.txt
@@ -60,7 +60,7 @@
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "sky"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/item_stop_killing_yourself_2.txt
+++ b/game/scripts/npc/items/item_stop_killing_yourself_2.txt
@@ -48,7 +48,7 @@
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "sky"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Items that can no longer be disassembled:
Any tier 2+ item

Items that can now still be disassembled:
Reflex items
Tier 1 farming boots
Tier 1 items that can be disassembled in vanilla dota
