### PR TITLE
Boss capture point and precache restructure

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -137,6 +137,7 @@ read_globals = { -- these globals can only be accessed.
 "IsInTrigger",
 "MoveCameraToPlayer",
 "MoveCameraToEntity",
+"IsPlayerTeam",
 
 
 "ACT_MELEE_VM_RELOAD",

--- a/content/particles/capture_point_ring/capture_point_ring.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring.vpcf
@@ -8,12 +8,13 @@
 	[
 		{
 			_class = "C_OP_SetSingleControlPointPosition"
-			m_vecCP1Pos = [ 0.0, 0.0, -25.0 ]
+			m_vecCP1Pos = [ 0.0, 0.0, 100.0 ]
 			m_nCP1 = 2
 		},
 		{
 			_class = "C_OP_SetSingleControlPointPosition"
 			m_vecCP1Pos = [ 0.0, 0.0, 100.0 ]
+			m_bDisableOperator = true
 		},
 		{
 			_class = "C_OP_RestartAfterDuration"
@@ -24,13 +25,11 @@
 	m_Children = 
 	[
 		{
-			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_b.vpcf"
+			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_endcap.vpcf"
+			m_bEndCap = true
 		},
 		{
 			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_e.vpcf"
-		},
-		{
-			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_c.vpcf"
 		},
 	]
 	m_controlPointConfigurations = 
@@ -133,12 +132,6 @@
 					m_entityName = "self"
 				},
 			]
-		},
-	]
-	m_Initializers = 
-	[
-		{
-			_class = "C_INIT_RemapCPtoVector"
 		},
 	]
 }

--- a/content/particles/capture_point_ring/capture_point_ring.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring.vpcf
@@ -1,0 +1,144 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 64
+	m_ConstantColor = [ 229, 187, 94, 55 ]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_SetSingleControlPointPosition"
+			m_vecCP1Pos = [ 0.0, 0.0, -25.0 ]
+			m_nCP1 = 2
+		},
+		{
+			_class = "C_OP_SetSingleControlPointPosition"
+			m_vecCP1Pos = [ 0.0, 0.0, 100.0 ]
+		},
+		{
+			_class = "C_OP_RestartAfterDuration"
+			m_flDurationMax = 2.0
+			m_bDisableOperator = true
+		},
+	]
+	m_Children = 
+	[
+		{
+			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_b.vpcf"
+		},
+		{
+			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_e.vpcf"
+		},
+		{
+			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_c.vpcf"
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "Radiance"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ 0.0, 0.0, 0.0 ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 1
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ 0.0, 0.0, 0.0 ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 2
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ 0.0, 0.0, 0.0 ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 3
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 162.0, 255.0 ]
+					m_angOffset = [ 0.0, 0.0, 0.0 ]
+					m_entityName = "self"
+				},
+			]
+		},
+		{
+			m_name = "Dire"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ 0.0, 0.0, 0.0 ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 1
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ 0.0, 0.0, 0.0 ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 2
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ 0.0, 0.0, 0.0 ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 3
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 241.0, 5.0, 5.0 ]
+					m_angOffset = [ 0.0, 0.0, 0.0 ]
+					m_entityName = "self"
+				},
+			]
+		},
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ 0.0, 0.0, 0.0 ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 1
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ 0.0, 0.0, 0.0 ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 2
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ 0.0, 0.0, 0.0 ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 3
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 229.0, 187.0, 94.0 ]
+					m_angOffset = [ 0.0, 0.0, 0.0 ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RemapCPtoVector"
+		},
+	]
+}

--- a/content/particles/capture_point_ring/capture_point_ring_b.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_b.vpcf
@@ -2,7 +2,7 @@
 {
 	_class = "CParticleSystemDefinition"
 	m_bShouldHitboxesFallbackToRenderBounds = false
-	m_nMaxParticles = 16
+	m_nMaxParticles = 40
 	m_ConstantColor = [ 229, 187, 94, 55 ]
 	m_Renderers = 
 	[
@@ -67,6 +67,17 @@
 			m_flStartFadeOutTime = 0.2
 			m_flEndFadeOutTime = 0.4
 		},
+		{
+			_class = "C_OP_AlphaDecay"
+			m_nOpEndCapState = 1
+		},
+		{
+			_class = "C_OP_RampScalarLinearSimple"
+			m_Rate = -10.0
+			m_flEndTime = 999999999999999967336168804116691273849533185806555472917961779471295845921727862608739868455469056.0
+			m_nField = 16
+			m_nOpEndCapState = 1
+		},
 	]
 	m_Initializers = 
 	[
@@ -80,10 +91,10 @@
 		},
 		{
 			_class = "C_INIT_RingWave"
-			m_nControlPointNumber = 2
-			m_flInitialRadius = 256.0
+			m_flInitialRadius = 1.0
 			m_bEvenDistribution = true
 			m_flParticlesPerOrbit = 16.0
+			m_nOverrideCP = 9
 		},
 		{
 			_class = "C_INIT_PositionOffset"
@@ -115,7 +126,8 @@
 	m_Emitters = 
 	[
 		{
-			_class = "C_OP_MaintainEmitter"
+			_class = "C_OP_ContinuousEmitter"
+			m_flEmitRate = 16.0
 		},
 	]
 	m_controlPointConfigurations = 

--- a/content/particles/capture_point_ring/capture_point_ring_b.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_b.vpcf
@@ -72,10 +72,10 @@
 			m_nOpEndCapState = 1
 		},
 		{
-			_class = "C_OP_RampScalarLinearSimple"
-			m_Rate = -10.0
-			m_flEndTime = 999999999999999967336168804116691273849533185806555472917961779471295845921727862608739868455469056.0
-			m_nField = 16
+			_class = "C_OP_LerpEndCapScalar"
+			m_nFieldOutput = 7
+			m_flOutput = 0.0
+			m_flLerpTime = 0.1
 			m_nOpEndCapState = 1
 		},
 	]

--- a/content/particles/capture_point_ring/capture_point_ring_b.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_b.vpcf
@@ -1,0 +1,143 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 16
+	m_ConstantColor = [ 229, 187, 94, 55 ]
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_flAddSelfAmount = 2.0
+			m_bAdditive = true
+			m_hTexture = resource:"materials/particle/particle_flares/particle_flare_010.vtex"
+		},
+		{
+			_class = "C_OP_RenderDeferredLight"
+			m_flRadiusScale = 10.0
+			m_flAlphaScale = 5.0
+			m_ColorScale = [ 255, 255, 255 ]
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_BasicMovement"
+			m_fDrag = 0.1
+			m_Gravity = [ 0.0, 0.0, -250.0 ]
+		},
+		{
+			_class = "C_OP_FadeInSimple"
+			m_flFadeInTime = 0.05
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_nOpEndCapState = 0
+			m_flEndScale = 2.0
+			m_flStartScale = 1.5
+		},
+		{
+			_class = "C_OP_OscillateScalar"
+			m_FrequencyMax = 16.0
+			m_FrequencyMin = 3.0
+			m_RateMax = -5.0
+			m_RateMin = -3.0
+			m_nField = 16
+		},
+		{
+			_class = "C_OP_MoveToHitbox"
+			m_nControlPointNumber = 1
+			m_flLifeTimeLerpEnd = 0.1
+		},
+		{
+			_class = "C_OP_SetSingleControlPointPosition"
+			m_vecCP1Pos = [ 0.0, 0.0, 0.0 ]
+			m_nCP1 = 2
+		},
+		{
+			_class = "C_OP_LockToBone"
+			m_nControlPointNumber = 1
+			m_flOpEndFadeInTime = 0.05
+			m_flOpStartFadeInTime = 0.05
+		},
+		{
+			_class = "C_OP_FadeAndKill"
+			m_flStartAlpha = 0.0
+			m_flEndFadeInTime = 0.2
+			m_flStartFadeOutTime = 0.2
+			m_flEndFadeOutTime = 0.4
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMax = 2.0
+			m_fLifetimeMin = 2.0
+		},
+		{
+			_class = "C_INIT_RandomRotation"
+		},
+		{
+			_class = "C_INIT_RingWave"
+			m_nControlPointNumber = 2
+			m_flInitialRadius = 256.0
+			m_bEvenDistribution = true
+			m_flParticlesPerOrbit = 16.0
+		},
+		{
+			_class = "C_INIT_PositionOffset"
+			m_OffsetMin = [ 10.0, 10.0, 10.0 ]
+			m_OffsetMax = [ -10.0, -10.0, -10.0 ]
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMin = 15.0
+			m_flRadiusMax = 8.0
+		},
+		{
+			_class = "C_INIT_RandomAlpha"
+		},
+		{
+			_class = "C_INIT_InitialVelocityNoise"
+			m_vecOutputMin = [ 0.0, 0.0, 100.0 ]
+			m_vecOutputMax = [ 1.0, 1.0, 500.0 ]
+			m_flNoiseScaleLoc = 0.1
+		},
+		{
+			_class = "C_INIT_RemapCPtoVector"
+			m_nCPInput = 3
+			m_nFieldOutput = 6
+			m_vInputMax = [ 255.0, 255.0, 255.0 ]
+			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_MaintainEmitter"
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 2
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/particles/capture_point_ring/capture_point_ring_c.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_c.vpcf
@@ -55,10 +55,10 @@
 			m_nOpEndCapState = 1
 		},
 		{
-			_class = "C_OP_RampScalarLinearSimple"
-			m_Rate = -10.0
-			m_flEndTime = 999999999999999967336168804116691273849533185806555472917961779471295845921727862608739868455469056.0
-			m_nField = 16
+			_class = "C_OP_LerpEndCapScalar"
+			m_nFieldOutput = 7
+			m_flOutput = 0.0
+			m_flLerpTime = 0.1
 			m_nOpEndCapState = 1
 		},
 	]

--- a/content/particles/capture_point_ring/capture_point_ring_c.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_c.vpcf
@@ -1,0 +1,128 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 64
+	m_ConstantColor = [ 229, 187, 94, 55 ]
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_bAdditive = true
+			m_hTexture = resource:"materials/particle/blueflare1.vtex"
+			m_flAddSelfAmount = 2.0
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_BasicMovement"
+			m_fDrag = 0.1
+			m_Gravity = [ 0.0, 0.0, -250.0 ]
+		},
+		{
+			_class = "C_OP_FadeInSimple"
+			m_flFadeInTime = 0.05
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_nOpEndCapState = 0
+			m_flStartScale = 2.0
+		},
+		{
+			_class = "C_OP_OscillateScalar"
+			m_FrequencyMax = 16.0
+			m_FrequencyMin = 3.0
+			m_RateMax = -5.0
+			m_RateMin = -3.0
+			m_nField = 16
+		},
+		{
+			_class = "C_OP_LockToBone"
+			m_nControlPointNumber = 1
+			m_flOpEndFadeInTime = 0.05
+			m_flOpStartFadeInTime = 0.05
+		},
+		{
+			_class = "C_OP_FadeAndKill"
+			m_flStartAlpha = 0.0
+			m_flEndFadeInTime = 0.2
+			m_flStartFadeOutTime = 0.2
+			m_flEndFadeOutTime = 0.8
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMax = 2.0
+			m_fLifetimeMin = 2.0
+		},
+		{
+			_class = "C_INIT_RandomRotation"
+		},
+		{
+			_class = "C_INIT_RingWave"
+			m_nControlPointNumber = 2
+			m_flInitialRadius = 256.0
+			m_bEvenDistribution = true
+			m_flParticlesPerOrbit = 64.0
+		},
+		{
+			_class = "C_INIT_PositionOffset"
+			m_OffsetMin = [ 10.0, 10.0, 10.0 ]
+			m_OffsetMax = [ -10.0, -10.0, -10.0 ]
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMin = 20.0
+			m_flRadiusMax = 4.0
+		},
+		{
+			_class = "C_INIT_RandomAlpha"
+			m_nAlphaMin = 55
+		},
+		{
+			_class = "C_INIT_InitialVelocityNoise"
+			m_vecOutputMin = [ 0.0, 0.0, 100.0 ]
+			m_vecOutputMax = [ 1.0, 1.0, 500.0 ]
+			m_flNoiseScaleLoc = 0.1
+		},
+		{
+			_class = "C_INIT_RemapCPtoVector"
+			m_nCPInput = 3
+			m_nFieldOutput = 6
+			m_vInputMax = [ 255.0, 255.0, 255.0 ]
+			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_MaintainEmitter"
+			m_nParticlesToMaintain = 64
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 2
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/particles/capture_point_ring/capture_point_ring_c.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_c.vpcf
@@ -2,7 +2,7 @@
 {
 	_class = "CParticleSystemDefinition"
 	m_bShouldHitboxesFallbackToRenderBounds = false
-	m_nMaxParticles = 64
+	m_nMaxParticles = 150
 	m_ConstantColor = [ 229, 187, 94, 55 ]
 	m_Renderers = 
 	[
@@ -50,6 +50,17 @@
 			m_flStartFadeOutTime = 0.2
 			m_flEndFadeOutTime = 0.8
 		},
+		{
+			_class = "C_OP_AlphaDecay"
+			m_nOpEndCapState = 1
+		},
+		{
+			_class = "C_OP_RampScalarLinearSimple"
+			m_Rate = -10.0
+			m_flEndTime = 999999999999999967336168804116691273849533185806555472917961779471295845921727862608739868455469056.0
+			m_nField = 16
+			m_nOpEndCapState = 1
+		},
 	]
 	m_Initializers = 
 	[
@@ -63,10 +74,10 @@
 		},
 		{
 			_class = "C_INIT_RingWave"
-			m_nControlPointNumber = 2
-			m_flInitialRadius = 256.0
+			m_flInitialRadius = 1.0
 			m_bEvenDistribution = true
 			m_flParticlesPerOrbit = 64.0
+			m_nOverrideCP = 9
 		},
 		{
 			_class = "C_INIT_PositionOffset"
@@ -99,8 +110,8 @@
 	m_Emitters = 
 	[
 		{
-			_class = "C_OP_MaintainEmitter"
-			m_nParticlesToMaintain = 64
+			_class = "C_OP_ContinuousEmitter"
+			m_flEmitRate = 64.0
 		},
 	]
 	m_controlPointConfigurations = 

--- a/content/particles/capture_point_ring/capture_point_ring_capturing.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_capturing.vpcf
@@ -1,0 +1,28 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+	m_Children = 
+	[
+		{
+			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_b.vpcf"
+		},
+		{
+			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_c.vpcf"
+		},
+	]
+}

--- a/content/particles/capture_point_ring/capture_point_ring_clock.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_clock.vpcf
@@ -1,0 +1,126 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 1
+	m_flConstantRadius = 25.0
+	m_ConstantColor = [ 202, 150, 61, 255 ]
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
+			m_bAdditive = true
+			m_flOverbrightFactor = 5.0
+			m_hTexture = resource:"materials/particle/particle_glow_05.vtex"
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_AlphaDecay"
+			m_nOpEndCapState = 1
+		},
+		{
+			_class = "C_OP_PositionLock"
+			m_nControlPointNumber = 1
+			m_bLockRot = true
+		},
+		{
+			_class = "C_OP_FadeIn"
+			m_bProportional = false
+			m_flFadeInTimeMin = 0.5
+			m_flFadeInTimeMax = 0.5
+		},
+		{
+			_class = "C_OP_SetControlPointsToParticle"
+			m_nFirstControlPoint = 14
+		},
+		{
+			_class = "C_OP_RampScalarLinearSimple"
+			m_Rate = -10.0
+			m_flEndTime = 1000000000000001424337837973413494463445963303445735454723091068575936784781035166786953772361842688.0
+			m_nField = 7
+			m_nOpEndCapState = 1
+		},
+		{
+			_class = "C_OP_RemapCPtoVector"
+			m_nCPInput = 3
+			m_nFieldOutput = 6
+			m_vInputMax = [ 255.0, 255.0, 255.0 ]
+			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+		},
+		{
+			_class = "C_OP_MovementRotateParticleAroundAxis"
+			m_flRotRate = 72.0
+			m_bDisableOperator = true
+		},
+		{
+			_class = "C_OP_SetSingleControlPointPosition"
+			m_vecCP1Pos = [ 0.0, 0.0, 100.0 ]
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RingWave"
+			m_nControlPointNumber = 1
+			m_flInitialRadius = 0.9
+			m_bEvenDistribution = true
+			m_nOverrideCP = 9
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_InstantaneousEmitter"
+			m_nParticlesToEmit = 1
+		},
+	]
+	m_Children = 
+	[
+		{
+			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_hand.vpcf"
+		},
+		{
+			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_dial_glow.vpcf"
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iControlPoint = 1
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 9
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 1.0, 1.0, 1.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 11
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 1.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 14
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/particles/capture_point_ring/capture_point_ring_clock.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_clock.vpcf
@@ -37,10 +37,10 @@
 			m_nFirstControlPoint = 14
 		},
 		{
-			_class = "C_OP_RampScalarLinearSimple"
-			m_Rate = -10.0
-			m_flEndTime = 1000000000000001424337837973413494463445963303445735454723091068575936784781035166786953772361842688.0
-			m_nField = 7
+			_class = "C_OP_LerpEndCapScalar"
+			m_nFieldOutput = 7
+			m_flOutput = 0.0
+			m_flLerpTime = 0.1
 			m_nOpEndCapState = 1
 		},
 		{

--- a/content/particles/capture_point_ring/capture_point_ring_dial_glow.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_dial_glow.vpcf
@@ -1,0 +1,107 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 720
+	m_flConstantRadius = 50.0
+	m_flConstantLifespan = 3.0
+	m_ConstantColor = [ 165, 98, 37, 50 ]
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
+			m_bAdditive = true
+			m_flOverbrightFactor = 5.0
+			m_hTexture = resource:"materials/particle/particle_glow_05.vtex"
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_PositionLock"
+			m_nControlPointNumber = 1
+			m_bDisableOperator = true
+		},
+		{
+			_class = "C_OP_FadeIn"
+			m_bProportional = false
+		},
+		{
+			_class = "C_OP_AlphaDecay"
+		},
+		{
+			_class = "C_OP_RampScalarLinearSimple"
+			m_Rate = -2.0
+			m_flEndTime = 999999999999999967336168804116691273849533185806555472917961779471295845921727862608739868455469056.0
+			m_nField = 7
+			m_nOpEndCapState = 1
+		},
+		{
+			_class = "C_OP_DistanceToCP"
+			m_nFieldOutput = 16
+			m_flInputMin = 4.0
+			m_flInputMax = 10.0
+			m_nStartCP = 14
+			m_bScaleCurrent = true
+		},
+		{
+			_class = "C_OP_RemapCPtoVector"
+			m_nCPInput = 3
+			m_nFieldOutput = 6
+			m_vInputMax = [ 255.0, 255.0, 255.0 ]
+			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RingWave"
+			m_flParticlesPerOrbit = 720.0
+			m_nControlPointNumber = 1
+			m_flInitialRadius = 0.9
+			m_flRoll = 180.0
+			m_bEvenDistribution = true
+			m_nOverrideCP = 9
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_InstantaneousEmitter"
+			m_nParticlesToEmit = 720
+			m_nScaleControlPoint = 11
+			m_nScaleControlPointField = 2
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iControlPoint = 1
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 9
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 1.0, 1.0, 1.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 11
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 1.0, 0.0, 1.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/particles/capture_point_ring/capture_point_ring_dial_glow.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_dial_glow.vpcf
@@ -31,10 +31,10 @@
 			_class = "C_OP_AlphaDecay"
 		},
 		{
-			_class = "C_OP_RampScalarLinearSimple"
-			m_Rate = -2.0
-			m_flEndTime = 999999999999999967336168804116691273849533185806555472917961779471295845921727862608739868455469056.0
-			m_nField = 7
+			_class = "C_OP_LerpEndCapScalar"
+			m_nFieldOutput = 7
+			m_flOutput = 0.0
+			m_flLerpTime = 0.1
 			m_nOpEndCapState = 1
 		},
 		{

--- a/content/particles/capture_point_ring/capture_point_ring_e.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_e.vpcf
@@ -50,10 +50,10 @@
 			m_nOpEndCapState = 1
 		},
 		{
-			_class = "C_OP_RampScalarLinearSimple"
-			m_Rate = -10.0
-			m_flEndTime = 1000000000000001424337837973413494463445963303445735454723091068575936784781035166786953772361842688.0
-			m_nField = 16
+			_class = "C_OP_LerpEndCapScalar"
+			m_nFieldOutput = 7
+			m_flOutput = 0.0
+			m_flLerpTime = 0.1
 			m_nOpEndCapState = 1
 		},
 	]

--- a/content/particles/capture_point_ring/capture_point_ring_e.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_e.vpcf
@@ -11,7 +11,6 @@
 			_class = "C_OP_RenderSprites"
 			VisibilityInputs = 
 			{
-				m_nCPin = 0
 				m_flProxyRadius = 8.0
 			}
 			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
@@ -53,7 +52,7 @@
 		{
 			_class = "C_OP_RampScalarLinearSimple"
 			m_Rate = -10.0
-			m_flEndTime = 1000000000000000695837003388765092868647748244626145463820526424023616315351381514697846820408655872.0
+			m_flEndTime = 1000000000000001424337837973413494463445963303445735454723091068575936784781035166786953772361842688.0
 			m_nField = 16
 			m_nOpEndCapState = 1
 		},

--- a/content/particles/capture_point_ring/capture_point_ring_e.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_e.vpcf
@@ -2,7 +2,7 @@
 {
 	_class = "CParticleSystemDefinition"
 	m_bShouldHitboxesFallbackToRenderBounds = false
-	m_nMaxParticles = 10
+	m_nMaxParticles = 40
 	m_flConstantRadius = 15.0
 	m_ConstantColor = [ 83, 165, 128, 255 ]
 	m_Renderers = 
@@ -46,6 +46,17 @@
 		{
 			_class = "C_OP_FadeInSimple"
 		},
+		{
+			_class = "C_OP_AlphaDecay"
+			m_nOpEndCapState = 1
+		},
+		{
+			_class = "C_OP_RampScalarLinearSimple"
+			m_Rate = -10.0
+			m_flEndTime = 1000000000000000695837003388765092868647748244626145463820526424023616315351381514697846820408655872.0
+			m_nField = 16
+			m_nOpEndCapState = 1
+		},
 	]
 	m_Initializers = 
 	[
@@ -65,11 +76,6 @@
 			m_ColorMin = [ 229, 187, 94, 255 ]
 		},
 		{
-			_class = "C_INIT_RandomRadius"
-			m_flRadiusMax = 300.0
-			m_flRadiusMin = 300.0
-		},
-		{
 			_class = "C_INIT_RandomAlpha"
 		},
 		{
@@ -78,12 +84,24 @@
 			m_LocalCoordinateSystemSpeedMin = [ 0.0, 0.0, 150.0 ]
 		},
 		{
+			_class = "C_INIT_RemapCPtoScalar"
+			m_nCPInput = 9
+			m_flInputMax = 1000.0
+			m_flOutputMax = 1000.0
+		},
+		{
+			_class = "C_INIT_RemapCPtoVector"
+			m_nCPInput = 3
+			m_nFieldOutput = 6
+			m_vInputMax = [ 255.0, 255.0, 255.0 ]
+			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+		},
+		{
 			_class = "C_INIT_CreateSequentialPath"
 			m_flNumToAssign = 10.0
 			m_PathParams = 
 			{
 				m_nEndControlPointNumber = 2
-				m_nStartControlPointNumber = 1
 			}
 			m_bSaveOffset = true
 		},
@@ -101,19 +119,19 @@
 			m_nFieldOutput = 4
 			m_nInputMax = 100
 			m_flOutputMax = 360.0
+			m_bDisableOperator = true
 		},
 		{
-			_class = "C_INIT_RemapCPtoVector"
-			m_nCPInput = 3
-			m_nFieldOutput = 6
-			m_vInputMax = [ 255.0, 255.0, 255.0 ]
-			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+			_class = "C_INIT_RandomScalar"
+			m_flMax = 360.0
+			m_nFieldOutput = 4
 		},
 	]
 	m_Emitters = 
 	[
 		{
-			_class = "C_OP_MaintainEmitter"
+			_class = "C_OP_ContinuousEmitter"
+			m_flEmitRate = 12.0
 		},
 	]
 	m_nInitialParticles = 1

--- a/content/particles/capture_point_ring/capture_point_ring_e.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_e.vpcf
@@ -1,0 +1,149 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 10
+	m_flConstantRadius = 15.0
+	m_ConstantColor = [ 83, 165, 128, 255 ]
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			VisibilityInputs = 
+			{
+				m_nCPin = 0
+				m_flProxyRadius = 8.0
+			}
+			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
+			m_bAdditive = true
+			m_hTexture = resource:"materials/particle/particle_heroring_6_crisp.vtex"
+			m_nOrientationType = 2
+			m_flAddSelfAmount = 1.0
+		},
+		{
+			_class = "C_OP_RenderDeferredLight"
+			m_flAlphaScale = 5.0
+			m_flSpotFoV = 90.0
+			m_ColorScale = [ 255, 255, 255 ]
+			m_nAlphaTestRangeField = 3
+			m_hTexture = resource:"materials/particle/groundcracks_light_2.vtex"
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_Decay"
+		},
+		{
+			_class = "C_OP_FadeOut"
+			m_flFadeOutTimeMax = 0.75
+			m_flFadeOutTimeMin = 0.5
+		},
+		{
+			_class = "C_OP_BasicMovement"
+			m_fDrag = 0.1
+		},
+		{
+			_class = "C_OP_FadeInSimple"
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMax = 2.0
+			m_fLifetimeMin = 2.0
+		},
+		{
+			_class = "C_INIT_RandomSequence"
+			m_nSequenceMax = 5
+			m_nSequenceMin = 4
+		},
+		{
+			_class = "C_INIT_RandomColor"
+			m_ColorMax = [ 170, 138, 70, 255 ]
+			m_ColorMin = [ 229, 187, 94, 255 ]
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMax = 300.0
+			m_flRadiusMin = 300.0
+		},
+		{
+			_class = "C_INIT_RandomAlpha"
+		},
+		{
+			_class = "C_INIT_VelocityRandom"
+			m_LocalCoordinateSystemSpeedMax = [ 0.0, 0.0, 150.0 ]
+			m_LocalCoordinateSystemSpeedMin = [ 0.0, 0.0, 150.0 ]
+		},
+		{
+			_class = "C_INIT_CreateSequentialPath"
+			m_flNumToAssign = 10.0
+			m_PathParams = 
+			{
+				m_nEndControlPointNumber = 2
+				m_nStartControlPointNumber = 1
+			}
+			m_bSaveOffset = true
+		},
+		{
+			_class = "C_INIT_DistanceToCPInit"
+			m_nFieldOutput = 16
+			m_flInputMax = 10.0
+			m_flOutputMin = 1.0
+			m_flOutputMax = 0.25
+			m_nStartCP = 2
+			m_bScaleInitialRange = true
+		},
+		{
+			_class = "C_INIT_RemapParticleCountToScalar"
+			m_nFieldOutput = 4
+			m_nInputMax = 100
+			m_flOutputMax = 360.0
+		},
+		{
+			_class = "C_INIT_RemapCPtoVector"
+			m_nCPInput = 3
+			m_nFieldOutput = 6
+			m_vInputMax = [ 255.0, 255.0, 255.0 ]
+			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_MaintainEmitter"
+		},
+	]
+	m_nInitialParticles = 1
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 1
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 2
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/particles/capture_point_ring/capture_point_ring_endcap.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_endcap.vpcf
@@ -1,0 +1,128 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 128
+	m_flCullRadius = 80.0
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderTrails"
+			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
+			m_flOverbrightFactor = 6.0
+			m_flAddSelfAmount = 2.0
+			m_bSaturateColorPreAlphaBlend = false
+			m_hTexture = resource:"materials/particle/sparks/sparks.vtex"
+			m_bIgnoreDT = true
+			m_flLengthFadeInTime = 0.25
+			m_flRadiusScale = 0.5
+			m_flFinalTextureScaleV = -1.0
+			m_flFinalTextureOffsetV = 1.0
+			m_vEndTrailTintFactor = [ 1.0, 1.0, 1.0, 0.0 ]
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_Decay"
+		},
+		{
+			_class = "C_OP_FadeOutSimple"
+			m_flFadeOutTime = 0.5
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_flBias = 0.7
+			m_flEndScale = 0.0
+			m_flStartScale = 20.0
+		},
+		{
+			_class = "C_OP_ColorInterpolate"
+			m_ColorFade = [ 255, 130, 29, 255 ]
+			m_bDisableOperator = true
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomAlpha"
+			m_nAlphaMax = 100
+			m_nAlphaMin = 50
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMax = 10.0
+			m_flRadiusMin = 5.0
+		},
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMin = 0.3
+			m_fLifetimeMax = 0.3
+		},
+		{
+			_class = "C_INIT_RingWave"
+			m_flInitialRadius = 0.9
+			m_nOverrideCP = 9
+		},
+		{
+			_class = "C_INIT_RandomRotation"
+			m_bRandomlyFlipDirection = false
+			m_flDegreesMax = 0.0
+			m_flDegrees = 90.0
+		},
+		{
+			_class = "C_INIT_RandomColor"
+			m_ColorMax = [ 255, 243, 186, 255 ]
+			m_ColorMin = [ 255, 199, 109, 255 ]
+		},
+		{
+			_class = "C_INIT_OffsetVectorToVector"
+			m_vecOutputMax = [ 0.0, 0.0, 1000.0 ]
+			m_vecOutputMin = [ 0.0, 0.0, 500.0 ]
+			m_nFieldOutput = 2
+		},
+		{
+			_class = "C_INIT_RandomTrailLength"
+			m_flMaxLength = 0.5
+			m_flMinLength = 0.25
+			m_flLengthRandExponent = 0.5
+		},
+		{
+			_class = "C_INIT_RemapCPtoVector"
+			m_nCPInput = 3
+			m_nFieldOutput = 6
+			m_vInputMax = [ 255.0, 255.0, 255.0 ]
+			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_InstantaneousEmitter"
+		},
+	]
+	m_Children = 
+	[
+		{
+			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_endcap_burst.vpcf"
+		},
+		{
+			m_ChildRef = resource:"particles/capture_point_ring/capture_point_ring_endcap_flare.vpcf"
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/particles/capture_point_ring/capture_point_ring_endcap_burst.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_endcap_burst.vpcf
@@ -1,0 +1,134 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 300
+	m_flConstantRadius = 3.0
+	m_flConstantLifespan = 600.0
+	m_ConstantColor = [ 255, 208, 82, 255 ]
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
+			m_bAdditive = true
+			m_flOverbrightFactor = 10.0
+			m_hTexture = resource:"materials/particle/yellowflare2.vtex"
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_FadeInSimple"
+			m_flFadeInTime = 0.001
+		},
+		{
+			_class = "C_OP_Decay"
+		},
+		{
+			_class = "C_OP_PositionLock"
+		},
+		{
+			_class = "C_OP_BasicMovement"
+			m_fDrag = 0.05
+			m_Gravity = [ 0.0, 0.0, -150.0 ]
+		},
+		{
+			_class = "C_OP_SpinUpdate"
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_flBias = 0.9
+			m_flStartScale = 3.0
+			m_flEndScale = 0.1
+		},
+		{
+			_class = "C_OP_VectorNoise"
+			m_bAdditive = true
+			m_vecOutputMax = [ 5.0, 5.0, 4.0 ]
+			m_vecOutputMin = [ -5.0, -5.0, -5.0 ]
+			m_nFieldOutput = 0
+			m_fl4NoiseScale = 0.3
+		},
+		{
+			_class = "C_OP_ColorInterpolate"
+			m_ColorFade = [ 215, 106, 0, 255 ]
+			m_bDisableOperator = true
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RingWave"
+			m_flInitialRadius = 0.9
+			m_flRoll = 180.0
+			m_bEvenDistribution = true
+			m_flParticlesPerOrbit = 300.0
+			m_nOverrideCP = 9
+		},
+		{
+			_class = "C_INIT_PositionOffset"
+			m_OffsetMax = [ 0.0, 0.0, 20.0 ]
+			m_OffsetMin = [ 0.0, 0.0, 20.0 ]
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMax = 10.0
+			m_flRadiusMin = 5.0
+		},
+		{
+			_class = "C_INIT_RandomRotation"
+		},
+		{
+			_class = "C_INIT_RandomRotationSpeed"
+			m_flDegreesMax = 60.0
+			m_flDegreesMin = 30.0
+		},
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMax = 1.75
+			m_fLifetimeMin = 1.5
+		},
+		{
+			_class = "C_INIT_InitialVelocityNoise"
+			m_vecOutputMax = [ 10.0, 10.0, 750.0 ]
+			m_vecOutputMin = [ -10.0, -10.0, 250.0 ]
+			m_flNoiseScaleLoc = 0.45
+		},
+		{
+			_class = "C_INIT_RandomColor"
+			m_ColorMax = [ 255, 211, 153, 255 ]
+			m_ColorMin = [ 255, 238, 202, 255 ]
+		},
+		{
+			_class = "C_INIT_RemapCPtoVector"
+			m_nCPInput = 3
+			m_nFieldOutput = 6
+			m_vInputMax = [ 255.0, 255.0, 255.0 ]
+			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_ContinuousEmitter"
+			m_flEmissionDuration = 0.5
+			m_flEmitRate = 2000.0
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/particles/capture_point_ring/capture_point_ring_endcap_flare.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_endcap_flare.vpcf
@@ -1,0 +1,102 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 16
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
+			m_bAdditive = true
+			m_bDisableZBuffering = true
+			m_hTexture = resource:"materials/particle/particle_flares/aircraft_white_v2.vtex"
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_Decay"
+		},
+		{
+			_class = "C_OP_FadeOutSimple"
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_flStartScale = 4.0
+			m_flEndScale = 0.0
+			m_flBias = 0.2
+		},
+		{
+			_class = "C_OP_ColorInterpolate"
+			m_ColorFade = [ 255, 130, 29, 255 ]
+			m_bDisableOperator = true
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomAlpha"
+			m_nAlphaMin = 150
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMin = 50.0
+			m_flRadiusMax = 100.0
+		},
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMax = 0.4
+			m_fLifetimeMin = 0.3
+		},
+		{
+			_class = "C_INIT_RingWave"
+			m_flInitialRadius = 30.0
+		},
+		{
+			_class = "C_INIT_RandomRotation"
+			m_flDegrees = 90.0
+			m_flDegreesMax = 0.0
+			m_bRandomlyFlipDirection = false
+		},
+		{
+			_class = "C_INIT_RandomColor"
+			m_ColorMin = [ 255, 199, 109, 255 ]
+			m_ColorMax = [ 255, 243, 186, 255 ]
+		},
+		{
+			_class = "C_INIT_PositionOffset"
+			m_OffsetMax = [ 0.0, 0.0, 200.0 ]
+			m_OffsetMin = [ 0.0, 0.0, 50.0 ]
+		},
+		{
+			_class = "C_INIT_RemapCPtoVector"
+			m_nCPInput = 3
+			m_nFieldOutput = 6
+			m_vInputMax = [ 255.0, 255.0, 255.0 ]
+			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_InstantaneousEmitter"
+			m_nParticlesToEmit = 10
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/particles/capture_point_ring/capture_point_ring_hand.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_hand.vpcf
@@ -53,10 +53,10 @@
 			}
 		},
 		{
-			_class = "C_OP_RampScalarLinearSimple"
-			m_Rate = -10.0
-			m_flEndTime = 1000000000000000695837003388765092868647748244626145463820526424023616315351381514697846820408655872.0
-			m_nField = 7
+			_class = "C_OP_LerpEndCapScalar"
+			m_nFieldOutput = 7
+			m_flOutput = 0.0
+			m_flLerpTime = 0.1
 			m_nOpEndCapState = 1
 		},
 		{

--- a/content/particles/capture_point_ring/capture_point_ring_hand.vpcf
+++ b/content/particles/capture_point_ring/capture_point_ring_hand.vpcf
@@ -1,0 +1,121 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 500
+	m_flConstantRadius = 40.0
+	m_flConstantLifespan = 1.5
+	m_ConstantColor = [ 149, 104, 26, 200 ]
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
+			m_bAdditive = true
+			m_flOverbrightFactor = 5.0
+			m_hTexture = resource:"materials/particle/particle_glow_05.vtex"
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_AlphaDecay"
+		},
+		{
+			_class = "C_OP_PositionLock"
+			m_nControlPointNumber = 1
+		},
+		{
+			_class = "C_OP_FadeIn"
+			m_bProportional = false
+			m_flFadeInTimeMin = 0.5
+			m_flFadeInTimeMax = 0.5
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_flStartScale = 0.2
+			m_flEndScale = 0.0
+		},
+		{
+			_class = "C_OP_DistanceToCP"
+			m_flInputMax = 120.0
+			m_flOutputMin = 0.25
+			m_nStartCP = 14
+			m_bScaleInitialRange = true
+		},
+		{
+			_class = "C_OP_MaintainSequentialPath"
+			m_flNumToAssign = 40.0
+			m_PathParams = 
+			{
+				m_nEndControlPointNumber = 14
+				m_nStartControlPointNumber = 1
+			}
+		},
+		{
+			_class = "C_OP_RampScalarLinearSimple"
+			m_Rate = -10.0
+			m_flEndTime = 1000000000000000695837003388765092868647748244626145463820526424023616315351381514697846820408655872.0
+			m_nField = 7
+			m_nOpEndCapState = 1
+		},
+		{
+			_class = "C_OP_RemapCPtoVector"
+			m_nCPInput = 3
+			m_nFieldOutput = 6
+			m_vInputMax = [ 255.0, 255.0, 255.0 ]
+			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_CreateSequentialPath"
+			m_flNumToAssign = 40.0
+			m_bLoop = false
+			m_PathParams = 
+			{
+				m_nStartControlPointNumber = 1
+				m_nEndControlPointNumber = 14
+				m_flMidPoint = 0.1
+			}
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_InstantaneousEmitter"
+			m_nParticlesToEmit = 40
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iControlPoint = 1
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 11
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 1.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 14
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/game/scripts/vscripts/addon_game_mode.lua
+++ b/game/scripts/vscripts/addon_game_mode.lua
@@ -17,6 +17,7 @@ require('internal/eventwrapper')
 
 require('internal/util')
 require('gamemode')
+require('precache')
 -- DotaStats
 require("statcollection/init")
 
@@ -33,47 +34,29 @@ function Precache( context )
 
   DebugPrint("[BAREBONES] Performing pre-load precache")
 
-  PrecacheItemByNameSync("item_postactive", context)
-  PrecacheItemByNameSync("item_preemptive_3c", context)
-  PrecacheItemByNameSync("item_stoneskin", context)
-  PrecacheItemByNameSync("item_greater_phase_boots", context)
-  PrecacheItemByNameSync("item_greater_power_treads", context)
-  PrecacheItemByNameSync("item_greater_tranquil_boots", context)
-  PrecacheItemByNameSync("item_dagon", context)
-  PrecacheItemByNameSync("item_manta_1", context)
+  for _,Item in pairs( g_ItemPrecache ) do
+    PrecacheItemByNameSync( Item, context )
+  end
 
-  PrecacheUnitByNameSync("npc_dota_visage_familiar", context)
-  PrecacheUnitByNameSync("dota_fountain", context)
-  PrecacheUnitByNameSync("npc_dota_boss_shielder", context)
-  PrecacheUnitByNameSync("npc_dota_boss_charger", context)
-  PrecacheUnitByNameSync("npc_dota_boss_charger_pillar", context)
-  PrecacheUnitByNameSync("npc_dota_boss_simple_1", context)
-  PrecacheUnitByNameSync("npc_dota_boss_simple_2", context)
-  PrecacheUnitByNameSync("npc_dota_boss_simple_3", context)
-  PrecacheUnitByNameSync("npc_dota_boss_simple_5", context)
-  PrecacheUnitByNameSync("npc_dota_boss_simple_6", context)
-  PrecacheUnitByNameSync("npc_dota_boss_simple_7", context)
-  PrecacheUnitByNameSync("npc_dota_boss_stopfightingyourself", context)
+   for _,Unit in pairs( g_UnitPrecache ) do
+    PrecacheUnitByNameAsync( Unit, function( unit ) end )
+  end
 
-  PrecacheUnitByNameSync("npc_dota_creature_ogre_tank_boss", context)
-  PrecacheUnitByNameSync("npc_dota_creature_ogre_seer", context)
-  -- Needed for kill event on Ogre Boss
-  PrecacheResource("soundfile", "soundevents/game_sounds_heroes/game_sounds_phantom_assassin.vsndevts", context)
+   for _,Model in pairs( g_ModelPrecache ) do
+    PrecacheResource( "model", Model, context  )
+  end
 
-  PrecacheUnitByNameSync("npc_dota_creature_lycan_boss", context)
-  PrecacheUnitByNameSync("npc_dota_creature_dire_hound", context)
-  PrecacheUnitByNameSync("npc_dota_creature_dire_hound_boss", context)
-  PrecacheUnitByNameSync("npc_dota_creature_werewolf", context)
+  for _,Particle in pairs( g_ParticlePrecache ) do
+    PrecacheResource( "particle", Particle, context  )
+  end
 
-  -- Needed for Lycan Boss Wolf transformation
-  PrecacheUnitByNameSync("npc_dota_hero_bloodseeker", context)
+  for _,ParticleFolder in pairs( g_ParticleFolderPrecache ) do
+    PrecacheResource( "particle_folder", ParticleFolder, context )
+  end
 
-  -- Ambient Sounds
-  PrecacheResource("soundfile", "soundevents/ambient/doors.vsndevts", context)
-  PrecacheResource("soundfile", "soundevents/music/music.vsndevts", context)
-
-  PrecacheResource("soundfile", "soundevents/game_sounds_creeps.vsndevts", context)
-  PrecacheResource("soundfile", "soundevents/bosses/game_sounds_dungeon_enemies.vsndevts", context)
+  for _,Sound in pairs( g_SoundPrecache ) do
+    PrecacheResource( "soundfile", Sound, context )
+  end
 
   -- precache all hero econ folders
   -- this makes immortals and stuff work

--- a/game/scripts/vscripts/components/boss/ai.lua
+++ b/game/scripts/vscripts/components/boss/ai.lua
@@ -78,22 +78,9 @@ function BossAI:GiveItemToWholeTeam (item, teamId)
   end
 end
 
-function BossAI:DeathHandler (state, keys)
-  DebugPrint('Handling death of boss ' .. state.tier)
-  state.state = BossAI.DEAD
+function BossAI:RewardBossKill(teamId, tier)
 
-  CreateModifierThinker(state.handle, nil, "modifier_boss_capture_point", {}, state.origin, state.handle:GetTeamNumber(), false)
-
-  state.handle = nil
-  local killer = EntIndexToHScript(keys.entindex_attacker)
-  local teamId = killer:GetTeam()
   local team = nil
-
-  state.deathEvent.broadcast(keys)
-
-  if state.isProtected then
-    teamId = state.owner
-  end
   if teamId == 2 then
     team = 'good'
   elseif teamId == 3 then
@@ -114,7 +101,7 @@ function BossAI:DeathHandler (state, keys)
   print(bossKills[tostring(teamId)])
   CustomNetTables:SetTableValue("stat_display_team", "BK", { value = bossKills })
 
-  if state.tier == 1 then
+  if tier == 1 then
     BossAI:GiveItemToWholeTeam("item_upgrade_core", teamId)
 
     if not BossAI.hasFarmingCore[team] then
@@ -143,26 +130,39 @@ function BossAI:DeathHandler (state, keys)
       end
     end
 
-  elseif state.tier == 2 then
+  elseif tier == 2 then
     -- NGP:GiveItemToTeam(BossItems["item_upgrade_core_2"], team)
     -- NGP:GiveItemToTeam(BossItems["item_upgrade_core"], team)
     BossAI:GiveItemToWholeTeam("item_upgrade_core_2", teamId)
 
-  elseif state.tier == 3 then
+  elseif tier == 3 then
     -- NGP:GiveItemToTeam(BossItems["item_upgrade_core_3"], team)
     BossAI:GiveItemToWholeTeam("item_upgrade_core_3", teamId)
-  elseif state.tier == 4 then
+  elseif tier == 4 then
 
     -- NGP:GiveItemToTeam(BossItems["item_upgrade_core_4"], team)
     BossAI:GiveItemToWholeTeam("item_upgrade_core_4", teamId)
-  elseif state.tier == 5 then
+  elseif tier == 5 then
 
     -- NGP:GiveItemToTeam(BossItems["item_upgrade_core_4"], team)
     BossAI:GiveItemToWholeTeam("item_upgrade_core_4", teamId)
-  elseif state.tier == 6 then
+  elseif tier == 6 then
     -- NGP:GiveItemToTeam(BossItems["item_upgrade_core_4"], team)
     BossAI:GiveItemToWholeTeam("item_upgrade_core_4", teamId)
   end
+end
+
+function BossAI:DeathHandler (state, keys)
+  DebugPrint('Handling death of boss ' .. state.tier)
+  state.state = BossAI.DEAD
+
+  state.deathEvent.broadcast(keys)
+
+  local kv ={ tier = state.tier }
+
+  CreateModifierThinker( state.handle, nil, "modifier_boss_capture_point", kv, state.origin, state.handle:GetTeamNumber(), false)
+
+  state.handle = nil
 end
 
 function BossAI:Agro (state, target)

--- a/game/scripts/vscripts/components/boss/ai.lua
+++ b/game/scripts/vscripts/components/boss/ai.lua
@@ -1,3 +1,4 @@
+LinkLuaModifier("modifier_boss_capture_point", "modifiers/modifier_boss_capture_point.lua", LUA_MODIFIER_MOTION_NONE)
 
 -- Taken from bb template
 if BossAI == nil then
@@ -80,6 +81,8 @@ end
 function BossAI:DeathHandler (state, keys)
   DebugPrint('Handling death of boss ' .. state.tier)
   state.state = BossAI.DEAD
+
+  CreateModifierThinker(state.handle, nil, "modifier_boss_capture_point", {}, state.origin, state.handle:GetTeamNumber(), false)
 
   state.handle = nil
   local killer = EntIndexToHScript(keys.entindex_attacker)

--- a/game/scripts/vscripts/components/boss/ai.lua
+++ b/game/scripts/vscripts/components/boss/ai.lua
@@ -38,10 +38,10 @@ function BossAI:Create (unit, options)
   }
 
   unit:OnHurt(function (keys)
-    BossAI:HurtHandler(state, keys)
+    self:HurtHandler(state, keys)
   end)
   unit:OnDeath(function (keys)
-    BossAI:DeathHandler(state, keys)
+    self:DeathHandler(state, keys)
   end)
 
   unit:SetIdleAcquire(false)
@@ -60,7 +60,7 @@ function BossAI:HurtHandler (state, keys)
     state.currentDamage = state.currentDamage + keys.damage
 
     if state.currentDamage > state.agroDamage then
-      BossAI:Agro(state, EntIndexToHScript(keys.entindex_attacker))
+      self:Agro(state, EntIndexToHScript(keys.entindex_attacker))
       state.currentDamage = 0
     end
   elseif state.state == BossAI.AGRO then --luacheck: ignore
@@ -101,12 +101,12 @@ function BossAI:RewardBossKill(teamId, tier)
   CustomNetTables:SetTableValue("stat_display_team", "BK", { value = bossKills })
 
   if tier == 1 then
-    BossAI:GiveItemToWholeTeam("item_upgrade_core", teamId)
+    self:GiveItemToWholeTeam("item_upgrade_core", teamId)
 
-    if not BossAI.hasFarmingCore[team] then
-      BossAI.hasFarmingCore[team] = true
-    elseif not BossAI.hasReflexCore[team] then
-      BossAI.hasReflexCore[team] = true
+    if not self.hasFarmingCore[team] then
+      self.hasFarmingCore[team] = true
+    elseif not self.hasReflexCore[team] then
+      self.hasReflexCore[team] = true
 
       BossSpawner[team .. "Zone1"].disable()
       BossSpawner[team .. "Zone2"].disable()
@@ -118,10 +118,10 @@ function BossAI:RewardBossKill(teamId, tier)
         local hero = player:GetAssignedHero()
 
         if hero then
-          if BossAI.hasFarmingCore[team] and not hero.hasFarmingCore then
+          if self.hasFarmingCore[team] and not hero.hasFarmingCore then
             hero:AddItemByName("item_farming_core")
             hero.hasFarmingCore = true
-          elseif BossAI.hasReflexCore[team] and not hero.hasReflexCore then
+          elseif self.hasReflexCore[team] and not hero.hasReflexCore then
             hero:AddItemByName("item_reflex_core")
             hero.hasReflexCore = true
           end
@@ -132,22 +132,22 @@ function BossAI:RewardBossKill(teamId, tier)
   elseif tier == 2 then
     -- NGP:GiveItemToTeam(BossItems["item_upgrade_core_2"], team)
     -- NGP:GiveItemToTeam(BossItems["item_upgrade_core"], team)
-    BossAI:GiveItemToWholeTeam("item_upgrade_core_2", teamId)
+    self:GiveItemToWholeTeam("item_upgrade_core_2", teamId)
 
   elseif tier == 3 then
     -- NGP:GiveItemToTeam(BossItems["item_upgrade_core_3"], team)
-    BossAI:GiveItemToWholeTeam("item_upgrade_core_3", teamId)
+    self:GiveItemToWholeTeam("item_upgrade_core_3", teamId)
   elseif tier == 4 then
 
     -- NGP:GiveItemToTeam(BossItems["item_upgrade_core_4"], team)
-    BossAI:GiveItemToWholeTeam("item_upgrade_core_4", teamId)
+    self:GiveItemToWholeTeam("item_upgrade_core_4", teamId)
   elseif tier == 5 then
 
     -- NGP:GiveItemToTeam(BossItems["item_upgrade_core_4"], team)
-    BossAI:GiveItemToWholeTeam("item_upgrade_core_4", teamId)
+    self:GiveItemToWholeTeam("item_upgrade_core_4", teamId)
   elseif tier == 6 then
     -- NGP:GiveItemToTeam(BossItems["item_upgrade_core_4"], team)
-    BossAI:GiveItemToWholeTeam("item_upgrade_core_4", teamId)
+    self:GiveItemToWholeTeam("item_upgrade_core_4", teamId)
   end
 end
 
@@ -175,7 +175,7 @@ function BossAI:Agro (state, target)
       return
     end
 
-    if not BossAI:Think(state) or state.state == BossAI.IDLE then
+    if not self:Think(state) or state.state == BossAI.IDLE then
       DebugPrint('Stopping think timer')
       return
     end
@@ -214,7 +214,7 @@ function BossAI:Think (state)
   DebugPrint(distance)
 
   if distance > state.leash then
-    BossAI:Leash(state)
+    self:Leash(state)
   elseif distance < state.leash / 2 and state.state == BossAI.LEASHING then
     state.state = BossAI.IDLE
     return false

--- a/game/scripts/vscripts/components/boss/ai.lua
+++ b/game/scripts/vscripts/components/boss/ai.lua
@@ -92,13 +92,12 @@ function BossAI:RewardBossKill(teamId, tier)
   PointsManager:AddPoints(teamId)
 
   local bossKills = CustomNetTables:GetTableValue("stat_display_team", "BK").value
-  print(bossKills[tostring(teamId)])
   if bossKills[tostring(teamId)] then
     bossKills[tostring(teamId)] = bossKills[tostring(teamId)] + 1
   else
     bossKills[tostring(teamId)] = 1
   end
-  print(bossKills[tostring(teamId)])
+  DebugPrint("Setting team " .. teamId .. " boss kills to " .. bossKills[tostring(teamId)])
   CustomNetTables:SetTableValue("stat_display_team", "BK", { value = bossKills })
 
   if tier == 1 then

--- a/game/scripts/vscripts/internal/util.lua
+++ b/game/scripts/vscripts/internal/util.lua
@@ -253,15 +253,15 @@ function HideWearables( unit )
     end
 end
 
-function ShowWearables( unit )
-
+function ShowWearables(unit)
   for i,v in pairs(unit.hiddenWearables) do
     v:RemoveEffects(EF_NODRAW)
   end
 end
 
 
-function GetShortTeamName (teamID)
+function GetShortTeamName(teamID)
+  assert(type(teamID) == "number", "teamID: " .. teamID .. " is not of type number but " .. type(teamID))
   local teamNames = {
     [DOTA_TEAM_GOODGUYS] = "good",
     [DOTA_TEAM_BADGUYS] = "bad",
@@ -276,6 +276,11 @@ function GetShortTeamName (teamID)
     [DOTA_TEAM_CUSTOM_8] = "custom8",
   }
   return teamNames[teamID]
+end
+
+function IsPlayerTeam(teamID)
+  assert(type(teamID) == "number", "teamID: " .. teamID .. " is not of type number but " .. type(teamID))
+  return teamID == DOTA_TEAM_GOODGUYS or teamID == DOTA_TEAM_BADGUYS
 end
 
 function IsInTrigger(entity, trigger)

--- a/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
+++ b/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
@@ -60,7 +60,7 @@ if IsServer() then
     self.radius = keys.radius or 300
     self.captureTime = keys.captureTime or 10
     self.captureProgress = 0
-    self.thinkInterval = 0.025
+    self.thinkInterval = 0.02
     local parent = self:GetParent()
     self.captureRingEffect = ParticleManager:CreateParticle(particleDirectory .. "capture_point_ring.vpcf", PATTACH_ABSORIGIN, parent)
     -- Particle colour

--- a/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
+++ b/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
@@ -1,0 +1,155 @@
+modifier_boss_capture_point = class(ModifierBaseClass)
+
+local particleDirectory = "particles/capture_point_ring/"
+
+function modifier_boss_capture_point:IsPurgable()
+  return false
+end
+
+function modifier_boss_capture_point:IsHidden()
+  return true
+end
+
+-- Looks up the name on self and cleans up the particle and index
+function modifier_boss_capture_point:DestroyParticleByName(particleName)
+  local particleIndex = self[particleName]
+  if particleIndex then
+    ParticleManager:DestroyParticle(particleIndex, false)
+    ParticleManager:ReleaseParticleIndex(particleIndex)
+    self[particleName] = nil
+  end
+end
+
+function modifier_boss_capture_point:StartInProgressParticle()
+  if not self.captureInProgressEffect then
+    self.captureInProgressEffect = ParticleManager:CreateParticle(particleDirectory .. "capture_point_ring_capturing.vpcf", PATTACH_ABSORIGIN, self:GetParent())
+    ParticleManager:SetParticleControl(self.captureInProgressEffect, 9, Vector(self.radius, 0, 0))
+  end
+  ParticleManager:SetParticleControl(self.captureInProgressEffect, 3, self:GetColor())
+end
+
+function modifier_boss_capture_point:StartClockParticle()
+  if not self.captureClockEffect then
+    self.captureClockEffect = ParticleManager:CreateParticle(particleDirectory .. "capture_point_ring_clock.vpcf", PATTACH_ABSORIGIN, self:GetParent())
+    ParticleManager:SetParticleControl(self.captureClockEffect, 9, Vector(self.radius, 0, 0))
+    -- Controls how much of the dial to spawn. 1 is the full circle
+    ParticleManager:SetParticleControl(self.captureClockEffect, 11, Vector(0, 0, 1))
+  end
+  ParticleManager:SetParticleControl(self.captureClockEffect, 3, self:GetColor())
+end
+
+function modifier_boss_capture_point:GetColor()
+  local neutralColor = Vector(255, 150, 0)
+  local radiantColor = Vector(0, 162, 255)
+  local direColor = Vector(5, 155, 255)
+  local endColor
+  if self.capturingTeam == DOTA_TEAM_GOODGUYS then
+    endColor = radiantColor
+  elseif self.capturingTeam == DOTA_TEAM_BADGUYS then
+    endColor = direColor
+  else
+    endColor = neutralColor
+  end
+  return SplineVectors(neutralColor, endColor, self.captureProgress / self.captureTime)
+end
+
+if IsServer() then
+  function modifier_boss_capture_point:OnCreated(keys)
+    self.captureFinishCallback = keys.finishFunction
+    self.radius = keys.radius or 300
+    self.captureTime = keys.captureTime or 10
+    self.captureProgress = 0
+    self.thinkInterval = 0.025
+    local parent = self:GetParent()
+    self.captureRingEffect = ParticleManager:CreateParticle(particleDirectory .. "capture_point_ring.vpcf", PATTACH_ABSORIGIN, parent)
+    -- Particle colour
+    ParticleManager:SetParticleControl(self.captureRingEffect, 3, self:GetColor())
+    -- Ring radius
+    ParticleManager:SetParticleControl(self.captureRingEffect, 9, Vector(self.radius, 0, 0))
+
+    self:StartIntervalThink(self.thinkInterval)
+  end
+end
+
+function modifier_boss_capture_point:OnIntervalThink()
+  local parent = self:GetParent()
+  local radiantUnits = FindUnitsInRadius(
+    DOTA_TEAM_GOODGUYS,
+    parent:GetAbsOrigin(),
+    nil,
+    self.radius,
+    DOTA_UNIT_TARGET_TEAM_FRIENDLY,
+    DOTA_UNIT_TARGET_HERO,
+    DOTA_UNIT_TARGET_FLAG_NOT_ILLUSIONS,
+    FIND_ANY_ORDER,
+    false
+  )
+  local direUnits = FindUnitsInRadius(
+    DOTA_TEAM_BADGUYS,
+    parent:GetAbsOrigin(),
+    nil,
+    self.radius,
+    DOTA_UNIT_TARGET_TEAM_FRIENDLY,
+    DOTA_UNIT_TARGET_HERO,
+    DOTA_UNIT_TARGET_FLAG_NOT_ILLUSIONS,
+    FIND_ANY_ORDER,
+    false
+  )
+  if radiantUnits[1] and direUnits[1] then
+    -- Point is being contested, just destroy capture in progress effect
+    self:DestroyParticleByName("captureInProgressEffect")
+    return
+  end
+
+  local function ResetStateToNeutral()
+    self:DestroyParticleByName("captureInProgressEffect")
+    self:DestroyParticleByName("captureClockEffect")
+    self.captureProgress = 0
+    self.capturingTeam = nil
+    -- Update ring color
+    ParticleManager:SetParticleControl(self.captureRingEffect, 3, self:GetColor())
+  end
+  if not radiantUnits[1] and not direUnits[1] then
+    -- Point is empty, reset to neutral state
+      ResetStateToNeutral()
+    return
+  end
+
+  if radiantUnits[1] and self.capturingTeam ~= DOTA_TEAM_GOODGUYS then
+    ResetStateToNeutral()
+    self.capturingTeam = DOTA_TEAM_GOODGUYS
+    return
+  elseif direUnits[1] and self.capturingTeam ~= DOTA_TEAM_BADGUYS then
+    ResetStateToNeutral()
+    self.capturingTeam = DOTA_TEAM_BADGUYS
+    return
+  end
+
+  self.captureProgress = self.captureProgress + self.thinkInterval
+  if self.captureProgress >= self.captureTime then
+    -- Point has been captured
+    if self.captureFinishCallback then
+      self.captureFinishCallback(self.capturingTeam)
+    end
+    self:Destroy()
+    return
+  end
+  self:StartInProgressParticle()
+  self:StartClockParticle()
+  -- Set the orientation of the clock hand based on progress
+  local theta = self.captureProgress / self.captureTime * 2 * math.pi
+  ParticleManager:SetParticleControlForward(self.captureClockEffect, 1, Vector(math.cos(theta), math.sin(theta), 0))
+  -- Update ring color
+  ParticleManager:SetParticleControl(self.captureRingEffect, 3, self:GetColor())
+end
+
+if IsServer() then
+  function modifier_boss_capture_point:OnDestroy()
+    local particles = {
+      "captureRingEffect",
+      "captureInProgressEffect",
+      "captureClockEffect"
+    }
+    foreach(partial(self.DestroyParticleByName, self), particles)
+  end
+end

--- a/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
+++ b/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
@@ -50,7 +50,7 @@ function modifier_boss_capture_point:GetColor()
   else
     endColor = neutralColor
   end
-  return SplineVectors(neutralColor, endColor, self.captureProgress / self.captureTime)
+  return SplineVectors(neutralColor, endColor, (self.captureProgress / self.captureTime) ^ (1/5))
 end
 
 if IsServer() then

--- a/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
+++ b/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
@@ -39,9 +39,9 @@ function modifier_boss_capture_point:StartClockParticle()
 end
 
 function modifier_boss_capture_point:GetColor()
-  local neutralColor = Vector(255, 150, 0)
+  local neutralColor = Vector(229, 187, 94)
   local radiantColor = Vector(0, 162, 255)
-  local direColor = Vector(5, 155, 255)
+  local direColor = Vector(241, 5, 5)
   local endColor
   if self.capturingTeam == DOTA_TEAM_GOODGUYS then
     endColor = radiantColor
@@ -55,6 +55,7 @@ end
 
 if IsServer() then
   function modifier_boss_capture_point:OnCreated(keys)
+    self.tier = keys.tier
     self.captureFinishCallback = keys.finishFunction
     self.radius = keys.radius or 300
     self.captureTime = keys.captureTime or 10
@@ -127,6 +128,7 @@ function modifier_boss_capture_point:OnIntervalThink()
 
   self.captureProgress = self.captureProgress + self.thinkInterval
   if self.captureProgress >= self.captureTime then
+    BossAI:RewardBossKill(self.capturingTeam, self.tier)
     -- Point has been captured
     if self.captureFinishCallback then
       self.captureFinishCallback(self.capturingTeam)

--- a/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
+++ b/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
@@ -41,7 +41,7 @@ end
 function modifier_boss_capture_point:GetColor()
   local neutralColor = Vector(229, 187, 94)
   local radiantColor = Vector(0, 162, 255)
-  local direColor = Vector(241, 5, 5)
+  local direColor = Vector(250, 50, 67)
   local endColor
   if self.capturingTeam == DOTA_TEAM_GOODGUYS then
     endColor = radiantColor

--- a/game/scripts/vscripts/precache.lua
+++ b/game/scripts/vscripts/precache.lua
@@ -1,0 +1,53 @@
+g_ItemPrecache = {
+  "item_postactive",
+  "item_preemptive_3c",
+  "item_stoneskin",
+  "item_greater_phase_boots",
+  "item_greater_power_treads",
+  "item_greater_tranquil_boots",
+  "item_dagon",
+  "item_manta_1",
+}
+
+g_UnitPrecache = {
+  "npc_dota_visage_familiar",
+  "dota_fountain",
+  "npc_dota_boss_shielder",
+  "npc_dota_boss_charger",
+  "npc_dota_boss_charger_pillar",
+  "npc_dota_boss_simple_1",
+  "npc_dota_boss_simple_2",
+  "npc_dota_boss_simple_3",
+  "npc_dota_boss_simple_5",
+  "npc_dota_boss_simple_6",
+  "npc_dota_boss_simple_7",
+  "npc_dota_boss_stopfightingyourself",
+  "npc_dota_creature_ogre_tank_boss",
+  "npc_dota_creature_ogre_seer",
+  "npc_dota_creature_lycan_boss",
+  "npc_dota_creature_dire_hound",
+  "npc_dota_creature_dire_hound_boss",
+  "npc_dota_creature_werewolf",
+  "npc_dota_hero_bloodseeker", -- For Lycan Boss Wolf transformation
+}
+
+g_ModelPrecache = {
+
+}
+
+g_ParticlePrecache = {
+
+}
+
+g_ParticleFolderPrecache = {
+  "particles/capture_point_ring",
+}
+
+g_SoundPrecache = {
+  "soundevents/game_sounds_heroes/game_sounds_phantom_assassin.vsndevts", -- For Ogre Boss kill sound
+  -- Ambient sounds
+  "soundevents/ambient/doors.vsndevts",
+  "soundevents/music/music.vsndevts",
+  "soundevents/game_sounds_creeps.vsndevts",
+  "soundevents/bosses/game_sounds_dungeon_enemies.vsndevts",
+}


### PR DESCRIPTION
Implementing #1521. I'm currently assuming the capture pauses when it's contested rather than resetting. Is that correct? Also, how big should the capture point be?

Current state:
Spawns on death of boss. Seems to correctly animate to indicate capturing.
Does not yet actually do anything. Probably want to change how and when the colour changes to better indicate capturing team.

Also, the main ring particle (the only one that shows when the CP is empty) seems quite flaky. It flickers a bunch for some reason. No idea if it's just my computer. Would be great if someone could check that for me.

Credits to @carlosrpg for hacking together the initial particle.