### PR TITLE
Re-enable printing of Steam ID in bottle.lua with more detailed message

### DIFF
--- a/game/scripts/vscripts/items/bottle.lua
+++ b/game/scripts/vscripts/items/bottle.lua
@@ -72,7 +72,7 @@ end
 
 --------------------------------------------------------------------------------
 
---Debug:EnableDebugging()
+Debug:EnableDebugging()
 
 modifier_bottle_texture_tracker = class(ModifierBaseClass)
 
@@ -84,7 +84,8 @@ function modifier_bottle_texture_tracker:OnCreated()
   if IsServer() then
     local playerID = parent:GetPlayerOwnerID()
     local steamid = PlayerResource:GetSteamAccountID(playerID)
-    DebugPrint(steamid)
+    local playerName = PlayerResource:GetPlayerName(playerID)
+    DebugPrint("Steam ID of " .. playerName .. ": " .. steamid)
 
     self:SetStackCount(special_bottles[steamid] or 0)
   end


### PR DESCRIPTION
Or perhaps just having this as a chat command would be better. Would require starting a lobby with cheats enabled though.