### PR TITLE
Make Dagger of Moriah not self-damage for damage with no_spell_amp flag

### DIFF
--- a/game/scripts/vscripts/items/transformation/dagger_of_moriah.lua
+++ b/game/scripts/vscripts/items/transformation/dagger_of_moriah.lua
@@ -91,7 +91,7 @@ end
 --------------------------------------------------------------------------------
 
 function modifier_item_dagger_of_moriah_sangromancy:OnTakeDamage(event)
-  if event.damage_category == 0 and event.attacker == self:GetParent() and not (event.unit == self:GetParent()) then
+  if event.damage_category == 0 and event.attacker == self:GetParent() and not (event.unit == self:GetParent()) and bit.band(event.damage_flags, DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION) == 0 then
 
     local damage = {
       victim = event.attacker,


### PR DESCRIPTION
Doesn't make much sense to have the penalty for things that don't gain the benefit