### PR TITLE
Modify Urn of Sorcery GetAttributes and RemoveOnDeath

### DIFF
--- a/game/scripts/vscripts/items/urn_of_sorcery.lua
+++ b/game/scripts/vscripts/items/urn_of_sorcery.lua
@@ -68,9 +68,7 @@ function modifier_item_urn_of_sorcery:IsPurgable()
 end
 
 function modifier_item_urn_of_sorcery:GetAttributes()
-  return {
-    MODIFIER_ATTRIBUTE_MULTIPLE
-  }
+  return MODIFIER_ATTRIBUTE_MULTIPLE
 end
 
 function modifier_item_urn_of_sorcery:OnCreated()

--- a/game/scripts/vscripts/items/urn_of_sorcery.lua
+++ b/game/scripts/vscripts/items/urn_of_sorcery.lua
@@ -67,6 +67,10 @@ function modifier_item_urn_of_sorcery:IsPurgable()
   return false
 end
 
+function modifier_item_urn_of_sorcery:RemoveOnDeath()
+  return false
+end
+
 function modifier_item_urn_of_sorcery:GetAttributes()
   return MODIFIER_ATTRIBUTE_MULTIPLE
 end


### PR DESCRIPTION
GetAttributes was returning a table when it should just return an integer.

Item passive modifiers should have RemoveOnDeath false. Vanilla item modifiers appear to have this. I wonder if we shouldn't just make a base class for this at this point.