### PR TITLE
Prevent Doom from getting True Sight from Cave creeps

### DIFF
--- a/game/scripts/npc/units/npc_dota_neutral_custom_cave_big_horse.txt
+++ b/game/scripts/npc/units/npc_dota_neutral_custom_cave_big_horse.txt
@@ -1,7 +1,7 @@
 "DOTAUnits"
 {
 	"npc_dota_neutral_custom_cave_big_horse"
-	{										
+	{
 		// General
 		//----------------------------------------------------------------
 		"Model"						"models/creeps/neutral_creeps/n_creep_centaur_lrg/n_creep_centaur_lrg.vmdl"	// Model.
@@ -15,8 +15,8 @@
 		// Abilities
 		//----------------------------------------------------------------
 		"Ability1"				"centaur_khan_war_stomp"			// Ability 1
-		"Ability2"				"necronomicon_warrior_sight"			// Ability 2
-		"Ability3"				"boss_inner_beast"				// Ability 3
+		"Ability2"				"boss_inner_beast"			// Ability 2
+		"Ability3"				"necronomicon_warrior_sight"				// Ability 3
 		"Ability4"				""						// Ability 4
 
 		// Armor
@@ -27,13 +27,13 @@
 		//----------------------------------------------------------------
 		"AttackCapabilities"			"DOTA_UNIT_CAP_MELEE_ATTACK"
 		"AttackDamageMin"			"49"						// Damage range min.
-		"AttackDamageMax"			"55"						// Damage range max.	
+		"AttackDamageMax"			"55"						// Damage range max.
 		"AttackRate"				"3.0"						// Speed of attack.
 		"AttackAnimationPoint"			"0.3"						// Normalized time in animation cycle to attack.
 		"AttackAcquisitionRange"		"500"						// Range within a target can be acquired.
 		"AttackRange"				"100"						// Range within a target can be attacked.
 		"ProjectileModel"			""						// Particle system model for projectile.
-		"ProjectileSpeed"			"0"						// Speed of projectile.		   
+		"ProjectileSpeed"			"0"						// Speed of projectile.
 
 		// Bounds
 		//----------------------------------------------------------------
@@ -56,8 +56,8 @@
 		"StatusHealth"				"1100"						// Base health.
 		"StatusHealthRegen"			"1"						// Health regeneration rate.
 		"StatusMana"				"200"						// Base mana.
-		"StatusManaRegen"			"1.0"						// Mana regeneration rate.		 
-		
+		"StatusManaRegen"			"1.0"						// Mana regeneration rate.
+
 		// Vision
 		//----------------------------------------------------------------
 		"VisionDaytimeRange"			"800"						// Range of vision during day light.

--- a/game/scripts/npc/units/npc_dota_neutral_custom_cave_black_drake.txt
+++ b/game/scripts/npc/units/npc_dota_neutral_custom_cave_black_drake.txt
@@ -1,6 +1,6 @@
 "DOTAUnits"
 {
-	"npc_dota_neutral_custom_cave_black_drake"	
+	"npc_dota_neutral_custom_cave_black_drake"
 	{
 		// General
 		//----------------------------------------------------------------
@@ -14,9 +14,9 @@
 
 		// Abilities
 		//----------------------------------------------------------------
-		"Ability1"					"necronomicon_warrior_sight"		// Ability 1
-		"Ability2"					"boss_inner_beast"			// Ability 2
-		"Ability3"					""					// Ability 3
+		"Ability1"					"boss_inner_beast"		// Ability 1
+		"Ability2"					"doom_bringer_empty2"			// Ability 2
+		"Ability3"					"necronomicon_warrior_sight"					// Ability 3
 		"Ability4"					""					// Ability 4
 
 		// Armor
@@ -33,7 +33,7 @@
 		"AttackAcquisitionRange"		"300"		// Range within a target can be acquired.
 		"AttackRange"				"300"		// Range within a target can be attacked.
 		"ProjectileModel"			"particles/neutral_fx/black_drake_attack.vpcf" // Particle system model for projectile.
-		"ProjectileSpeed"			"900"		// Speed of projectile.		     
+		"ProjectileSpeed"			"900"		// Speed of projectile.
 
 		// Bounds
 		//----------------------------------------------------------------
@@ -49,7 +49,7 @@
 		// Movement
 		//----------------------------------------------------------------
 		"MovementCapabilities"		"DOTA_UNIT_CAP_MOVE_GROUND"
-		"MovementSpeed"				"350"		// Speed.			
+		"MovementSpeed"				"350"		// Speed.
 
 		// Status
 		//----------------------------------------------------------------
@@ -57,7 +57,7 @@
 		"StatusHealthRegen"			"0.5"		// Health regeneration rate.
 		"StatusMana"				"0"			// Base mana.
 		"StatusManaRegen"			"1"			// Mana regeneration rate.
-		
+
 		// Vision
 		//----------------------------------------------------------------
 		"VisionDaytimeRange"		"800"		// Range of vision during day light.


### PR DESCRIPTION
With the level 20 Talent, Doom can Devour the Cave creeps and thus get True Sight from some of them. He won't get the ability if it's not in the first 2 slots, so the centaur's abilities were reordered to give the attack speed aura instead. Dragon currently just has an empty ability, which looks slightly odd if you examine the creep. Dunno if we might want to give them another ability.