### PR TITLE
Duel fix

### DIFF
--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -595,7 +595,7 @@ function Duels:SafeTeleportAll(owner, location, maxDistance)
                                      nil,
                                      FIND_UNITS_EVERYWHERE,
                                      DOTA_UNIT_TARGET_TEAM_FRIENDLY,
-                                     DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC,
+                                     bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC),
                                      DOTA_UNIT_TARGET_FLAG_PLAYER_CONTROLLED,
                                      FIND_ANY_ORDER,
                                      false)

--- a/game/scripts/vscripts/items/manta.lua
+++ b/game/scripts/vscripts/items/manta.lua
@@ -180,7 +180,7 @@ function modifier_item_manta_splitted:OnDestroy()
       end
 
       --Recreate the caster's items for the image.
-      for itemSlot = DOTA_ITEM_SLOT_1, DOTA_ITEM_SLOT_5 do
+      for itemSlot = DOTA_ITEM_SLOT_1, DOTA_ITEM_SLOT_6 do
         local casterItem = caster:GetItemInSlot(itemSlot)
         if casterItem ~= nil then
           local imageItem = CreateItem(casterItem:GetName(), image, image)

--- a/game/scripts/vscripts/modifiers/modifier_duel_rune_hill.lua
+++ b/game/scripts/vscripts/modifiers/modifier_duel_rune_hill.lua
@@ -5,7 +5,7 @@ modifier_duel_rune_hill = class(ModifierBaseClass)
 modifier_duel_rune_hill_enemy = class(ModifierBaseClass)
 
 function modifier_duel_rune_hill_enemy:IsHidden()
-  return true
+  return false
 end
 
 function modifier_duel_rune_hill:OnCreated()
@@ -36,10 +36,10 @@ function modifier_duel_rune_hill:GetModifierAura()
   return "modifier_duel_rune_hill_enemy"
 end
 
-function modifier_duel_rune_hill:GetAuraEntityReject(entity)
+--[[function modifier_duel_rune_hill:GetAuraEntityReject(entity)
   self:SetStackCount(0)
   return false
-end
+end]]
 
 --------------------------------------------------------------------------
 

--- a/game/scripts/vscripts/modifiers/modifier_duel_rune_hill.lua
+++ b/game/scripts/vscripts/modifiers/modifier_duel_rune_hill.lua
@@ -5,7 +5,7 @@ modifier_duel_rune_hill = class(ModifierBaseClass)
 modifier_duel_rune_hill_enemy = class(ModifierBaseClass)
 
 function modifier_duel_rune_hill_enemy:IsHidden()
-  return false
+  return true
 end
 
 function modifier_duel_rune_hill:OnCreated()


### PR DESCRIPTION
Commented out the GetAuraEntityReject. Was thinking this can be replaced with a separate duel modifier zone that applies the modifier_duel_rune_enemy aura but is a larger area so that there is more control if this fix has the reverse effect on duels.