### PR TITLE
Redo gold and experience

### DIFF
--- a/game/scripts/vscripts/components/cave/cave_types.lua
+++ b/game/scripts/vscripts/components/cave/cave_types.lua
@@ -42,12 +42,12 @@ CaveTypes = {
   [1] = { -- 1 "Howl's it Going?"
     {                                                  --HP  MANA  DMG  ARM   GOLD   EXP  RESIST
       units = {
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   307,  30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   307,  30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   307,  30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   307,  30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   307,  30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   307,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   176,   204,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   176,   204,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   176,   204,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   176,   204,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   176,   204,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   176,   204,  30},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, 0, CaveProgressionBuff), -- function (k) return 1 end,
@@ -63,12 +63,12 @@ CaveTypes = {
   [2] = { -- 2 "Horse Tomatina"
     {                                                  --HP  MANA  DMG  ARM   GOLD   EXP  RESIST
       units = {
-        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  141,   307,  40},
-        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  141,   307,  40},
-        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  141,   307,  40},
-        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  141,   307,  40},
-        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  141,   307,  40},
-        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  141,   307,  40},
+        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  176,   204,  40},
+        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  176,   204,  40},
+        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  176,   204,  40},
+        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  176,   204,  40},
+        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  176,   204,  40},
+        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  176,   204,  40},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, _G.CAVE_ROOM_INTERVAL, CaveProgressionBuff), -- function (k) return 1 end,
@@ -84,10 +84,10 @@ CaveTypes = {
   [3] = { -- 3 "Draggin' it Around"
     {                                                  --HP  MANA  DMG  ARM   GOLD   EXP  RESIST
       units = {
-        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   460,  50},
-        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   460,  50},
-        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   460,  50},
-        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   460,  50},
+        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   264,   309,  50},
+        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   264,   309,  50},
+        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   264,   309,  50},
+        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   264,   309,  50},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, 2 * _G.CAVE_ROOM_INTERVAL, CaveProgressionBuff), -- function (k) return 1 end,
@@ -103,8 +103,8 @@ CaveTypes = {
   [4] = { -- 4 "Roashes Everywhere"
     {                                                  --HP  MANA  DMG  ARM   GOLD   EXP  RESIST
       units = {
-        {"npc_dota_mini_roshan",                      1200,    0,  68,  1.2,  424,   922,  60},
-        {"npc_dota_mini_roshan",                      1200,    0,  68,  1.2,  424,   922,  60},
+        {"npc_dota_mini_roshan",                      1200,    0,  68,  1.2,  528,   614,  60},
+        {"npc_dota_mini_roshan",                      1200,    0,  68,  1.2,  528,   614,  60},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, 3 * _G.CAVE_ROOM_INTERVAL, CaveProgressionBuff), -- function (k) return 1 end,

--- a/game/scripts/vscripts/components/cave/cave_types.lua
+++ b/game/scripts/vscripts/components/cave/cave_types.lua
@@ -40,14 +40,14 @@ local BaseMultipliers = {
 -- "creep name", Health, Mana, Damage, Armor, Gold Bounty, Exp Bounty
 CaveTypes = {
   [1] = { -- 1 "Howl's it Going?"
-    {                                                 --HP  MANA  DMG   ARM   GOLD  EXP RESIST
+    {                                                  --HP  MANA  DMG  ARM   GOLD   EXP  RESIST
       units = {
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,  0,    30,   1,     78,  40, 30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,  0,    30,   1,     78,  40, 30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,  0,    30,   1,     78,  40, 30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,  0,    30,   1,     78,  40, 30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,  0,    30,   1,     78,  40, 30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,  0,    30,   1,     78,  40, 30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   162,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   162,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   162,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   162,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   162,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   162,  30},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, 0, CaveProgressionBuff), -- function (k) return 1 end,
@@ -61,14 +61,14 @@ CaveTypes = {
     }
   },
   [2] = { -- 2 "Horse Tomatina"
-    {                                                    --HP  MANA  DMG   ARM   GOLD  EXP RESIST
+    {                                                  --HP  MANA  DMG  ARM   GOLD   EXP  RESIST
       units = {
-        {"npc_dota_neutral_custom_cave_tomato",           450,   0,  38,   0.8,    78, 40,  40},
-        {"npc_dota_neutral_custom_cave_tomato",           450,   0,  38,   0.8,    78, 40,  40},
-        {"npc_dota_neutral_custom_cave_tomato",           450,   0,  38,   0.8,    78, 40,  40},
-        {"npc_dota_neutral_custom_cave_big_horse",        750,   0,  19,   1.2,    78, 40,  40},
-        {"npc_dota_neutral_custom_cave_big_horse",        750,   0,  19,   1.2,    78, 40,  40},
-        {"npc_dota_neutral_custom_cave_big_horse",        750,   0,  19,   1.2,    78, 40,  40},
+        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  141,   162,  40},
+        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  141,   162,  40},
+        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  141,   162,  40},
+        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  141,   162,  40},
+        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  141,   162,  40},
+        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  141,   162,  40},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, _G.CAVE_ROOM_INTERVAL, CaveProgressionBuff), -- function (k) return 1 end,
@@ -82,12 +82,12 @@ CaveTypes = {
     }
   },
   [3] = { -- 3 "Draggin' it Around"
-    {                                                    --HP  MANA  DMG   ARM   GOLD  EXP RESIST
+    {                                                  --HP  MANA  DMG  ARM   GOLD   EXP  RESIST
       units = {
-        {"npc_dota_neutral_custom_cave_black_drake",      900,   0,  45,    1,    116, 61,  50},
-        {"npc_dota_neutral_custom_cave_black_drake",      900,   0,  45,    1,    116, 61,  50},
-        {"npc_dota_neutral_custom_cave_black_drake",      900,   0,  45,    1,    116, 61,  50},
-        {"npc_dota_neutral_custom_cave_black_drake",      900,   0,  45,    1,    116, 61,  50},
+        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   243,  50},
+        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   243,  50},
+        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   243,  50},
+        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   243,  50},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, 2 * _G.CAVE_ROOM_INTERVAL, CaveProgressionBuff), -- function (k) return 1 end,
@@ -101,10 +101,10 @@ CaveTypes = {
     }
   },
   [4] = { -- 4 "Roashes Everywhere"
-    {                                                    --HP  MANA  DMG   ARM   GOLD  EXP RESIST
+    {                                                  --HP  MANA  DMG  ARM   GOLD   EXP  RESIST
       units = {
-        {"npc_dota_mini_roshan",                         1200,   0,  68,   1.2,   234, 122,  60},
-        {"npc_dota_mini_roshan",                         1200,   0,  68,   1.2,   234, 122,  60},
+        {"npc_dota_mini_roshan",                      1200,    0,  68,  1.2,  432,   486,  60},
+        {"npc_dota_mini_roshan",                      1200,    0,  68,  1.2,  432,   486,  60},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, 3 * _G.CAVE_ROOM_INTERVAL, CaveProgressionBuff), -- function (k) return 1 end,

--- a/game/scripts/vscripts/components/cave/cave_types.lua
+++ b/game/scripts/vscripts/components/cave/cave_types.lua
@@ -42,12 +42,12 @@ CaveTypes = {
   [1] = { -- 1 "Howl's it Going?"
     {                                                  --HP  MANA  DMG  ARM   GOLD   EXP  RESIST
       units = {
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   162,  30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   162,  30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   162,  30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   162,  30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   162,  30},
-        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   162,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   307,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   307,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   307,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   307,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   307,  30},
+        {"npc_dota_neutral_custom_cave_big_pupper",    600,    0,  30,   1,   141,   307,  30},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, 0, CaveProgressionBuff), -- function (k) return 1 end,
@@ -63,12 +63,12 @@ CaveTypes = {
   [2] = { -- 2 "Horse Tomatina"
     {                                                  --HP  MANA  DMG  ARM   GOLD   EXP  RESIST
       units = {
-        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  141,   162,  40},
-        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  141,   162,  40},
-        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  141,   162,  40},
-        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  141,   162,  40},
-        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  141,   162,  40},
-        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  141,   162,  40},
+        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  141,   307,  40},
+        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  141,   307,  40},
+        {"npc_dota_neutral_custom_cave_tomato",        450,    0,  38,  0.8,  141,   307,  40},
+        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  141,   307,  40},
+        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  141,   307,  40},
+        {"npc_dota_neutral_custom_cave_big_horse",     750,    0,  19,  1.2,  141,   307,  40},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, _G.CAVE_ROOM_INTERVAL, CaveProgressionBuff), -- function (k) return 1 end,
@@ -84,10 +84,10 @@ CaveTypes = {
   [3] = { -- 3 "Draggin' it Around"
     {                                                  --HP  MANA  DMG  ARM   GOLD   EXP  RESIST
       units = {
-        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   243,  50},
-        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   243,  50},
-        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   243,  50},
-        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   243,  50},
+        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   460,  50},
+        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   460,  50},
+        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   460,  50},
+        {"npc_dota_neutral_custom_cave_black_drake",   900,    0,  45,   1,   211,   460,  50},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, 2 * _G.CAVE_ROOM_INTERVAL, CaveProgressionBuff), -- function (k) return 1 end,
@@ -103,8 +103,8 @@ CaveTypes = {
   [4] = { -- 4 "Roashes Everywhere"
     {                                                  --HP  MANA  DMG  ARM   GOLD   EXP  RESIST
       units = {
-        {"npc_dota_mini_roshan",                      1200,    0,  68,  1.2,  432,   486,  60},
-        {"npc_dota_mini_roshan",                      1200,    0,  68,  1.2,  432,   486,  60},
+        {"npc_dota_mini_roshan",                      1200,    0,  68,  1.2,  424,   922,  60},
+        {"npc_dota_mini_roshan",                      1200,    0,  68,  1.2,  424,   922,  60},
       },
       multiplier = {
         mana = BaseMultipliers.mana(BaseCreepPowerMultiplier, 3 * _G.CAVE_ROOM_INTERVAL, CaveProgressionBuff), -- function (k) return 1 end,

--- a/game/scripts/vscripts/components/creeps/creep_power.lua
+++ b/game/scripts/vscripts/components/creeps/creep_power.lua
@@ -35,7 +35,7 @@ function CreepPower:GetBasePowerForMinute (minute, multFactor)
     (0 * ((minute / 100) ^ 4) - 0 * ((minute/100) ^ 3) + 60 * ((minute/100) ^ 2) + 6 * (minute/100)) + 1,     -- damage
     (0 * (minute / 26) ^ 2 + minute / 6) + 1,       -- armor
     ((3 * minute ^ 2 + 3 * minute + 91)/91) * self.BootGoldFactor,                      -- gold
-    ((3 * minute ^ 2 + 23 * minute + 311) / 311) * self.numPlayersXPFactor * multFactor -- xp
+    ((9 * minute ^ 2 + 17 * minute + 607) / 607) * self.numPlayersXPFactor * multFactor -- xp
   }
 end
 

--- a/game/scripts/vscripts/components/creeps/creep_power.lua
+++ b/game/scripts/vscripts/components/creeps/creep_power.lua
@@ -34,8 +34,8 @@ function CreepPower:GetBasePowerForMinute (minute, multFactor)
     (0 * ((minute / 100) ^ 4) - 0 * ((minute/100) ^ 3) + 30 * ((minute/100) ^ 2) + 3 * (minute/100)) + 1,   -- mana
     (0 * ((minute / 100) ^ 4) - 0 * ((minute/100) ^ 3) + 60 * ((minute/100) ^ 2) + 6 * (minute/100)) + 1,     -- damage
     (0 * (minute / 26) ^ 2 + minute / 6) + 1,       -- armor
-    ((4 * minute ^ 2 + 4 * minute + 468)/468) * self.BootGoldFactor,                         -- gold
-    ((45 * minute ^ 2 + 67 * minute + 2500) / 2500) * self.numPlayersXPFactor * multFactor -- xp
+    ((3 * minute ^ 2 + 3 * minute + 91)/91) * self.BootGoldFactor,                      -- gold
+    ((3 * minute ^ 2 + 23 * minute + 311) / 311) * self.numPlayersXPFactor * multFactor -- xp
   }
 end
 

--- a/game/scripts/vscripts/components/creeps/creep_power.lua
+++ b/game/scripts/vscripts/components/creeps/creep_power.lua
@@ -34,7 +34,7 @@ function CreepPower:GetBasePowerForMinute (minute, multFactor)
     (0 * ((minute / 100) ^ 4) - 0 * ((minute/100) ^ 3) + 30 * ((minute/100) ^ 2) + 3 * (minute/100)) + 1,   -- mana
     (0 * ((minute / 100) ^ 4) - 0 * ((minute/100) ^ 3) + 60 * ((minute/100) ^ 2) + 6 * (minute/100)) + 1,     -- damage
     (0 * (minute / 26) ^ 2 + minute / 6) + 1,       -- armor
-    ((3 * minute ^ 2 + 3 * minute + 91)/91) * self.BootGoldFactor,                      -- gold
+    ((3 * minute ^ 2 - 5 * minute + 177)/177) * self.BootGoldFactor,                      -- gold
     ((9 * minute ^ 2 + 17 * minute + 607) / 607) * self.numPlayersXPFactor * multFactor -- xp
   }
 end

--- a/game/scripts/vscripts/components/creeps/creep_types.lua
+++ b/game/scripts/vscripts/components/creeps/creep_types.lua
@@ -38,45 +38,45 @@ CreepTypes = {
     -- 3 "hard camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   50,  76}, --expected gold is 82 and XP is 151
-      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   32,  75},
+      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   60,  76}, --expected gold is 96 and XP is 151
+      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   36,  75},
     },
     {
-      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   50,  76},
-      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   32,  75},
+      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   60,  76},
+      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   36,  75},
     },
     {
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  39},
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  39},
-      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    66,  99}
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    16,  39},
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    16,  39},
+      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    76,  99}
     },
     {
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  39},
-      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    66,  99}
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    16,  39},
+      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    76,  99}
     },
     {
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  39},
-      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    66,  99}
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    16,  39},
+      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    76,  99}
     },
     {
-      {"npc_dota_neutral_satyr_tickster",           350,  160,  10,    1,    14,  35},
-      {"npc_dota_neutral_satyr_soulstealer",        450,  480,  20,    1,    24,  51},
-      {"npc_dota_neutral_satyr_hellcaller",         550,  480,  30,   1.5,   44,  65}
+      {"npc_dota_neutral_satyr_tickster",           350,  160,  10,    1,    22,  35},
+      {"npc_dota_neutral_satyr_soulstealer",        450,  480,  20,    1,    32,  51},
+      {"npc_dota_neutral_satyr_hellcaller",         550,  480,  30,   1.5,   42,  65}
     }
   },
    -- 4 "ancient camp"
   {
     {                                               --HP  MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_granite_golem",           1400,    0,  50,    2,    96, 106}, --expected gold is 191 and XP is 212
-      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    47,  53},
-      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    47,  53}
+      {"npc_dota_neutral_granite_golem",           1400,    0,  50,    2,   116, 106}, --expected gold is 232 and XP is 212
+      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    58,  53},
+      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    58,  53}
     },
     {
-      {"npc_dota_neutral_prowler_acolyte",          900,    0,  30,    1,    63,  71},
-      {"npc_dota_neutral_prowler_shaman",          1200,    0,  60,    2,   128, 141}
+      {"npc_dota_neutral_prowler_acolyte",          900,    0,  30,    1,    78,  71},
+      {"npc_dota_neutral_prowler_shaman",          1200,    0,  60,    2,   154, 141}
     },
     {
-      {"npc_dota_neutral_custom_black_dragon",     1700,    0,  80,    3,   191, 212}
+      {"npc_dota_neutral_custom_black_dragon",     1700,    0,  80,    3,   232, 212}
     }
   }
 }

--- a/game/scripts/vscripts/components/creeps/creep_types.lua
+++ b/game/scripts/vscripts/components/creeps/creep_types.lua
@@ -4,79 +4,79 @@ CreepTypes = {
   -- 1 "easy camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   10,  30}, --expected gold is 41 and XP is 91
-      {"npc_dota_neutral_kobold_tunneler",          480,    0,  12,    1,    20,  52}
+      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   20,  30}, --expected gold is 80 and XP is 91
+      {"npc_dota_neutral_kobold_tunneler",          480,    0,  12,    1,    40,  52}
     },
     {
-      {"npc_dota_neutral_kobold_taskmaster",        560,    0,  16,    1,    30,  65},
-      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   10,  30}
+      {"npc_dota_neutral_kobold_taskmaster",        560,    0,  16,    1,    60,  65},
+      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   20,  30}
     },
     {
-      {"npc_dota_neutral_kobold_taskmaster",        560,    0,  16,    1,    30,  65},
-      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   10,  30}
+      {"npc_dota_neutral_kobold_taskmaster",        560,    0,  16,    1,    60,  65},
+      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   20,  30}
     },
     {
-      {"npc_dota_neutral_ghost",                    480,    0,  12,    1,    27,  46},
-      {"npc_dota_neutral_ghost",                    480,    0,  12,    1,    27,  46}
+      {"npc_dota_neutral_ghost",                    480,    0,  12,    1,    50,  46},
+      {"npc_dota_neutral_ghost",                    480,    0,  12,    1,    50,  46}
     }
   },
     -- 2 "medium camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   30, 118}, --expected gold is 55 and XP is 212
-      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   30, 118},
-      {"npc_dota_neutral_harpy_scout",              440,    0,  40,   0.7,   11,  70},
+      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   60, 118}, --expected gold is 106 and XP is 212
+      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   60, 118},
+      {"npc_dota_neutral_harpy_scout",              440,    0,  40,   0.7,   20,  70},
     },
     {
-      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   30, 118}
+      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   60, 118}
     },
     {
-      {"npc_dota_neutral_polar_furbolg_champion",   480,    0,  28,   1.3,   32, 106},
-      {"npc_dota_neutral_beardude",                 800,    0,  28,   1.3,   32, 106}
+      {"npc_dota_neutral_polar_furbolg_champion",   480,    0,  28,   1.3,   59, 106},
+      {"npc_dota_neutral_beardude",                 800,    0,  28,   1.3,   59, 106}
     }
   },
     -- 3 "hard camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   60,  76}, --expected gold is 96 and XP is 151
-      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   36,  75},
+      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,  120,  76}, --expected gold is 186 and XP is 151
+      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   66,  75},
     },
     {
-      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   60,  76},
-      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   36,  75},
+      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,  120,  76},
+      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   66,  75},
     },
     {
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    16,  39},
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    16,  39},
-      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    76,  99}
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    33,  39},
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    33,  39},
+      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,   142,  99}
     },
     {
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    16,  39},
-      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    76,  99}
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    33,  39},
+      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,   142,  99}
     },
     {
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    16,  39},
-      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    76,  99}
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    33,  39},
+      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,   142,  99}
     },
     {
-      {"npc_dota_neutral_satyr_tickster",           350,  160,  10,    1,    22,  35},
-      {"npc_dota_neutral_satyr_soulstealer",        450,  480,  20,    1,    32,  51},
-      {"npc_dota_neutral_satyr_hellcaller",         550,  480,  30,   1.5,   42,  65}
+      {"npc_dota_neutral_satyr_tickster",           350,  160,  10,    1,    47,  35},
+      {"npc_dota_neutral_satyr_soulstealer",        450,  480,  20,    1,    62,  51},
+      {"npc_dota_neutral_satyr_hellcaller",         550,  480,  30,   1.5,   77,  65}
     }
   },
    -- 4 "ancient camp"
   {
     {                                               --HP  MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_granite_golem",           1400,    0,  50,    2,   116, 106}, --expected gold is 232 and XP is 212
-      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    58,  53},
-      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    58,  53}
+      {"npc_dota_neutral_granite_golem",           1400,    0,  50,    2,   225, 106}, --expected gold is 451 and XP is 212
+      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,   113,  53},
+      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,   113,  53}
     },
     {
-      {"npc_dota_neutral_prowler_acolyte",          900,    0,  30,    1,    78,  71},
-      {"npc_dota_neutral_prowler_shaman",          1200,    0,  60,    2,   154, 141}
+      {"npc_dota_neutral_prowler_acolyte",          900,    0,  30,    1,   151,  71},
+      {"npc_dota_neutral_prowler_shaman",          1200,    0,  60,    2,   300, 141}
     },
     {
-      {"npc_dota_neutral_custom_black_dragon",     1700,    0,  80,    3,   232, 212}
+      {"npc_dota_neutral_custom_black_dragon",     1700,    0,  80,    3,   451, 212}
     }
   }
 }

--- a/game/scripts/vscripts/components/creeps/creep_types.lua
+++ b/game/scripts/vscripts/components/creeps/creep_types.lua
@@ -4,83 +4,83 @@ CreepTypes = {
   -- 1 "easy camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   14,  14}, --expected gold is 70 and XP is 37
-      {"npc_dota_neutral_kobold_tunneler",          480,    0,  12,    1,    30,  24}
+      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   10,  19}, --expected gold is 41 and XP is 47
+      {"npc_dota_neutral_kobold_tunneler",          480,    0,  12,    1,    20,  29}
     },
     {
-      {"npc_dota_neutral_kobold_taskmaster",        560,    0,  16,    1,    44,  22},
-      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   14,  14}
+      {"npc_dota_neutral_kobold_taskmaster",        560,    0,  16,    1,    30,  27},
+      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   10,  19}
     },
     {
-      {"npc_dota_neutral_kobold_taskmaster",        560,    0,  16,    1,    44,  22},
-      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   14,  14}
+      {"npc_dota_neutral_kobold_taskmaster",        560,    0,  16,    1,    30,  27},
+      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   10,  19}
     },
     {
-      {"npc_dota_neutral_ghost",                    480,    0,  12,    1,    60,  19},
-      {"npc_dota_neutral_ghost",                    480,    0,  12,    1,    60,  19}
+      {"npc_dota_neutral_ghost",                    480,    0,  12,    1,    27,  24},
+      {"npc_dota_neutral_ghost",                    480,    0,  12,    1,    27,  24}
     }
   },
     -- 2 "medium camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   53,  49}, --expected gold is 94 and XP is 86
-      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   53,  49},
-      {"npc_dota_neutral_harpy_scout",              440,    0,  40,   0.7,   32,  23},
+      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   30,  60}, --expected gold is 55 and XP is 109
+      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   30,  60},
+      {"npc_dota_neutral_harpy_scout",              440,    0,  40,   0.7,   11,  35},
     },
     {
-      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   53,  49}
+      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   30,  60}
     },
     {
-      {"npc_dota_neutral_polar_furbolg_champion",   480,    0,  28,   1.3,   47,  43},
-      {"npc_dota_neutral_beardude",                 800,    0,  28,   1.3,   47,  43},
+      {"npc_dota_neutral_polar_furbolg_champion",   480,    0,  28,   1.3,   32,  56},
+      {"npc_dota_neutral_beardude",                 800,    0,  28,   1.3,   32,  56},
     }
   },
     -- 3 "hard camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   90,  31}, --expected gold is 140 and XP is 62
-      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   50,  31},
+      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   50,  39}, --expected gold is 82 and XP is 78
+      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   32,  39},
     },
     {
-      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   90,  31},
-      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   50,  31},
+      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   50,  39},
+      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   32,  39},
     },
     {
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    30,  21},
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    30,  21},
-      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,   100,  34}
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  27},
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  27},
+      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    66,  42}
     },
     {
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    30,  21},
-      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,   100,  34}
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  27},
+      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    66,  42}
     },
     {
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    30,  21},
-      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,   100,  34}
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  27},
+      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    66,  42}
     },
     {
-      {"npc_dota_neutral_satyr_tickster",           350,  160,  10,    1,    20,  11},
-      {"npc_dota_neutral_satyr_soulstealer",        450,  480,  20,    1,    40,  20},
-      {"npc_dota_neutral_satyr_hellcaller",         550,  480,  30,   1.5,   80,  31}
+      {"npc_dota_neutral_satyr_tickster",           350,  160,  10,    1,    14,  15},
+      {"npc_dota_neutral_satyr_soulstealer",        450,  480,  20,    1,    24,  25},
+      {"npc_dota_neutral_satyr_hellcaller",         550,  480,  30,   1.5,   44,  38}
     }
   },
    -- 4 "ancient camp"
   {
     {                                               --HP  MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_granite_golem",           1400,    0,  50,    2,   166,  44}, --expected gold is 332 and XP is 86
-      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    83,  20},
-      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    83,  20}
+      {"npc_dota_neutral_granite_golem",           1400,    0,  50,    2,    96,  56}, --expected gold is 191 and XP is 109
+      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    47,  25},
+      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    47,  25}
     },
     {
-      {"npc_dota_neutral_granite_golem",           1400,    0,  50,    2,   166,  44},
-      {"npc_dota_neutral_granite_golem",           1400,    0,  40,    2,   166,  44}
+      {"npc_dota_neutral_granite_golem",           1400,    0,  50,    2,    96,  56},
+      {"npc_dota_neutral_granite_golem",           1400,    0,  40,    2,    96,  56}
     },
     {
-      {"npc_dota_neutral_prowler_acolyte",          900,    0,  30,    1,   112,  29},
-      {"npc_dota_neutral_prowler_shaman",          1200,    0,  60,    2,   220,  57}
+      {"npc_dota_neutral_prowler_acolyte",          900,    0,  30,    1,    63,  36},
+      {"npc_dota_neutral_prowler_shaman",          1200,    0,  60,    2,   128,  73}
     },
     {
-      {"npc_dota_neutral_custom_black_dragon",     1700,    0,  80,    3,   332,  86}
+      {"npc_dota_neutral_custom_black_dragon",     1700,    0,  80,    3,   191, 109}
     }
   }
 }

--- a/game/scripts/vscripts/components/creeps/creep_types.lua
+++ b/game/scripts/vscripts/components/creeps/creep_types.lua
@@ -4,83 +4,79 @@ CreepTypes = {
   -- 1 "easy camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   10,  19}, --expected gold is 41 and XP is 47
-      {"npc_dota_neutral_kobold_tunneler",          480,    0,  12,    1,    20,  29}
+      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   10,  30}, --expected gold is 41 and XP is 91
+      {"npc_dota_neutral_kobold_tunneler",          480,    0,  12,    1,    20,  52}
     },
     {
-      {"npc_dota_neutral_kobold_taskmaster",        560,    0,  16,    1,    30,  27},
-      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   10,  19}
+      {"npc_dota_neutral_kobold_taskmaster",        560,    0,  16,    1,    30,  65},
+      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   10,  30}
     },
     {
-      {"npc_dota_neutral_kobold_taskmaster",        560,    0,  16,    1,    30,  27},
-      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   10,  19}
+      {"npc_dota_neutral_kobold_taskmaster",        560,    0,  16,    1,    30,  65},
+      {"npc_dota_neutral_kobold",                   280,    0,  10,   0.5,   10,  30}
     },
     {
-      {"npc_dota_neutral_ghost",                    480,    0,  12,    1,    27,  24},
-      {"npc_dota_neutral_ghost",                    480,    0,  12,    1,    27,  24}
+      {"npc_dota_neutral_ghost",                    480,    0,  12,    1,    27,  46},
+      {"npc_dota_neutral_ghost",                    480,    0,  12,    1,    27,  46}
     }
   },
     -- 2 "medium camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   30,  60}, --expected gold is 55 and XP is 109
-      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   30,  60},
-      {"npc_dota_neutral_harpy_scout",              440,    0,  40,   0.7,   11,  35},
+      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   30, 118}, --expected gold is 55 and XP is 212
+      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   30, 118},
+      {"npc_dota_neutral_harpy_scout",              440,    0,  40,   0.7,   11,  70},
     },
     {
-      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   30,  60}
+      {"npc_dota_neutral_harpy_storm",              560,  320,  24,   1.2,   30, 118}
     },
     {
-      {"npc_dota_neutral_polar_furbolg_champion",   480,    0,  28,   1.3,   32,  56},
-      {"npc_dota_neutral_beardude",                 800,    0,  28,   1.3,   32,  56},
+      {"npc_dota_neutral_polar_furbolg_champion",   480,    0,  28,   1.3,   32, 106},
+      {"npc_dota_neutral_beardude",                 800,    0,  28,   1.3,   32, 106}
     }
   },
     -- 3 "hard camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   50,  39}, --expected gold is 82 and XP is 78
-      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   32,  39},
+      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   50,  76}, --expected gold is 82 and XP is 151
+      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   32,  75},
     },
     {
-      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   50,  39},
-      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   32,  39},
+      {"npc_dota_neutral_custom_big_horse",         800,  400,  30,   1.5,   50,  76},
+      {"npc_dota_neutral_custom_small_horse",       600,  240,  20,   0.8,   32,  75},
     },
     {
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  27},
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  27},
-      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    66,  42}
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  39},
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  39},
+      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    66,  99}
     },
     {
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  27},
-      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    66,  42}
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  39},
+      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    66,  99}
     },
     {
-      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  27},
-      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    66,  42}
+      {"npc_dota_neutral_custom_small_pupper",      400,  160,  15,    1,    12,  39},
+      {"npc_dota_neutral_custom_big_pupper",        600,  480,  35,    2,    66,  99}
     },
     {
-      {"npc_dota_neutral_satyr_tickster",           350,  160,  10,    1,    14,  15},
-      {"npc_dota_neutral_satyr_soulstealer",        450,  480,  20,    1,    24,  25},
-      {"npc_dota_neutral_satyr_hellcaller",         550,  480,  30,   1.5,   44,  38}
+      {"npc_dota_neutral_satyr_tickster",           350,  160,  10,    1,    14,  35},
+      {"npc_dota_neutral_satyr_soulstealer",        450,  480,  20,    1,    24,  51},
+      {"npc_dota_neutral_satyr_hellcaller",         550,  480,  30,   1.5,   44,  65}
     }
   },
    -- 4 "ancient camp"
   {
     {                                               --HP  MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_granite_golem",           1400,    0,  50,    2,    96,  56}, --expected gold is 191 and XP is 109
-      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    47,  25},
-      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    47,  25}
+      {"npc_dota_neutral_granite_golem",           1400,    0,  50,    2,    96, 106}, --expected gold is 191 and XP is 212
+      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    47,  53},
+      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    47,  53}
     },
     {
-      {"npc_dota_neutral_granite_golem",           1400,    0,  50,    2,    96,  56},
-      {"npc_dota_neutral_granite_golem",           1400,    0,  40,    2,    96,  56}
+      {"npc_dota_neutral_prowler_acolyte",          900,    0,  30,    1,    63,  71},
+      {"npc_dota_neutral_prowler_shaman",          1200,    0,  60,    2,   128, 141}
     },
     {
-      {"npc_dota_neutral_prowler_acolyte",          900,    0,  30,    1,    63,  36},
-      {"npc_dota_neutral_prowler_shaman",          1200,    0,  60,    2,   128,  73}
-    },
-    {
-      {"npc_dota_neutral_custom_black_dragon",     1700,    0,  80,    3,   191, 109}
+      {"npc_dota_neutral_custom_black_dragon",     1700,    0,  80,    3,   191, 212}
     }
   }
 }

--- a/game/scripts/vscripts/internal/gamemode.lua
+++ b/game/scripts/vscripts/internal/gamemode.lua
@@ -46,7 +46,7 @@ function GameMode:_InitGameMode()
   local goldTickCount = 0
   Timers:CreateTimer(5, function ()
     goldTickCount = goldTickCount + 1
-    GameRules:SetGoldPerTick((goldTickCount*goldTickCount + goldTickCount + 16800)*20/43200)
+    GameRules:SetGoldPerTick((goldTickCount*goldTickCount + goldTickCount + 4320)*20/19200)
     return 5
   end)
 

--- a/game/scripts/vscripts/internal/gamemode.lua
+++ b/game/scripts/vscripts/internal/gamemode.lua
@@ -46,7 +46,7 @@ function GameMode:_InitGameMode()
   local goldTickCount = 0
   Timers:CreateTimer(5, function ()
     goldTickCount = goldTickCount + 1
-    GameRules:SetGoldPerTick((goldTickCount*goldTickCount + goldTickCount + 4320)*20/19200)
+    GameRules:SetGoldPerTick((goldTickCount*goldTickCount + goldTickCount + 4320)*15/19200)
     return 5
   end)
 

--- a/game/scripts/vscripts/internal/gamemode.lua
+++ b/game/scripts/vscripts/internal/gamemode.lua
@@ -46,7 +46,7 @@ function GameMode:_InitGameMode()
   local goldTickCount = 0
   Timers:CreateTimer(5, function ()
     goldTickCount = goldTickCount + 1
-    GameRules:SetGoldPerTick((goldTickCount*goldTickCount + goldTickCount + 4320)*15/19200)
+    GameRules:SetGoldPerTick((goldTickCount*goldTickCount - 31*goldTickCount + 8624)*15/19200)
     return 5
   end)
 

--- a/game/scripts/vscripts/modifiers/modifier_xpm_thinker.lua
+++ b/game/scripts/vscripts/modifiers/modifier_xpm_thinker.lua
@@ -51,12 +51,13 @@ end
 function modifier_xpm_thinker:GetXPMForPlayer( playerID )
 	if IsServer() then
 		local gameTime = ( GameRules:GetDOTATime( true, true ) - self.baseTime ) / 5.0
-		local a = 15
-		local b = 103
-		local c = 116401
-		local divisor = 5760 * 5 -- this isn't any different from adding a 0 but it's more future proof
+		local a = 3
+		local b = 5
+		local c = 43202
+    local divisor = 1728
+		local percent = 20
 
-		local value = ( ( a * gameTime * gameTime ) + ( b * gameTime ) + c ) / divisor
+		local value = ( ( a * gameTime * gameTime ) + ( b * gameTime ) + c ) * (percent / 100) / divisor
 
 		-- quick and dirty rounding
 		value = math.floor( value + 0.5 )

--- a/game/scripts/vscripts/modifiers/modifier_xpm_thinker.lua
+++ b/game/scripts/vscripts/modifiers/modifier_xpm_thinker.lua
@@ -52,9 +52,9 @@ function modifier_xpm_thinker:GetXPMForPlayer( playerID )
 	if IsServer() then
 		local gameTime = ( GameRules:GetDOTATime( true, true ) - self.baseTime ) / 5.0
 		local a = 3
-		local b = 5
-		local c = 43202
-    local divisor = 1728
+		local b = 35
+		local c = 28817
+    local divisor = 1152
 		local percent = 20
 
 		local value = ( ( a * gameTime * gameTime ) + ( b * gameTime ) + c ) * (percent / 100) / divisor

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -51,7 +51,7 @@ _G.BOOT_GOLD_FACTOR = 0.7               -- Multiplier to account for the presenc
 
 --Cave
 _G.CAVE_ROOM_INTERVAL = 2               -- Expected time of room clear, in minutes
-_G.CAVE_DIFFICULTY = 2                  -- Multiplies cave difficulty growth compared to normal creeps
+_G.CAVE_DIFFICULTY = 3                  -- Multiplies cave difficulty growth compared to normal creeps
 _G.CAVE_BOUNTY = 1                      -- Accelerates cave bounty increase compared to the rest of the game
 
 -- Logging


### PR DESCRIPTION
Added more experience early.
Added a lot more gold, especially after the first ten minutes.
Fixed a math mistake which made cave give less gold.
Would like to (but dare not) put boots in progression with the gold:
Arcanes 670/1830/4000/7200/11400
Tranquils 1000/3000/6700/12000/19000
I hope no one will find these values unreasonable.