### PR TITLE
Added true sight to cave Roshans

### DIFF
--- a/game/scripts/npc/units/npc_dota_mini_roshan.txt
+++ b/game/scripts/npc/units/npc_dota_mini_roshan.txt
@@ -19,6 +19,7 @@
     "Ability3"                                            "roshan_slam"			// Ability 3.
     "Ability4"                                            "boss_cliffwalk"		// Ability 4.
     "Ability5"                                            "boss_inner_beast"		// Ability 5
+    "Ability6"                                  					"necronomicon_warrior_sight"			// Ability 6
 
     // Armor
     //----------------------------------------------------------------


### PR DESCRIPTION
They didn't have true sight like the rest of the cave. Riki could just attack them.