### PR TITLE
Make unit files match their respective ability kv values

### DIFF
--- a/game/scripts/npc/abilities/lycan_summon_wolves.txt
+++ b/game/scripts/npc/abilities/lycan_summon_wolves.txt
@@ -44,12 +44,12 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "wolf_damage"                                     "18 29 37 46 165 340"
+        "wolf_damage"                                     "17 28 37 46 65 140"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "wolf_hp"                                         "200 240 280 320 1320 2720"
+        "wolf_hp"                                         "200 240 280 320 400 720"
       }
       "06"
       {

--- a/game/scripts/npc/abilities/warlock_rain_of_chaos.txt
+++ b/game/scripts/npc/abilities/warlock_rain_of_chaos.txt
@@ -56,17 +56,17 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "golem_hp_tooltip"                                "1000 1500 2000 4500 7000"
+        "golem_hp_tooltip"                                "1000 1500 2500 5000 10000"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "golem_dmg_tooltip"                               "75 100 125 250 375"
+        "golem_dmg_tooltip"                               "75 100 150 250 500"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "golem_armor_tooltip"                             "6 9 12 17 42"
+        "golem_armor_tooltip"                             "6 9 15 25 50"
         "LinkedSpecialBonus"                              "special_bonus_unique_warlock_2"
       }
       "07"


### PR DESCRIPTION
tooltips on summons were not matching, tooltips now changed to acctual figures.

warlock
health
acctual:
1000/1500/2500/5000/10000
tooltip:
1000/1500/2000/4500/7000

damage
acctual:
75/100/150/250/500
tooltip:
75/100/125/250/375

armour
acctual:
6/9/15/25/50
tooltip:
6/9/12/17/42

lycan
health
acctual:
200//240/280/320/400/720
tooltip:
200/240/280/320/1320/2720

damage
acctual:
17/28/37/46/65/140
tooltip:
18/29/37/46/165/340