### PR TITLE
Change boss drop to use PlayerResource:GetSelectedHeroEntity

### DIFF
--- a/game/scripts/vscripts/components/boss/ai.lua
+++ b/game/scripts/vscripts/components/boss/ai.lua
@@ -69,8 +69,7 @@ end
 
 function BossAI:GiveItemToWholeTeam (item, teamId)
   PlayerResource:GetPlayerIDsForTeam(teamId):each(function (playerId)
-    local player = PlayerResource:GetPlayer(playerId)
-    local hero = player:GetAssignedHero()
+    local hero = PlayerResource:GetSelectedHeroEntity(playerId)
 
     hero:AddItemByName(item)
   end)
@@ -108,8 +107,7 @@ function BossAI:RewardBossKill(state, deathEventData, teamId)
     end
 
     PlayerResource:GetPlayerIDsForTeam(teamId):each(function (playerId)
-      local player = PlayerResource:GetPlayer(playerId)
-      local hero = player:GetAssignedHero()
+      local hero = PlayerResource:GetSelectedHeroEntity(playerId)
 
       if hero then
         if self.hasFarmingCore[team] and not hero.hasFarmingCore then


### PR DESCRIPTION
This avoids errors with nil players caused by disconnects. Also allows the items to actually be granted to disconnected players. Hopefully this doesn't introduce some other new and interesting bug.