### PR TITLE
Fixed spider boss lifesteal

### DIFF
--- a/game/scripts/npc/abilities/siltbreaker/spider_boss_rage.txt
+++ b/game/scripts/npc/abilities/siltbreaker/spider_boss_rage.txt
@@ -33,7 +33,7 @@
       "02"
       {
           "var_type"              "FIELD_INTEGER"
-          "lifesteal_pct"         "450"
+          "lifesteal_pct"         "10"
       }
       "03"
       {


### PR DESCRIPTION
would make it so it lifesteals for 80health (800 effective) pre target armor's damage reduction