### PR TITLE
Make capture point actually accelerate for additional heroes

### DIFF
--- a/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
+++ b/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
@@ -104,10 +104,8 @@ function modifier_boss_capture_point:OnIntervalThink()
   -- Start capturing from neutral
   if radiantUnits[1] and self.capturingTeam == nil then
     self.capturingTeam = DOTA_TEAM_GOODGUYS
-    heroMultiplier = #radiantUnits
   elseif direUnits[1] and self.capturingTeam == nil then
     self.capturingTeam = DOTA_TEAM_BADGUYS
-    heroMultiplier = #direUnits
   end
 
   if radiantUnits[1] and direUnits[1] then
@@ -122,16 +120,13 @@ function modifier_boss_capture_point:OnIntervalThink()
   else
     -- Point is being captured by a team
     captureTick = self.thinkInterval
+    if self.capturingTeam == DOTA_TEAM_GOODGUYS then
+      heroMultiplier = math.max(0, #radiantUnits - 1)
+    elseif self.capturingTeam == DOTA_TEAM_BADGUYS then
+      heroMultiplier = math.max(0, #direUnits - 1)
   end
-  heroMultiplier = math.max(0, heroMultiplier - 1)
   captureTick = captureTick * (1 + heroMultiplier / 2)
   self.captureProgress = min(self.captureTime, max(0, self.captureProgress + captureTick))
-
-  -- if not radiantUnits[1] and not direUnits[1] then
-  --   -- Point is empty, reset to neutral state
-  --     ResetStateToNeutral()
-  --   return
-  -- end
 
   if self.captureProgress == 0 then
     self.capturingTeam = nil

--- a/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
+++ b/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
@@ -124,6 +124,7 @@ function modifier_boss_capture_point:OnIntervalThink()
       heroMultiplier = math.max(0, #radiantUnits - 1)
     elseif self.capturingTeam == DOTA_TEAM_BADGUYS then
       heroMultiplier = math.max(0, #direUnits - 1)
+    end
   end
   captureTick = captureTick * (1 + heroMultiplier / 2)
   self.captureProgress = min(self.captureTime, max(0, self.captureProgress + captureTick))

--- a/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
+++ b/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
@@ -99,7 +99,14 @@ function modifier_boss_capture_point:OnIntervalThink()
     false
   )
   local captureTick
-  local heroMultiplier = 0
+  local heroMultiplierTable = {
+    1,
+    1.11,
+    1.25,
+    1.42,
+    1.66
+  }
+  local numHeroes = 1
 
   -- Start capturing from neutral
   if radiantUnits[1] and self.capturingTeam == nil then
@@ -117,16 +124,21 @@ function modifier_boss_capture_point:OnIntervalThink()
   elseif (radiantUnits[1] and self.capturingTeam ~= DOTA_TEAM_GOODGUYS) or (direUnits[1] and self.capturingTeam ~= DOTA_TEAM_BADGUYS) then
     -- Point has switched capturing team, reverse progress at 1.5 times speed
     captureTick = -self.thinkInterval * 1.5
+    if self.capturingTeam == DOTA_TEAM_GOODGUYS then
+      numHeroes = #direUnits
+    elseif self.capturingTeam == DOTA_TEAM_BADGUYS then
+      numHeroes = #radiantUnits
+    end
   else
     -- Point is being captured by a team
     captureTick = self.thinkInterval
     if self.capturingTeam == DOTA_TEAM_GOODGUYS then
-      heroMultiplier = math.max(0, #radiantUnits - 1)
+      numHeroes = #radiantUnits
     elseif self.capturingTeam == DOTA_TEAM_BADGUYS then
-      heroMultiplier = math.max(0, #direUnits - 1)
+      numHeroes = #direUnits
     end
   end
-  captureTick = captureTick * (1 + heroMultiplier / 2)
+  captureTick = captureTick * heroMultiplierTable[math.min(#heroMultiplierTable, numHeroes)]
   self.captureProgress = min(self.captureTime, max(0, self.captureProgress + captureTick))
 
   if self.captureProgress == 0 then


### PR DESCRIPTION
Previously, it was only checking the number of heroes on the very first tick of a team starting a capture. Subsequent ticks would have no multiplier for additional heroes, effectively meaning the capture rate never changed.

The acceleration only applies for capturing and not reversing capture.

Do we even still want this? Seeing as it's been sitting non-functional for so long. Maybe at a reduced multiplier? Additional 0.5 per hero is quite fast.