### PR TITLE
Fix Covfefe interaction with health regen amp from Strength

### DIFF
--- a/game/scripts/vscripts/items/trumps_fists.lua
+++ b/game/scripts/vscripts/items/trumps_fists.lua
@@ -82,8 +82,7 @@ modifier_item_trumps_fists_frostbite = class(ModifierBaseClass)
 function modifier_item_trumps_fists_frostbite:OnCreated()
   if IsServer() then
     self.heal_prevent_percent = self:GetAbility():GetSpecialValueFor( "heal_prevent_percent" )
-    self.passive_heal_reduction = self:GetParent():GetHealthRegen() * self.heal_prevent_percent / 100
-    self:StartIntervalThink(0.1)
+    self.health_fraction = 0
   end
 end
 
@@ -93,29 +92,21 @@ end
 
 function modifier_item_trumps_fists_frostbite:DeclareFunctions()
   local funcs = {
-    MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT,
     MODIFIER_EVENT_ON_HEALTH_GAINED
   }
   return funcs
 end
 
-function modifier_item_trumps_fists_frostbite:OnIntervalThink()
-  -- Update passive health regen reduction
-  self.passive_heal_reduction = (self:GetParent():GetHealthRegen() - self.passive_heal_reduction) * self.heal_prevent_percent / 100
-end
-
-function modifier_item_trumps_fists_frostbite:GetModifierConstantHealthRegen()
-  return self.passive_heal_reduction
-end
-
 function modifier_item_trumps_fists_frostbite:OnHealthGained( kv )
   if IsServer() then
     -- Check that event is being called for the unit that self is attached to
-    -- and that the healing is not passive regen
-    if kv.unit == self:GetParent() and not kv.process_procs then
-      local desiredHP = kv.unit:GetHealth() + kv.gain * self.heal_prevent_percent / 100
+    if kv.unit == self:GetParent() and kv.gain > 0 then
+      local desiredHP = kv.unit:GetHealth() + kv.gain * self.heal_prevent_percent / 100 + self.health_fraction
       desiredHP = math.max(desiredHP, 1)
+      -- Keep record of fractions of health since Dota doesn't (mainly to make passive health regen sort of work)
+      self.health_fraction = desiredHP % 1
 
+      DebugPrint(desiredHP)
       kv.unit:SetHealth( desiredHP )
     end
   end


### PR DESCRIPTION
Turns out the health regen % increase from Strength also applies to negative regen. This combined with changes in health regen during Covfefe's duration (or possibly even without) caused unstable oscillation in the regen amount that Covfefe applies. And turns out Dota doesn't like things applying insanely large numbers of negative health regen.

So this rewrites Covfefe to not use a health regen modifier property. Probably causes health regen to not be smooth in cases, but until Valve actually makes Spirit Vessel's effect accessible from Lua, this is probably the best that can be done.

Side note: This effect seems to stack multiplicatively with Spirit Vessel now. Though that only matters for lvl 1 Covfefe anyway.