### PR TITLE
Make fountain target exiled units and ward type units

### DIFF
--- a/game/scripts/npc/abilities/dev_attack.txt
+++ b/game/scripts/npc/abilities/dev_attack.txt
@@ -11,7 +11,7 @@
 
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_AURA"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
-    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_ALL"
+    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
     "AbilityUnitDamageType"                               "DAMAGE_TYPE_PURE"
     "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_YES"

--- a/game/scripts/npc/abilities/dev_attack.txt
+++ b/game/scripts/npc/abilities/dev_attack.txt
@@ -12,7 +12,7 @@
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_AURA"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_ALL"
-    "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE | DOTA_UNIT_TARGET_FLAG_OUT_OF_WORLD"
+    "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
     "AbilityUnitDamageType"                               "DAMAGE_TYPE_PURE"
     "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_YES"
 

--- a/game/scripts/npc/abilities/fountain_attack.txt
+++ b/game/scripts/npc/abilities/fountain_attack.txt
@@ -12,7 +12,7 @@
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_AURA"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
-    "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE | DOTA_UNIT_TARGET_FLAG_OUT_OF_WORLD"
+    "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
     "AbilityUnitDamageType"                               "DAMAGE_TYPE_PURE"
     "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_YES"
     "AbilityCastPoint"                                    "0"

--- a/game/scripts/vscripts/abilities/dev_attack.lua
+++ b/game/scripts/vscripts/abilities/dev_attack.lua
@@ -25,7 +25,7 @@ function modifier_dev_attack:GetAuraRadius()
 end
 
 function modifier_dev_attack:GetAuraSearchFlags()
-  return self:GetAbility():GetAbilityTargetFlags()
+  return bit.bor(self:GetAbility():GetAbilityTargetFlags(), DOTA_UNIT_TARGET_FLAG_OUT_OF_WORLD)
 end
 
 function modifier_dev_attack:GetAuraSearchTeam()
@@ -33,7 +33,7 @@ function modifier_dev_attack:GetAuraSearchTeam()
 end
 
 function modifier_dev_attack:GetAuraSearchType()
-  return self:GetAbility():GetAbilityTargetType()
+  return bit.bor(self:GetAbility():GetAbilityTargetType(), DOTA_UNIT_TARGET_OTHER)
 end
 
 function modifier_dev_attack:GetTexture()

--- a/game/scripts/vscripts/abilities/fountain_attack.lua
+++ b/game/scripts/vscripts/abilities/fountain_attack.lua
@@ -36,7 +36,7 @@ function modifier_fountain_attack:GetAuraRadius()
 end
 
 function modifier_fountain_attack:GetAuraSearchFlags()
-  return self:GetAbility():GetAbilityTargetFlags()
+  return bit.bor(self:GetAbility():GetAbilityTargetFlags(), DOTA_UNIT_TARGET_FLAG_OUT_OF_WORLD)
 end
 
 function modifier_fountain_attack:GetAuraSearchTeam()

--- a/game/scripts/vscripts/abilities/fountain_attack.lua
+++ b/game/scripts/vscripts/abilities/fountain_attack.lua
@@ -44,7 +44,7 @@ function modifier_fountain_attack:GetAuraSearchTeam()
 end
 
 function modifier_fountain_attack:GetAuraSearchType()
-  return self:GetAbility():GetAbilityTargetType()
+  return bit.bor(self:GetAbility():GetAbilityTargetType(), DOTA_UNIT_TARGET_OTHER)
 end
 
 function modifier_fountain_attack:GetAuraEntityReject(entity)


### PR DESCRIPTION
Turns out KV does not understand `DOTA_UNIT_TARGET_OTHER` or `DOTA_UNIT_TARGET_FLAG_OUT_OF_WORLD` cause Valve.