### PR TITLE
Minor Description fix

### DIFF
--- a/game/resource/English/ability/items/tooltip_martyrs_mail.txt
+++ b/game/resource/English/ability/items/tooltip_martyrs_mail.txt
@@ -47,4 +47,4 @@
 //"DOTA_Tooltip_Ability_item_martyrs_mail_4_martyr_duration"                  "MARTYR DURATION:"
 //"DOTA_Tooltip_Ability_item_martyrs_mail_4_martyr_heal_aoe"                  "MARTYR HEAL AOE:"
 //"DOTA_Tooltip_Ability_item_martyrs_mail_4_martyr_heal_percent"              "%MARTYR HEAL PERCENT:"
-"DOTA_Tooltip_Ability_item_martyrs_mail_4_Description"                      "<h1>Active: Martyr</h1> For %martyr_duration%, heals nearby allies for %martyr_heal_percent%%% of any damage taken. <br><br>Radius: %martyr_heal_aoe%"
+"DOTA_Tooltip_Ability_item_martyrs_mail_4_Description"                      "<h1>Active: Martyr</h1> For %martyr_duration% seconds, heals nearby allies for %martyr_heal_percent%%% of any damage taken. <br><br>Radius: %martyr_heal_aoe%"


### PR DESCRIPTION
Add the word "seconds" next to %martyr_duration%.  Currently it would have only shown the number.