### PR TITLE
Fix DialogVariables in notifications not getting replaced properly

### DIFF
--- a/content/panorama/scripts/barebones_notifications.js
+++ b/content/panorama/scripts/barebones_notifications.js
@@ -79,7 +79,12 @@ function AddNotification (msg, panel) {
     notification.html = true;
     if (msg.replacement_map) {
       for (var key in msg.replacement_map) {
-        notification.SetDialogVariable(key, msg.replacement_map[key]);
+        var val = msg.replacement_map[key];
+        if (typeof val === 'number') {
+          notification.SetDialogVariableInt(key, val);
+        } else {
+          notification.SetDialogVariable(key, val);
+        }
       }
     }
     var text = msg.text || 'No Text provided';

--- a/content/panorama/scripts/barebones_notifications.ts
+++ b/content/panorama/scripts/barebones_notifications.ts
@@ -126,7 +126,12 @@ function AddNotification(msg: NotificationData, panel: Panel) {
     notification.html = true;
     if (msg.replacement_map) {
       for (const key in msg.replacement_map) {
-        notification.SetDialogVariable(key, msg.replacement_map[key]);
+        let val = msg.replacement_map[key]
+        if (typeof val === 'number') {
+          notification.SetDialogVariableInt(key, val);
+        } else {
+          notification.SetDialogVariable(key, val);
+        }
       }
     }
     let text = msg.text || 'No Text provided';


### PR DESCRIPTION
I'm certain I did it this way and found it not working the first time round. Whatever works though.

<sub>inb4 it doesn't work when it goes into production again</sub>