### PR TITLE
Trying to make Greevils Greed do anything

### DIFF
--- a/game/scripts/npc/abilities/alchemist_goblins_greed.txt
+++ b/game/scripts/npc/abilities/alchemist_goblins_greed.txt
@@ -26,17 +26,17 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_gold"                                      "4"
+        "bonus_gold"                                      "20 20 20 20 50 100"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_bonus_gold"                                "4"
+        "bonus_bonus_gold"                                "20 20 20 20 50 100"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_gold_cap"                                  "16 20 24 28 56 84"
+        "bonus_gold_cap"                                  "80 120 180 200 560 1240"
       }
       "05"
       {


### PR DESCRIPTION
Because our creeps give much more gold than regular ones I think it is needed to increase how much gold you get from greevils greed. I mean maxed out greevils greed gave you less gold then the weakest creeps at the beginning of the game.