### PR TITLE
Add AP_GAME_TIME to settings.lua

### DIFF
--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -16,6 +16,7 @@ CAPTAINS_MODE_HERO_PICK_TIME = 20         -- time to choose which hero you're go
 
 -- Game timings
 PREGAME_TIME = 10
+AP_GAME_TIME = 90
 
 -- Duels
 INITIAL_DUEL_DELAY = 1                  -- how long after the clock hits 0 should the initial duel start countind down


### PR DESCRIPTION
Set it to 90 seconds for now. Can't remember how long the old All Pick was.

Note: The game pause breaks the courier because it attempts to use the courier while the game is paused (it also currently results in an annoying "GAME IS PAUSED" message in the middle of the pick screen). I'd fix the former, but I'm not really sure what the best way to do that might be.