### PR TITLE
Rework Charger resistances, some general Charger cleanup

### DIFF
--- a/content/particles/charger/charger_super_armor_shield.vpcf
+++ b/content/particles/charger/charger_super_armor_shield.vpcf
@@ -1,0 +1,119 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:vpcf1:version{d47d07e6-072c-49cb-9718-5bfd8d6c3d21} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 1
+	m_flConstantRadius = 2.5
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderModels"
+			m_ModelList = 
+			[
+				{
+					m_model = resource:"models/props_gameplay/status_shield.vmdl"
+				},
+			]
+			m_bAnimated = true
+			m_nLOD = 1
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_OscillateScalarSimple"
+			m_nField = 3
+			m_Rate = 1.0
+			m_Frequency = 0.75
+			m_flOscAdd = 0.0
+		},
+		{
+			_class = "C_OP_PositionLock"
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_flEndTime = 0.25
+			m_flBias = 0.75
+			m_flStartScale = 0.0
+			m_nOpEndCapState = 0
+			m_flEndScale = 0.5
+		},
+		{
+			_class = "C_OP_AlphaDecay"
+			m_nOpEndCapState = 1
+		},
+		{
+			_class = "C_OP_RampScalarLinearSimple"
+			m_flEndTime = 9999.0
+			m_Rate = -8.0
+			m_nField = 16
+			m_nOpEndCapState = 1
+		},
+		{
+			_class = "C_OP_BasicMovement"
+		},
+		{
+			_class = "C_OP_ClampScalar"
+			m_flOutputMin = 0.5
+			m_flOutputMax = 2.5
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomScalar"
+			m_flMin = 1.2
+			m_flMax = 1.2
+			m_nFieldOutput = 20
+		},
+		{
+			_class = "C_INIT_CreateWithinSphere"
+		},
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMax = 1.0
+			m_fLifetimeMin = 1.0
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_InstantaneousEmitter"
+			m_nParticlesToEmit = 1
+		},
+	]
+	m_Children = 
+	[
+		{
+			m_ChildRef = resource:"particles/items3_fx/star_emblem_orbiter_friend.vpcf"
+		},
+		{
+			m_ChildRef = resource:"particles/items3_fx/star_emblem_friend_shield_glow.vpcf"
+		},
+		{
+			m_ChildRef = resource:"particles/charger/charger_super_armor_sun.vpcf"
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 5
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/particles/charger/charger_super_armor_sun.vpcf
+++ b/content/particles/charger/charger_super_armor_sun.vpcf
@@ -1,0 +1,138 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:vpcf1:version{d47d07e6-072c-49cb-9718-5bfd8d6c3d21} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 8
+	m_flConstantRadius = 1.0
+	m_ConstantColor = [ 247, 183, 114, 255 ]
+	m_flMaxRecreationTime = -1.0
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			VisibilityInputs = 
+			{
+				m_flCameraBias = 20.0
+			}
+			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
+			m_bAdditive = true
+			m_hTexture = resource:"materials/particle/particle_glow_01.vtex"
+			m_flAnimationRate = 1.0
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_SpinUpdate"
+		},
+		{
+			_class = "C_OP_PositionLock"
+		},
+		{
+			_class = "C_OP_BasicMovement"
+		},
+		{
+			_class = "C_OP_LerpEndCapScalar"
+			m_nFieldOutput = 7
+			m_flOutput = 0.0
+			m_flLerpTime = 0.36
+			m_nOpEndCapState = 1
+		},
+		{
+			_class = "C_OP_AlphaDecay"
+			m_nOpEndCapState = 1
+		},
+		{
+			_class = "C_OP_FadeIn"
+			m_flFadeInTimeMin = 0.36
+			m_flFadeInTimeMax = 0.36
+			m_bProportional = false
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMin = 7.2
+			m_fLifetimeMax = 7.2
+		},
+		{
+			_class = "C_INIT_CreateWithinSphere"
+		},
+		{
+			_class = "C_INIT_RandomRotation"
+			m_flDegreesMax = 0.0
+			m_flDegrees = 360.0
+		},
+		{
+			_class = "C_INIT_RandomAlpha"
+			m_nAlphaMax = 96
+			m_nAlphaMin = 96
+		},
+		{
+			_class = "C_INIT_RandomRotationSpeed"
+			m_flDegreesMax = 20.0
+			m_flDegreesMin = 10.0
+		},
+		{
+			_class = "C_INIT_RandomColor"
+			m_ColorMin = [ 255, 105, 46, 255 ]
+			m_ColorMax = [ 255, 105, 46, 255 ]
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMin = 48.0
+			m_flRadiusMax = 48.0
+		},
+		{
+			_class = "C_INIT_PositionOffset"
+			m_OffsetMin = [ 0.0, 10.0, 14.0 ]
+			m_OffsetMax = [ 0.0, 10.0, 14.0 ]
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_InstantaneousEmitter"
+			m_nParticlesToEmit = 1
+		},
+	]
+	m_ForceGenerators = 
+	[
+		{
+			_class = "C_OP_AttractToControlPoint"
+			m_nControlPointNumber = 5
+			m_fFalloffPower = 0.0
+			m_fForceAmount = 5000.0
+			m_nOpEndCapState = 1
+		},
+	]
+	m_Children = 
+	[
+		{
+			m_ChildRef = resource:"particles/items3_fx/star_emblem_sun_rays.vpcf"
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 5
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/game/resource/English/ability/units/boss/tooltip_boss_cliffwalk.txt
+++ b/game/resource/English/ability/units/boss/tooltip_boss_cliffwalk.txt
@@ -3,4 +3,7 @@
 //=============================================================================
 
 "dota_tooltip_ability_boss_cliffwalk"                     "Cliff Walk"
-"dota_tooltip_ability_boss_cliffwalk_description"         "Walks Cliffs"
+"dota_tooltip_ability_boss_cliffwalk_description"         "Grants flying movement"
+
+"DOTA_Tooltip_modifier_cliffwalk"                         "Cliff Walk"
+"DOTA_Tooltip_modifier_cliffwalk_description"             "Has flying movement"

--- a/game/resource/English/ability/units/charger/tooltip_boss_charger_super_armor.txt
+++ b/game/resource/English/ability/units/charger/tooltip_boss_charger_super_armor.txt
@@ -1,0 +1,11 @@
+//=============================================================================
+// Charger Super Armor (Unholy Shielding)
+//=============================================================================
+"DOTA_Tooltip_Ability_boss_charger_super_armor"                        "Unholy Shielding"
+"DOTA_Tooltip_Ability_boss_charger_super_armor_description"            "Charger maintains a protective field around himself, greatly reducing incoming damage.\n\nWhen Charger is stunned by charging into a pillar, he loses focus, causing #{DOTA_Tooltip_Ability_boss_charger_super_armor} to be disabled for the duration he is stunned."
+"DOTA_Tooltip_Ability_boss_charger_super_armor_Note0"                  "Boss Resistance does not stack with #{DOTA_Tooltip_Ability_boss_charger_super_armor}."
+"DOTA_Tooltip_Ability_boss_charger_super_armor_Note1"                  "Boss Resistance still applies when #{DOTA_Tooltip_Ability_boss_charger_super_armor} is disabled."
+"DOTA_Tooltip_Ability_boss_charger_super_armor_percent_damage_reduce"  "%DAMAGE REDUCTION:"
+
+"DOTA_Tooltip_modifier_boss_charger_super_armor"                       "#{DOTA_Tooltip_Ability_boss_charger_super_armor}"
+"DOTA_Tooltip_modifier_boss_charger_super_armor_description"           "Taking greatly reduced damage"

--- a/game/resource/English/modifier/units/charger/tooltip_modifier_boss_charger_pillar_debuff.txt
+++ b/game/resource/English/modifier/units/charger/tooltip_modifier_boss_charger_pillar_debuff.txt
@@ -1,5 +1,5 @@
 //=============================================================================
 // Charger Pillar Debuff
 //=============================================================================
-"DOTA_Tooltip_modifier_boss_charger_pillar_debuff"          "Lowered Resistance"
-"DOTA_Tooltip_modifier_boss_charger_pillar_debuff_description"    "Attack him now!"
+"DOTA_Tooltip_modifier_boss_charger_pillar_debuff"                "Shielding Disabled"
+"DOTA_Tooltip_modifier_boss_charger_pillar_debuff_description"    "#{DOTA_Tooltip_Ability_boss_charger_super_armor} disabled."

--- a/game/scripts/npc/abilities/charger/boss_charger_charge.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_charge.txt
@@ -45,25 +45,15 @@
         "var_type"                                        "FIELD_FLOAT"
         "debuff_duration"                                 "5.0 4.0 3.0"
       }
-      "06"
-      {
-        "var_type"                                        "FIELD_INTEGER"
-        "debuff_magic_resist"                             "-1500"
-      }
-      "07"
-      {
-        "var_type"                                        "FIELD_INTEGER"
-        "debuff_armor"                                    "-225"
-      }
       //----------------------------
       // hero is dragged into a pillar
       //----------------------------
-      "08"
+      "06"
       {
         "var_type"                                        "FIELD_FLOAT"
         "hero_stun_duration"                              "2.0 2.75 3.5"
       }
-      "09"
+      "07"
       {
         "var_type"                                        "FIELD_FLOAT"
         "hero_pillar_damage"                              "8000 10000 12000"
@@ -71,22 +61,22 @@
       //----------------------------------
       // Glancing blow, when the charger strikes a hero indirectly and pushes them away
       //----------------------------------
-      "10"
+      "08"
       {
         "var_type"                                        "FIELD_FLOAT"
         "glancing_damage"                                  "75 100 150"
       }
-      "11"
+      "09"
       {
         "var_type"                                        "FIELD_FLOAT"
         "glancing_slow"                                    "10 30 50"
       }
-      "12"
+      "10"
       {
         "var_type"                                        "FIELD_FLOAT"
         "glancing_duration"                                "1 2 3"
       }
-      "13"
+      "11"
       {
         "var_type"                                        "FIELD_FLOAT"
         "glancing_knockback"                               "200 250 300"

--- a/game/scripts/npc/abilities/charger/boss_charger_charge.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_charge.txt
@@ -69,27 +69,27 @@
         "hero_pillar_damage"                              "8000 10000 12000"
       }
       //----------------------------------
-      // Glacing blow, when the charger strikes a hero indirectly and pushes them away
+      // Glancing blow, when the charger strikes a hero indirectly and pushes them away
       //----------------------------------
       "10"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glacing_damage"                                  "75 100 150"
+        "glancing_damage"                                  "75 100 150"
       }
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glacing_slow"                                    "10 30 50"
+        "glancing_slow"                                    "10 30 50"
       }
       "12"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glacing_duration"                                "1 2 3"
+        "glancing_duration"                                "1 2 3"
       }
       "13"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glacing_knockback"                               "200 250 300"
+        "glancing_knockback"                               "200 250 300"
       }
     }
   }

--- a/game/scripts/npc/abilities/charger/boss_charger_charge.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_charge.txt
@@ -19,7 +19,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cooldown"                                        "6 4 0"
+        "cooldown"                                        "6 4 0" // Put cooldown in AbilitySpecial to avoid triggering cooldown on channel start
       }
       "02"
       {

--- a/game/scripts/npc/abilities/charger/boss_charger_super_armor.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_super_armor.txt
@@ -1,0 +1,25 @@
+
+"DOTAAbilities" {
+  "boss_charger_super_armor" {
+    "ID"                                                  "127009"
+    "BaseClass"                                           "ability_lua"
+    "ScriptFile"                                          "abilities/charger/boss_charger_super_armor.lua"
+    "AbilityTextureName"                                  "sylph_sprite_shield"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+    "MaxLevel"                                            "3"
+    "RequiredLevel"                                       "1"
+    "LevelsBetweenUpgrades"                               "1"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "percent_damage_reduce"                           "96" // Extra damage reduction before hitting pillar
+      }
+    }
+  }
+}

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -25,6 +25,7 @@
 
 #base "abilities/charger/boss_charger_charge.txt"
 #base "abilities/charger/boss_charger_summon_pillar.txt"
+#base "abilities/charger/boss_charger_super_armor.txt"
 #base "abilities/shielder/boss_shielder_shield.txt"
 #base "abilities/twin/boss_twin_twin_empathy.txt"
 

--- a/game/scripts/npc/units/charger/npc_dota_boss_charger.txt
+++ b/game/scripts/npc/units/charger/npc_dota_boss_charger.txt
@@ -20,13 +20,14 @@
     //----------------------------------------------------------------
     "Ability1"                                            "boss_charger_summon_pillar"
     "Ability2"                                            "boss_charger_charge"
-    "Ability3"                                            "boss_resistance"
-    "Ability4"                                            "boss_cliffwalk"
+    "Ability3"                                            "boss_charger_super_armor"
+    "Ability4"                                            "boss_resistance"
+    "Ability5"                                            "boss_cliffwalk"
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "250"            // Physical protection.
-    "MagicalResistance"                                   "95"                                 // Magical protection (percentage).
+    "ArmorPhysical"                                       "25"            // Physical protection.
+    "MagicalResistance"                                   "-25"                                 // Magical protection (percentage).
 
     // Attack
     //----------------------------------------------------------------
@@ -96,6 +97,7 @@
     {
       "soundfile"                                         "soundevents/bosses/charger.vsndevts"
       "particle"                                          "particles/charger/charger_charge_debuff.vpcf"
+      "particle"                                          "particles/charger/charger_super_armor_shield.vpcf"
     }
   }
 }

--- a/game/scripts/vscripts/abilities/charger/boss_charger_charge.lua
+++ b/game/scripts/vscripts/abilities/charger/boss_charger_charge.lua
@@ -34,6 +34,8 @@ function boss_charger_charge:OnOwnerDied()
   self:GetCaster():StopSound("Boss_Charger.Charge.Movement")
 end
 
+--------------------------------------------------------------------------------
+
 modifier_boss_charger_charge = class(ModifierBaseClass)
 
 function modifier_boss_charger_charge:IsHidden()
@@ -164,10 +166,10 @@ function modifier_boss_charger_charge:OnCreated(keys)
   self.debuff_duration = ability:GetSpecialValueFor( "debuff_duration" )
   self.hero_stun_duration = ability:GetSpecialValueFor( "hero_stun_duration" )
   self.hero_pillar_damage = ability:GetSpecialValueFor( "hero_pillar_damage" )
-  self.glacing_damage = ability:GetSpecialValueFor( "glacing_damage" )
-  self.glacing_slow = ability:GetSpecialValueFor( "glacing_slow" )
-  self.glacing_duration = ability:GetSpecialValueFor( "glacing_duration" )
-  self.glacing_knockback = ability:GetSpecialValueFor( "glacing_knockback" )
+  self.glancing_damage = ability:GetSpecialValueFor( "glancing_damage" )
+  self.glancing_slow = ability:GetSpecialValueFor( "glancing_slow" )
+  self.glancing_duration = ability:GetSpecialValueFor( "glancing_duration" )
+  self.glancing_knockback = ability:GetSpecialValueFor( "glancing_knockback" )
 
   self:StartIntervalThink(0.01)
 end

--- a/game/scripts/vscripts/abilities/charger/boss_charger_charge.lua
+++ b/game/scripts/vscripts/abilities/charger/boss_charger_charge.lua
@@ -14,12 +14,12 @@ end
 
 function boss_charger_charge:OnChannelFinish(interrupted) --You misspelled "Interrupted"
   local caster = self:GetCaster()
-  self:StartCooldown(self:GetSpecialValueFor('cooldown'))
   if interrupted then
-    self:StartCooldown(self:GetSpecialValueFor('cooldown') / 2)
+    self:StartCooldown(self:GetSpecialValueFor("cooldown") / 2)
     caster:StopSound("Boss_Charger.Charge.Begin")
     return
   end
+  self:StartCooldown(self:GetSpecialValueFor("cooldown"))
 
   caster:AddNewModifier(caster, self, "modifier_boss_charger_charge", {
     duration = self:GetSpecialValueFor( "charge_duration" )

--- a/game/scripts/vscripts/abilities/charger/boss_charger_charge.lua
+++ b/game/scripts/vscripts/abilities/charger/boss_charger_charge.lua
@@ -123,7 +123,7 @@ function modifier_boss_charger_charge:OnIntervalThink()
         })
       end)
     else
-      caster:AddNewModifier(caster, self:GetAbility(), "modifier_boss_charger_pillar_debuff", {
+      caster:AddNewModifier(caster, caster:FindAbilityByName("boss_charger_super_armor"), "modifier_boss_charger_pillar_debuff", {
         duration = self.debuff_duration
       })
     end

--- a/game/scripts/vscripts/abilities/charger/boss_charger_super_armor.lua
+++ b/game/scripts/vscripts/abilities/charger/boss_charger_super_armor.lua
@@ -1,0 +1,42 @@
+LinkLuaModifier("modifier_boss_charger_super_armor", "abilities/charger/boss_charger_super_armor.lua", LUA_MODIFIER_MOTION_NONE)
+
+boss_charger_super_armor = class(AbilityBaseClass)
+
+function boss_charger_super_armor:GetIntrinsicModifierName()
+  return "modifier_boss_charger_super_armor"
+end
+
+--------------------------------------------------------------------------------
+
+modifier_boss_charger_super_armor = class(ModifierBaseClass)
+
+function modifier_boss_charger_super_armor:IsPurgable()
+  return false
+end
+
+function modifier_boss_charger_super_armor:IsHidden()
+  return self:GetParent():HasModifier("modifier_boss_charger_pillar_debuff")
+end
+
+if IsServer() then
+  function modifier_boss_charger_super_armor:OnCreated(keys)
+    local ability = self:GetAbility()
+    local parent = self:GetParent()
+    ability.shieldParticleName = "particles/charger/charger_super_armor_shield.vpcf"
+    ability.shieldParticle = ParticleManager:CreateParticle(ability.shieldParticleName, PATTACH_OVERHEAD_FOLLOW, parent)
+  end
+end
+
+function modifier_boss_charger_super_armor:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_TOTAL_CONSTANT_BLOCK
+  }
+end
+
+function modifier_boss_charger_super_armor:GetModifierTotal_ConstantBlock(keys)
+  if self:GetParent():HasModifier("modifier_boss_charger_pillar_debuff") then
+    return
+  end
+  local damageReduction = self:GetAbility():GetSpecialValueFor("percent_damage_reduce")
+  return math.floor(keys.damage * damageReduction / 100)
+end

--- a/game/scripts/vscripts/abilities/charger/modifier_boss_charger_pillar_debuff.lua
+++ b/game/scripts/vscripts/abilities/charger/modifier_boss_charger_pillar_debuff.lua
@@ -1,27 +1,10 @@
 
 modifier_boss_charger_pillar_debuff = class(ModifierBaseClass)
 
-function modifier_boss_charger_pillar_debuff:OnCreated(keys)
-  if not IsServer() then
-    return
-  end
-  local ability = self:GetAbility()
-end
-
 function modifier_boss_charger_pillar_debuff:DeclareFunctions()
   return {
-    MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS,
-    MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS,
     MODIFIER_PROPERTY_OVERRIDE_ANIMATION,
   }
-end
-
-function modifier_boss_charger_pillar_debuff:GetModifierPhysicalArmorBonus()
-  return self:GetAbility():GetSpecialValueFor( "debuff_armor" )
-end
-
-function modifier_boss_charger_pillar_debuff:GetModifierMagicalResistanceBonus()
-  return self:GetAbility():GetSpecialValueFor( "debuff_magic_resist" )
 end
 
 function modifier_boss_charger_pillar_debuff:IsDebuff()
@@ -38,6 +21,20 @@ end
 
 function modifier_boss_charger_pillar_debuff:IsStunDebuff()
   return true
+end
+
+if IsServer() then
+  function modifier_boss_charger_pillar_debuff:OnCreated(keys)
+    local ability = self:GetAbility()
+    ParticleManager:DestroyParticle(ability.shieldParticle, false)
+    ParticleManager:ReleaseParticleIndex(ability.shieldParticle)
+  end
+
+  function modifier_boss_charger_pillar_debuff:OnDestroy()
+    local ability = self:GetAbility()
+    local parent = self:GetParent()
+    ability.shieldParticle = ParticleManager:CreateParticle(ability.shieldParticleName, PATTACH_OVERHEAD_FOLLOW, parent)
+  end
 end
 
 function modifier_boss_charger_pillar_debuff:GetEffectName()

--- a/game/scripts/vscripts/units/charger.lua
+++ b/game/scripts/vscripts/units/charger.lua
@@ -137,6 +137,7 @@ function Spawn (entityKeyValues) --luacheck: ignore Spawn
   local phaseController = thisEntity:AddNewModifier(thisEntity, ABILITY_charge, "modifier_boss_phase_controller", {})
   phaseController:SetPhases({ 66, 33 })
   phaseController:SetAbilities({
-    "boss_charger_charge"
+    "boss_charger_charge",
+    "boss_charger_super_armor"
   })
 end

--- a/scripts/test/special-values.test.js
+++ b/scripts/test/special-values.test.js
@@ -17,6 +17,7 @@ var stupidItemNames = [
   'item_halloween_candy_corn',
   'item_halloween_rapier',
   'item_firework_mine',
+  'sylph_sprite_shield',
   'nothing'
 ];
 


### PR DESCRIPTION
Changed Charger to used damage block like Boss Resistance instead of relying on high armor and magic resistance that gets rekt'd by Heartpiercer. Closes #1574.

Also gave the Cliff Walk modifier a tooltip, fixed the misspelling of "glancing" in the Charger files, and made Charge have half the cooldown when it's interrupted.