### PR TITLE
Make all boss sounds respect Fog of War

### DIFF
--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_dire_hound_boss/ranged_quill_attack.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_dire_hound_boss/ranged_quill_attack.lua
@@ -8,7 +8,8 @@ function ranged_quill_attack:OnSpellStart()
 		self.attack_width_initial = self:GetSpecialValueFor( "attack_width_initial" )
 		self.attack_width_end = self:GetSpecialValueFor( "attack_width_end" )
 		self.attack_distance = self:GetSpecialValueFor( "attack_distance" )
-		self.attack_damage = self:GetSpecialValueFor( "attack_damage" )
+    self.attack_damage = self:GetSpecialValueFor( "attack_damage" )
+    local caster = self:GetCaster()
 
 		local vPos = nil
 		if self:GetCursorTarget() then
@@ -17,7 +18,7 @@ function ranged_quill_attack:OnSpellStart()
 			vPos = self:GetCursorPosition()
 		end
 
-		local vDirection = vPos - self:GetCaster():GetOrigin()
+		local vDirection = vPos - caster:GetOrigin()
 		vDirection.z = 0.0
 		vDirection = vDirection:Normalized()
 
@@ -26,18 +27,18 @@ function ranged_quill_attack:OnSpellStart()
 		local info = {
 			EffectName = "particles/test_particle/test_model_cluster_linear_projectile.vpcf",
 			Ability = self,
-			vSpawnOrigin = self:GetCaster():GetOrigin(),
+			vSpawnOrigin = caster:GetOrigin(),
 			fStartRadius = self.attack_width_initial,
 			fEndRadius = self.attack_width_end,
 			vVelocity = vDirection * self.attack_speed,
 			fDistance = self.attack_distance,
-			Source = self:GetCaster(),
+			Source = caster,
 			iUnitTargetTeam = DOTA_UNIT_TARGET_TEAM_ENEMY,
 			iUnitTargetType = DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC + DOTA_UNIT_TARGET_BUILDING,
 		}
 
 		ProjectileManager:CreateLinearProjectile( info )
-		EmitSoundOn( "Hound.QuillAttack.Cast", self:GetCaster() )
+		caster:EmitSound("Hound.QuillAttack.Cast")
 	end
 end
 
@@ -56,13 +57,13 @@ function ranged_quill_attack:OnProjectileHit( hTarget, vLocation )
 
 			ApplyDamage( damage )
 
-			local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_bristleback/bristleback_quill_spray_impact.vpcf", PATTACH_CUSTOMORIGIN, hTarget );
-			ParticleManager:SetParticleControlEnt( nFXIndex, 0, hTarget, PATTACH_ABSORIGIN_FOLLOW, nil, hTarget:GetOrigin(), true );
-			ParticleManager:SetParticleControlEnt( nFXIndex, 1, hTarget, PATTACH_POINT_FOLLOW, "attach_hitloc", hTarget:GetOrigin(), true );
-			ParticleManager:SetParticleControlEnt( nFXIndex, 2, self:GetCaster(), PATTACH_ABSORIGIN_FOLLOW, nil, hTarget:GetOrigin(), true  );
-			ParticleManager:ReleaseParticleIndex( nFXIndex );
+			local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_bristleback/bristleback_quill_spray_impact.vpcf", PATTACH_CUSTOMORIGIN, hTarget )
+			ParticleManager:SetParticleControlEnt( nFXIndex, 0, hTarget, PATTACH_ABSORIGIN_FOLLOW, nil, hTarget:GetOrigin(), true )
+			ParticleManager:SetParticleControlEnt( nFXIndex, 1, hTarget, PATTACH_POINT_FOLLOW, "attach_hitloc", hTarget:GetOrigin(), true )
+			ParticleManager:SetParticleControlEnt( nFXIndex, 2, self:GetCaster(), PATTACH_ABSORIGIN_FOLLOW, nil, hTarget:GetOrigin(), true  )
+			ParticleManager:ReleaseParticleIndex( nFXIndex )
 
-			EmitSoundOn( "Hound.QuillAttack.Target", hTarget );
+			hTarget:EmitSound("Hound.QuillAttack.Target")
 		end
 
 		return true

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_lycan_boss/lycan_boss_claw_attack.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_lycan_boss/lycan_boss_claw_attack.lua
@@ -59,35 +59,36 @@ end
 --------------------------------------------------------------------------------
 
 function lycan_boss_claw_attack:PlayClawAttackSpeech( bShapeshift )
-	if IsServer() then
-		if self:GetCaster().nLastClawSound == nil then
-			self:GetCaster().nLastClawSound = 0
+  if IsServer() then
+    local caster = self:GetCaster()
+		if caster.nLastClawSound == nil then
+			caster.nLastClawSound = 0
 		end
 		local nSound = RandomInt( 0, 3 )
-		while nSound == self:GetCaster().nLastClawSound do
+		while nSound == caster.nLastClawSound do
 			nSound = RandomInt( 0, 3 )
 		end
 		if nSound == 1 then
-				EmitSoundOn( "lycan_lycan_pain_01", self:GetCaster() )
+      caster:EmitSound("lycan_lycan_pain_01")
 		end
 		if nSound == 2 then
-			EmitSoundOn( "lycan_lycan_pain_08", self:GetCaster() )
+			caster:EmitSound("lycan_lycan_pain_08")
 		end
 		if bShapeshift then
 			if nSound == 0 then
-				EmitSoundOn( "lycan_lycan_wolf_attack_01", self:GetCaster() )
+				caster:EmitSound("lycan_lycan_wolf_attack_01")
 			end
 			if nSound == 3 then
-				EmitSoundOn( "lycan_lycan_wolf_attack_10", self:GetCaster() )
+				caster:EmitSound("lycan_lycan_wolf_attack_10")
 			end
 		else
 			if nSound == 0 then
-				EmitSoundOn( "lycan_lycan_attack_01", self:GetCaster() )
+				caster:EmitSound("lycan_lycan_attack_01")
 			end
 			if nSound == 3 then
-				EmitSoundOn( "lycan_lycan_pain_09", self:GetCaster() )
+				caster:EmitSound("lycan_lycan_pain_09")
 			end
 		end
-		self:GetCaster().nLastClawSound = nSound
+		caster.nLastClawSound = nSound
 	end
 end

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_lycan_boss/lycan_boss_claw_lunge.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_lycan_boss/lycan_boss_claw_lunge.lua
@@ -4,12 +4,13 @@ LinkLuaModifier( "modifier_lycan_boss_claw_lunge", "modifiers/modifier_lycan_bos
 --------------------------------------------------------------------------------
 
 function lycan_boss_claw_lunge:OnAbilityPhaseStart()
-	if IsServer() then
-		self:GetCaster():StartGesture( ACT_DOTA_CAST_ABILITY_2 )
-		EmitSoundOn( "LycanBoss.Howl", self:GetCaster() )
+  if IsServer() then
+    local caster = self:GetCaster()
+		caster:StartGesture( ACT_DOTA_CAST_ABILITY_2 )
+		caster:EmitSound("LycanBoss.Howl")
 
-		self.nPreviewFX = ParticleManager:CreateParticle( "particles/darkmoon_creep_warning.vpcf", PATTACH_ABSORIGIN_FOLLOW, self:GetCaster() )
-		ParticleManager:SetParticleControlEnt( self.nPreviewFX, 0, self:GetCaster(), PATTACH_ABSORIGIN_FOLLOW, nil, self:GetCaster():GetOrigin(), true )
+		self.nPreviewFX = ParticleManager:CreateParticle( "particles/darkmoon_creep_warning.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster )
+		ParticleManager:SetParticleControlEnt( self.nPreviewFX, 0, caster, PATTACH_ABSORIGIN_FOLLOW, nil, caster:GetOrigin(), true )
 		ParticleManager:SetParticleControl( self.nPreviewFX, 1, Vector( 150, 150, 150 ) )
 		ParticleManager:SetParticleControl( self.nPreviewFX, 15, Vector( 188, 26, 26 ) )
 	end

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_lycan_boss/lycan_boss_rupture_ball.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_lycan_boss/lycan_boss_rupture_ball.lua
@@ -4,11 +4,12 @@ lycan_boss_rupture_ball = class(AbilityBaseClass)
 --------------------------------------------------------------------------------
 
 function lycan_boss_rupture_ball:OnAbilityPhaseStart()
-	if IsServer() then
-		EmitSoundOn( "lycan_lycan_attack_09", self:GetCaster() )
+  if IsServer() then
+    local caster = self:GetCaster()
+		caster:EmitSound("lycan_lycan_attack_09")
 
-		self.nPreviewFX = ParticleManager:CreateParticle( "particles/darkmoon_creep_warning.vpcf", PATTACH_ABSORIGIN_FOLLOW, self:GetCaster() )
-		ParticleManager:SetParticleControlEnt( self.nPreviewFX, 0, self:GetCaster(), PATTACH_ABSORIGIN_FOLLOW, nil, self:GetCaster():GetOrigin(), true )
+		self.nPreviewFX = ParticleManager:CreateParticle( "particles/darkmoon_creep_warning.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster )
+		ParticleManager:SetParticleControlEnt( self.nPreviewFX, 0, caster, PATTACH_ABSORIGIN_FOLLOW, nil, caster:GetOrigin(), true )
 		ParticleManager:SetParticleControl( self.nPreviewFX, 1, Vector( 150, 150, 150 ) )
 		ParticleManager:SetParticleControl( self.nPreviewFX, 15, Vector( 188, 26, 26 ) )
 	end
@@ -33,7 +34,8 @@ end
 --------------------------------------------------------------------------------
 
 function lycan_boss_rupture_ball:OnSpellStart()
-	if IsServer() then
+  if IsServer() then
+    local caster = self:GetCaster()
 		ParticleManager:DestroyParticle( self.nPreviewFX, false )
 
 		self.attack_speed = self:GetSpecialValueFor( "attack_speed" )
@@ -48,7 +50,7 @@ function lycan_boss_rupture_ball:OnSpellStart()
 			vPos = self:GetCursorPosition()
 		end
 
-		local vDirection = vPos - self:GetCaster():GetOrigin()
+		local vDirection = vPos - caster:GetOrigin()
 		vDirection.z = 0.0
 		vDirection = vDirection:Normalized()
 
@@ -57,18 +59,18 @@ function lycan_boss_rupture_ball:OnSpellStart()
 		local info = {
 			EffectName = "particles/lycanboss_ruptureball_gale.vpcf",
 			Ability = self,
-			vSpawnOrigin = self:GetCaster():GetOrigin(),
+			vSpawnOrigin = caster:GetOrigin(),
 			fStartRadius = self.attack_width_initial,
 			fEndRadius = self.attack_width_end,
 			vVelocity = vDirection * self.attack_speed,
 			fDistance = self.attack_distance,
-			Source = self:GetCaster(),
+			Source = caster,
 			iUnitTargetTeam = DOTA_UNIT_TARGET_TEAM_ENEMY,
 			iUnitTargetType = DOTA_UNIT_TARGET_HERO,
 		}
 
 		ProjectileManager:CreateLinearProjectile( info )
-		EmitSoundOn( "Lycan.RuptureBall", self:GetCaster() )
+		caster:EmitSound("Lycan.RuptureBall")
 	end
 end
 
@@ -77,7 +79,7 @@ end
 function lycan_boss_rupture_ball:OnProjectileHit( hTarget, vLocation )
 	if IsServer() then
 		if hTarget ~= nil and ( not hTarget:IsMagicImmune() ) and ( not hTarget:IsInvulnerable() ) and hTarget:GetUnitName() then
-			EmitSoundOn( "Lycan.RuptureBall.Impact", hTarget );
+		  hTarget:EmitSound("Lycan.RuptureBall.Impact");
 
 			hTarget:AddNewModifier( self:GetCaster(), self, "modifier_bloodseeker_rupture", { duration = self:GetSpecialValueFor( "duration" ) } )
 		end

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_lycan_boss/lycan_boss_shapeshift.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_lycan_boss/lycan_boss_shapeshift.lua
@@ -6,7 +6,7 @@ LinkLuaModifier( "modifier_lycan_boss_shapeshift", "modifiers/modifier_lycan_bos
 
 function lycan_boss_shapeshift:OnAbilityPhaseStart()
 	if IsServer() then
-		EmitSoundOn( "lycan_lycan_ability_shapeshift_06", self:GetCaster() )
+		self:GetCaster():EmitSound("lycan_lycan_ability_shapeshift_06")
 	end
 	return true
 end

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_lycan_boss/lycan_boss_summon_wolves.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_lycan_boss/lycan_boss_summon_wolves.lua
@@ -5,15 +5,16 @@ lycan_boss_summon_wolves = class(AbilityBaseClass)
 
 function lycan_boss_summon_wolves:OnAbilityPhaseStart()
 	if IsServer() then
-		local nSound = RandomInt( 1, 3 )
+    local nSound = RandomInt( 1, 3 )
+    local caster = self:GetCaster()
 		if nSound == 1 then
-			EmitSoundOn( "lycan_lycan_ability_summon_02", self:GetCaster() )
+			caster:EmitSound("lycan_lycan_ability_summon_02")
 		end
 		if nSound == 2 then
-			EmitSoundOn( "lycan_lycan_ability_summon_03", self:GetCaster() )
+			caster:EmitSound("lycan_lycan_ability_summon_03")
 		end
 		if nSound == 3 then
-			EmitSoundOn( "lycan_lycan_ability_summon_06", self:GetCaster() )
+			caster:EmitSound("lycan_lycan_ability_summon_06")
 		end
 	end
 	return true
@@ -22,33 +23,34 @@ end
 --------------------------------------------------------------------------------
 
 function lycan_boss_summon_wolves:OnSpellStart()
-	if IsServer() then
-		EmitSoundOn( "LycanBoss.SummonWolves", self:GetCaster() )
+  if IsServer() then
+    local caster = self:GetCaster()
+		caster:EmitSound("LycanBoss.SummonWolves")
 		local nHoundSpawns = 3
 		local nHoundBossSpawns = 1
 		local nWerewolves = 1
-		if self:GetCaster():FindModifierByName( "modifier_lycan_boss_shapeshift" ) ~= nil then
+		if caster:FindModifierByName( "modifier_lycan_boss_shapeshift" ) ~= nil then
 			nHoundSpawns = 6
 			nHoundBossSpawns = 2
 			nWerewolves = 2
 		end
 
 		for i = 0, nHoundSpawns do
-			if #self:GetCaster().LYCAN_BOSS_SUMMONED_UNITS + 1 < self:GetCaster().LYCAN_BOSS_MAX_SUMMONS then
-				local hHound = CreateUnitByName( "npc_dota_creature_dire_hound", self:GetCaster():GetAbsOrigin(), true, self:GetCaster(), self:GetCaster(), self:GetCaster():GetTeamNumber() )
+			if #caster.LYCAN_BOSS_SUMMONED_UNITS + 1 < caster.LYCAN_BOSS_MAX_SUMMONS then
+				local hHound = CreateUnitByName( "npc_dota_creature_dire_hound", caster:GetAbsOrigin(), true, caster, caster, caster:GetTeamNumber() )
 				if hHound ~= nil then
-					hHound:SetInitialGoalEntity( self:GetCaster():GetInitialGoalEntity() )
-					table.insert( self:GetCaster().LYCAN_BOSS_SUMMONED_UNITS, hHound )
-					if self:GetCaster().zone ~= nil then
-						self:GetCaster().zone:AddEnemyToZone( hHound )
+					hHound:SetInitialGoalEntity( caster:GetInitialGoalEntity() )
+					table.insert( caster.LYCAN_BOSS_SUMMONED_UNITS, hHound )
+					if caster.zone ~= nil then
+						caster.zone:AddEnemyToZone( hHound )
 					end
 
 					local vRandomOffset = Vector( RandomInt( -300, 300 ), RandomInt( -300, 300 ), 0 )
-					local vSpawnPoint = self:GetCaster():GetAbsOrigin() + vRandomOffset
+					local vSpawnPoint = caster:GetAbsOrigin() + vRandomOffset
 					FindClearSpaceForUnit( hHound, vSpawnPoint, true )
 
-					local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_summon_wolves_cast.vpcf", PATTACH_CUSTOMORIGIN, self:GetCaster() )
-					ParticleManager:SetParticleControlEnt( nFXIndex, 0, self:GetCaster(), PATTACH_POINT_FOLLOW, "attach_attack1", self:GetCaster():GetAbsOrigin(), true )
+					local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_summon_wolves_cast.vpcf", PATTACH_CUSTOMORIGIN, caster )
+					ParticleManager:SetParticleControlEnt( nFXIndex, 0, caster, PATTACH_POINT_FOLLOW, "attach_attack1", caster:GetAbsOrigin(), true )
 					ParticleManager:ReleaseParticleIndex( nFXIndex )
 					ParticleManager:ReleaseParticleIndex(  ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_summon_wolves_spawn.vpcf", PATTACH_ABSORIGIN_FOLLOW, hHound ) )
 				end
@@ -56,21 +58,21 @@ function lycan_boss_summon_wolves:OnSpellStart()
 		end
 
 		for i = 0, nHoundBossSpawns do
-			if #self:GetCaster().LYCAN_BOSS_SUMMONED_UNITS + 1 < self:GetCaster().LYCAN_BOSS_MAX_SUMMONS then
-				local hHoundBoss = CreateUnitByName( "npc_dota_creature_dire_hound_boss", self:GetCaster():GetAbsOrigin(), true, self:GetCaster(), self:GetCaster(), self:GetCaster():GetTeamNumber() )
+			if #caster.LYCAN_BOSS_SUMMONED_UNITS + 1 < caster.LYCAN_BOSS_MAX_SUMMONS then
+				local hHoundBoss = CreateUnitByName( "npc_dota_creature_dire_hound_boss", caster:GetAbsOrigin(), true, caster, caster, caster:GetTeamNumber() )
 				if hHoundBoss ~= nil then
-					hHoundBoss:SetInitialGoalEntity( self:GetCaster():GetInitialGoalEntity() )
-					table.insert( self:GetCaster().LYCAN_BOSS_SUMMONED_UNITS, hHoundBoss )
-					if self:GetCaster().zone ~= nil then
-						self:GetCaster().zone:AddEnemyToZone( hHoundBoss )
+					hHoundBoss:SetInitialGoalEntity( caster:GetInitialGoalEntity() )
+					table.insert( caster.LYCAN_BOSS_SUMMONED_UNITS, hHoundBoss )
+					if caster.zone ~= nil then
+						caster.zone:AddEnemyToZone( hHoundBoss )
 					end
 
 					local vRandomOffset = Vector( RandomInt( -300, 300 ), RandomInt( -300, 300 ), 0 )
-					local vSpawnPoint = self:GetCaster():GetAbsOrigin() + vRandomOffset
+					local vSpawnPoint = caster:GetAbsOrigin() + vRandomOffset
 					FindClearSpaceForUnit( hHoundBoss, vSpawnPoint, true )
 
-					local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_summon_wolves_cast.vpcf", PATTACH_CUSTOMORIGIN, self:GetCaster() )
-					ParticleManager:SetParticleControlEnt( nFXIndex, 0, self:GetCaster(), PATTACH_POINT_FOLLOW, "attach_attack1", self:GetCaster():GetAbsOrigin(), true )
+					local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_summon_wolves_cast.vpcf", PATTACH_CUSTOMORIGIN, caster )
+					ParticleManager:SetParticleControlEnt( nFXIndex, 0, caster, PATTACH_POINT_FOLLOW, "attach_attack1", caster:GetAbsOrigin(), true )
 					ParticleManager:ReleaseParticleIndex( nFXIndex )
 					ParticleManager:ReleaseParticleIndex(  ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_summon_wolves_spawn.vpcf", PATTACH_ABSORIGIN_FOLLOW, hHoundBoss ) )
 				end
@@ -78,28 +80,28 @@ function lycan_boss_summon_wolves:OnSpellStart()
 		end
 
 		for i = 0, nWerewolves do
-			if #self:GetCaster().LYCAN_BOSS_SUMMONED_UNITS + 1 < self:GetCaster().LYCAN_BOSS_MAX_SUMMONS then
-				local hWerewolf = CreateUnitByName( "npc_dota_creature_werewolf", self:GetCaster():GetAbsOrigin(), true, self:GetCaster(), self:GetCaster(), self:GetCaster():GetTeamNumber() )
+			if #caster.LYCAN_BOSS_SUMMONED_UNITS + 1 < caster.LYCAN_BOSS_MAX_SUMMONS then
+				local hWerewolf = CreateUnitByName( "npc_dota_creature_werewolf", caster:GetAbsOrigin(), true, caster, caster, caster:GetTeamNumber() )
 				if hWerewolf ~= nil then
-					hWerewolf:SetInitialGoalEntity( self:GetCaster():GetInitialGoalEntity() )
-					table.insert( self:GetCaster().LYCAN_BOSS_SUMMONED_UNITS, hWerewolf )
-					if self:GetCaster().zone ~= nil then
-						self:GetCaster().zone:AddEnemyToZone( hWerewolf )
+					hWerewolf:SetInitialGoalEntity( caster:GetInitialGoalEntity() )
+					table.insert( caster.LYCAN_BOSS_SUMMONED_UNITS, hWerewolf )
+					if caster.zone ~= nil then
+						caster.zone:AddEnemyToZone( hWerewolf )
 					end
 
 					local vRandomOffset = Vector( RandomInt( -300, 300 ), RandomInt( -300, 300 ), 0 )
-					local vSpawnPoint = self:GetCaster():GetAbsOrigin() + vRandomOffset
+					local vSpawnPoint = caster:GetAbsOrigin() + vRandomOffset
 					FindClearSpaceForUnit( hWerewolf, vSpawnPoint, true )
 
-					local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_summon_wolves_cast.vpcf", PATTACH_CUSTOMORIGIN, self:GetCaster() )
-					ParticleManager:SetParticleControlEnt( nFXIndex, 0, self:GetCaster(), PATTACH_POINT_FOLLOW, "attach_attack1", self:GetCaster():GetAbsOrigin(), true )
+					local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_summon_wolves_cast.vpcf", PATTACH_CUSTOMORIGIN, caster )
+					ParticleManager:SetParticleControlEnt( nFXIndex, 0, caster, PATTACH_POINT_FOLLOW, "attach_attack1", caster:GetAbsOrigin(), true )
 					ParticleManager:ReleaseParticleIndex( nFXIndex )
 					ParticleManager:ReleaseParticleIndex(  ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_summon_wolves_spawn.vpcf", PATTACH_ABSORIGIN_FOLLOW, hWerewolf ) )
 				end
 			end
 		end
 
-		self:GetCaster().nCAST_SUMMON_WOLVES_COUNT = self:GetCaster().nCAST_SUMMON_WOLVES_COUNT + 1
+		caster.nCAST_SUMMON_WOLVES_COUNT = caster.nCAST_SUMMON_WOLVES_COUNT + 1
 	end
 end
 

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_ogre_seer/ogre_magi_channelled_bloodlust.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_ogre_seer/ogre_magi_channelled_bloodlust.lua
@@ -6,17 +6,18 @@ LinkLuaModifier( "modifier_ogre_magi_channelled_bloodlust", "modifiers/modifier_
 function ogre_magi_channelled_bloodlust:OnSpellStart()
 	if IsServer() then
 		local hTarget = self:GetCursorTarget()
-		if hTarget ~= nil then
+    if hTarget ~= nil then
+      local caster = self:GetCaster()
 			self.hTarget = hTarget
-			self.hTarget:AddNewModifier( self:GetCaster(), self, "modifier_ogre_magi_channelled_bloodlust", { duration = -1 } )
+			self.hTarget:AddNewModifier( caster, self, "modifier_ogre_magi_channelled_bloodlust", { duration = -1 } )
 
-			EmitSoundOn( "OgreMagi.Bloodlust.Target", self.hTarget )
-			EmitSoundOn( "OgreMagi.Bloodlust.Target.FP", self.hTarget )
-			EmitSoundOn( "OgreMagi.Bloodlust.Loop", self:GetCaster() )
+			self.hTarget:EmitSound( "OgreMagi.Bloodlust.Target")
+			self.hTarget:EmitSound( "OgreMagi.Bloodlust.Target.FP")
+			caster:EmitSound("OgreMagi.Bloodlust.Loop")
 
-			local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_ogre_magi/ogre_magi_bloodlust_cast.vpcf", PATTACH_CUSTOMORIGIN, self:GetCaster() )
-			ParticleManager:SetParticleControlEnt( nFXIndex, 0, self:GetCaster(), PATTACH_POINT_FOLLOW, "attach_attack1", self:GetCaster():GetOrigin(), true )
-			ParticleManager:SetParticleControlEnt( nFXIndex, 1, self:GetCaster(), PATTACH_ABSORIGIN_FOLLOW, nil, self:GetCaster():GetOrigin(), true  )
+			local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_ogre_magi/ogre_magi_bloodlust_cast.vpcf", PATTACH_CUSTOMORIGIN, caster )
+			ParticleManager:SetParticleControlEnt( nFXIndex, 0, caster, PATTACH_POINT_FOLLOW, "attach_attack1", caster:GetOrigin(), true )
+			ParticleManager:SetParticleControlEnt( nFXIndex, 1, caster, PATTACH_ABSORIGIN_FOLLOW, nil, caster:GetOrigin(), true  )
 			ParticleManager:SetParticleControlEnt( nFXIndex, 2, self.hTarget, PATTACH_POINT_FOLLOW, "attach_hitloc", self.hTarget:GetOrigin(), true )
 			ParticleManager:SetParticleControlEnt( nFXIndex, 3, self.hTarget, PATTACH_ABSORIGIN_FOLLOW, nil, self.hTarget:GetOrigin(), true   )
 			ParticleManager:ReleaseParticleIndex( nFXIndex )
@@ -27,17 +28,18 @@ end
 -----------------------------------------------------------------------------
 
 function ogre_magi_channelled_bloodlust:OnChannelFinish( bInterrupted )
-	if IsServer() then
+  if IsServer() then
+    local caster = self:GetCaster()
 		if bInterrupted then
 			self:StartCooldown( self:GetSpecialValueFor( "interrupted_cooldown" ) )
 		end
 
 		if self.hTarget ~= nil then
-			local hMyBuff = self.hTarget:FindModifierByNameAndCaster( "modifier_ogre_magi_channelled_bloodlust", self:GetCaster() )
+			local hMyBuff = self.hTarget:FindModifierByNameAndCaster( "modifier_ogre_magi_channelled_bloodlust", caster )
 			if hMyBuff then
 				hMyBuff:Destroy()
 			end
-			StopSoundOn( "OgreMagi.Bloodlust.Loop", self:GetCaster() )
+			caster:StopSound("OgreMagi.Bloodlust.Loop")
 			self.hTarget = nil
 		end
 	end

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_ogre_seer/ogre_seer_area_ignite.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_ogre_seer/ogre_seer_area_ignite.lua
@@ -5,7 +5,8 @@ LinkLuaModifier( "modifier_ogre_seer_area_ignite_thinker", "modifiers/modifier_o
 ----------------------------------------------------------------------------------------
 
 function ogre_seer_area_ignite:OnSpellStart()
-	if IsServer() then
+  if IsServer() then
+    local caster = self:GetCaster()
 		local vTargetPositions = { }
 		vTargetPositions[ 1 ] = self:GetCursorPosition()
 		vTargetPositions[ 2 ] = self:GetCursorPosition() + RandomVector( RandomFloat( 250, 300 ) )
@@ -14,22 +15,22 @@ function ogre_seer_area_ignite:OnSpellStart()
 		self.hThinkers = { }
 
 		for i, vTargetPos in ipairs( vTargetPositions ) do
-			self.hThinkers[ i ] = CreateModifierThinker( self:GetCaster(), self, "modifier_ogre_seer_area_ignite_thinker", { duration = -1 }, vTargetPos, self:GetCaster():GetTeamNumber(), false )
+			self.hThinkers[ i ] = CreateModifierThinker( caster, self, "modifier_ogre_seer_area_ignite_thinker", { duration = -1 }, vTargetPos, caster:GetTeamNumber(), false )
 			if self.hThinkers[ i ] ~= nil then
 				local projectile =
 				{
 					Target = self.hThinkers[ i ],
-					Source = self:GetCaster(),
+					Source = caster,
 					Ability = self,
 					EffectName = "particles/units/heroes/hero_ogre_magi/ogre_magi_ignite.vpcf",
 					iMoveSpeed = self:GetSpecialValueFor( "projectile_speed" ),
-					vSourceLoc = self:GetCaster():GetOrigin(),
+					vSourceLoc = caster:GetOrigin(),
 					bDodgeable = false,
 					bProvidesVision = false,
 				}
 
 				ProjectileManager:CreateTrackingProjectile( projectile )
-				EmitSoundOn( "OgreMagi.Ignite.Cast", self:GetCaster() )
+				caster:EmitSound("OgreMagi.Ignite.Cast")
 			end
 		end
 	end

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_ogre_tank_boss/ogre_tank_boss_melee_smash.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_ogre_tank_boss/ogre_tank_boss_melee_smash.lua
@@ -23,13 +23,14 @@ end
 -----------------------------------------------------------------------------
 
 function ogre_tank_boss_melee_smash:OnSpellStart()
-	if IsServer() then
-		EmitSoundOn( "OgreTank.Grunt", self:GetCaster() )
+  if IsServer() then
+    local caster = self:GetCaster()
+		caster:EmitSound("OgreTank.Grunt")
 		local flSpeed = self:GetSpecialValueFor( "base_swing_speed" ) / self:GetPlaybackRateOverride()
-		local vToTarget = self:GetCursorPosition() - self:GetCaster():GetOrigin()
+		local vToTarget = self:GetCursorPosition() - caster:GetOrigin()
 		vToTarget = vToTarget:Normalized()
-		local vTarget = self:GetCaster():GetOrigin() + vToTarget * self:GetCastRange( self:GetCaster():GetOrigin(), nil )
-		local hThinker = CreateModifierThinker( self:GetCaster(), self, "modifier_ogre_tank_melee_smash_thinker", { duration = flSpeed }, vTarget, self:GetCaster():GetTeamNumber(), false )
+		local vTarget = caster:GetOrigin() + vToTarget * self:GetCastRange( caster:GetOrigin(), nil )
+		local hThinker = CreateModifierThinker( caster, self, "modifier_ogre_tank_melee_smash_thinker", { duration = flSpeed }, vTarget, caster:GetTeamNumber(), false )
 	end
 end
 

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_spider_boss/spider_boss_larval_parasite.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_spider_boss/spider_boss_larval_parasite.lua
@@ -35,7 +35,8 @@ end
 --------------------------------------------------------------------------------
 
 function spider_boss_larval_parasite:OnSpellStart()
-	if IsServer() then
+  if IsServer() then
+    local caster = self:GetCaster()
 		ParticleManager:DestroyParticle( self.nPreviewFX, false )
 
 		self.projectile_speed = self:GetSpecialValueFor( "projectile_speed" )
@@ -46,12 +47,12 @@ function spider_boss_larval_parasite:OnSpellStart()
 		self.projectile_distance = self:GetSpecialValueFor( "projectile_distance" )
 		self.spider_lifetime = self:GetSpecialValueFor( "spider_lifetime" )
 
-		local fCastRange = self:GetCastRange( self:GetCaster():GetOrigin(), nil )
-		local hEnemies = FindUnitsInRadius( self:GetCaster():GetTeamNumber(), self:GetCaster():GetOrigin(), nil, fCastRange, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_CLOSEST, false )
+		local fCastRange = self:GetCastRange( caster:GetOrigin(), nil )
+		local hEnemies = FindUnitsInRadius( caster:GetTeamNumber(), caster:GetOrigin(), nil, fCastRange, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_CLOSEST, false )
 
 		for _, hEnemy in pairs( hEnemies ) do
 			local vPos = hEnemy:GetOrigin()
-			local vDirection = vPos - self:GetCaster():GetOrigin()
+			local vDirection = vPos - caster:GetOrigin()
 			vDirection.z = 0.0
 			vDirection = vDirection:Normalized()
 
@@ -60,12 +61,12 @@ function spider_boss_larval_parasite:OnSpellStart()
 			local info = {
 				EffectName = "particles/test_particle/dungeon_broodmother_linear.vpcf",
 				Ability = self,
-				vSpawnOrigin = self:GetCaster():GetOrigin(),
+				vSpawnOrigin = caster:GetOrigin(),
 				fStartRadius = self.projectile_width_initial,
 				fEndRadius = self.projectile_width_end,
 				vVelocity = vDirection * self.projectile_speed,
 				fDistance = self.projectile_distance,
-				Source = self:GetCaster(),
+				Source = caster,
 				iUnitTargetTeam = DOTA_UNIT_TARGET_TEAM_ENEMY,
 				iUnitTargetType = DOTA_UNIT_TARGET_HERO,
 			}
@@ -73,14 +74,14 @@ function spider_boss_larval_parasite:OnSpellStart()
 			ProjectileManager:CreateLinearProjectile( info )
 
 			local nFXIndex = ParticleManager:CreateParticle( "particles/darkmoon_creep_warning.vpcf", PATTACH_CUSTOMORIGIN, nil )
-			ParticleManager:SetParticleControl( nFXIndex, 0, self:GetCaster():GetOrigin() )
+			ParticleManager:SetParticleControl( nFXIndex, 0, caster:GetOrigin() )
 			ParticleManager:SetParticleControl( nFXIndex, 1, info.vVelocity )
 			ParticleManager:SetParticleControl( nFXIndex, 2, Vector( self.projectile_width_end, self.projectile_width_end, self.projectile_width_end ) )
       ParticleManager:DestroyParticle( nFXIndex , false)
       ParticleManager:ReleaseParticleIndex( nFXIndex )
 		end
 
-		EmitSoundOn( "Broodmother.LarvalParasite.Cast", self:GetCaster() )
+		caster:EmitSound("Broodmother.LarvalParasite.Cast")
 	end
 end
 
@@ -91,7 +92,7 @@ function spider_boss_larval_parasite:OnProjectileHit( hTarget, vLocation )
 		if hTarget ~= nil and ( not hTarget:IsMagicImmune() ) and ( not hTarget:IsInvulnerable() ) then
 			hTarget:AddNewModifier( self:GetCaster(), self, "modifier_spider_boss_larval_parasite", { duration = self.buff_duration } )
 
-			EmitSoundOn( "Broodmother.LarvalParasite.Impact", hTarget );
+			hTarget:EmitSound("Broodmother.LarvalParasite.Impact")
 		end
 
 		return true
@@ -101,30 +102,31 @@ end
 --------------------------------------------------------------------------------
 
 function spider_boss_larval_parasite:PlayLarvalParasiteSpeech()
-	if IsServer() then
-		if self:GetCaster().nLastLarvalSound == nil then
-			self:GetCaster().nLastLarvalSound = -1
+  if IsServer() then
+    local caster = self:GetCaster()
+		if caster.nLastLarvalSound == nil then
+			caster.nLastLarvalSound = -1
 		end
 
 		local nSound = RandomInt( 1, 3 )
-		while nSound == self:GetCaster().nLastLarvalSound do
+		while nSound == caster.nLastLarvalSound do
 			nSound = RandomInt( 1, 3 )
 		end
 
 		if nSound == 1 then
-			EmitSoundOn( "broodmother_broo_attack_06", self:GetCaster() )
+			caster:EmitSound("broodmother_broo_attack_06")
 		end
 		if nSound == 2 then
-			EmitSoundOn( "broodmother_broo_attack_10", self:GetCaster() )
+			caster:EmitSound("broodmother_broo_attack_10")
 		end
 		if nSound == 3 then
-			EmitSoundOn( "broodmother_broo_attack_11", self:GetCaster() )
+			caster:EmitSound("broodmother_broo_attack_11")
 		end
 		if nSound == 4 then
-			EmitSoundOn( "broodmother_broo_attack_12", self:GetCaster() )
+			caster:EmitSound("broodmother_broo_attack_12")
 		end
 
-		self:GetCaster().nLastLarvalSound = nSound
+		caster.nLastLarvalSound = nSound
 	end
 end
 

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_spider_boss/spider_boss_summon_eggs.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_spider_boss/spider_boss_summon_eggs.lua
@@ -34,7 +34,7 @@ function spider_boss_summon_eggs:OnSpellStart()
 
     local caster = self:GetCaster()
 
-		EmitSoundOn( "LycanBoss.SummonWolves", caster )
+		caster:EmitSound("LycanBoss.SummonWolves")
 
 		local nEggSpawns = 8
 		local nPoisonSpiderSpawns = 4
@@ -132,40 +132,40 @@ function spider_boss_summon_eggs:PlaySummonEggsSpeech()
 		end
 
 		if nSound == 1 then
-			EmitSoundOn( "broodmother_broo_ability_spawn_01", caster )
+			caster:EmitSound("broodmother_broo_ability_spawn_01")
 		end
 		if nSound == 2 then
-			EmitSoundOn( "broodmother_broo_ability_spawn_02", caster )
+			caster:EmitSound("broodmother_broo_ability_spawn_02")
 		end
 		if nSound == 3 then
-			EmitSoundOn( "broodmother_broo_ability_spawn_03", caster )
+			caster:EmitSound("broodmother_broo_ability_spawn_03")
 		end
 		if nSound == 4 then
-			EmitSoundOn( "broodmother_broo_ability_spawn_04", caster )
+			caster:EmitSound("broodmother_broo_ability_spawn_04")
 		end
 		if nSound == 5 then
-			EmitSoundOn( "broodmother_broo_ability_spawn_05", caster )
+			caster:EmitSound("broodmother_broo_ability_spawn_05")
 		end
 		if nSound == 6 then
-			EmitSoundOn( "broodmother_broo_ability_spawn_06", caster )
+			caster:EmitSound("broodmother_broo_ability_spawn_06")
 		end
 		if nSound == 7 then
-			EmitSoundOn( "broodmother_broo_ability_spawn_07", caster )
+			caster:EmitSound("broodmother_broo_ability_spawn_07")
 		end
 		if nSound == 8 then
-			EmitSoundOn( "broodmother_broo_ability_spawn_08", caster )
+			caster:EmitSound("broodmother_broo_ability_spawn_08")
 		end
 		if nSound == 9 then
-			EmitSoundOn( "broodmother_broo_ability_spawn_09", caster )
+			caster:EmitSound("broodmother_broo_ability_spawn_09")
 		end
 		if nSound == 10 then
-			EmitSoundOn( "broodmother_broo_ability_spawn_10", caster )
+			caster:EmitSound("broodmother_broo_ability_spawn_10")
 		end
 		if nSound == 11 then
-			EmitSoundOn( "broodmother_broo_ability_spawn_11", caster )
+			caster:EmitSound("broodmother_broo_ability_spawn_11")
 		end
 		if nSound == 12 then
-			EmitSoundOn( "broodmother_broo_ability_spawn_12", caster )
+			caster:EmitSound("broodmother_broo_ability_spawn_12")
 		end
 
 		caster.nLastSummonEggsSound = nSound

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_spider_boss/spider_poison_spit.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_spider_boss/spider_poison_spit.lua
@@ -3,7 +3,8 @@ spider_poison_spit = class( AbilityBaseClass )
 --------------------------------------------------------------------------------
 
 function spider_poison_spit:OnSpellStart()
-	if IsServer() then
+  if IsServer() then
+    local caster = self:GetCaster()
 		self.attack_speed = self:GetSpecialValueFor( "attack_speed" )
 		self.attack_width_initial = self:GetSpecialValueFor( "attack_width_initial" )
 		self.attack_width_end = self:GetSpecialValueFor( "attack_width_end" )
@@ -16,7 +17,7 @@ function spider_poison_spit:OnSpellStart()
 			vPos = self:GetCursorPosition()
 		end
 
-		local vDirection = vPos - self:GetCaster():GetOrigin()
+		local vDirection = vPos - caster:GetOrigin()
 		vDirection.z = 0.0
 		vDirection = vDirection:Normalized()
 
@@ -25,18 +26,18 @@ function spider_poison_spit:OnSpellStart()
 		local info = {
 			EffectName = "particles/units/heroes/hero_venomancer/venomancer_venomous_gale.vpcf",
 			Ability = self,
-			vSpawnOrigin = self:GetCaster():GetOrigin(),
+			vSpawnOrigin = caster:GetOrigin(),
 			fStartRadius = self.attack_width_initial,
 			fEndRadius = self.attack_width_end,
 			vVelocity = vDirection * self.attack_speed,
 			fDistance = self.attack_distance,
-			Source = self:GetCaster(),
+			Source = caster,
 			iUnitTargetTeam = DOTA_UNIT_TARGET_TEAM_ENEMY,
 			iUnitTargetType = DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC + DOTA_UNIT_TARGET_BUILDING,
 		}
 
 		ProjectileManager:CreateLinearProjectile( info )
-		EmitSoundOn( "Spider.PoisonSpit", self:GetCaster() )
+		caster:EmitSound("Spider.PoisonSpit")
 	end
 end
 
@@ -48,7 +49,7 @@ function spider_poison_spit:OnProjectileHit( hTarget, vLocation )
 			hTarget:AddNewModifier( self:GetCaster(), self, "modifier_venomancer_venomous_gale", { duration = self:GetSpecialValueFor( "duration" ) } )
 
 			ParticleManager:ReleaseParticleIndex( ParticleManager:CreateParticle( "particles/units/heroes/hero_venomancer/venomancer_venomous_gale_impact.vpcf", PATTACH_ABSORIGIN_FOLLOW, hTarget ) )
-			EmitSoundOn( "Spider.PoisonSpit.Impact", hTarget );
+			hTarget:EmitSound("Spider.PoisonSpit.Impact");
 
 			hTarget:AddNewModifier( self:GetCaster(), self, "modifier_disarmed", { duration = self:GetSpecialValueFor( "duration" ) } )
 		end

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_temple_guardian/temple_guardian_hammer_smash.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_temple_guardian/temple_guardian_hammer_smash.lua
@@ -6,7 +6,7 @@ LinkLuaModifier( "modifier_ogre_tank_melee_smash_thinker", "modifiers/modifier_o
 
 function temple_guardian_hammer_smash:OnAbilityPhaseStart()
 	if IsServer() then
-		EmitSoundOn( "TempleGuardian.PreAttack", self:GetCaster() )
+		self:GetCaster():EmitSound("TempleGuardian.PreAttack")
 	end
 	return true
 end

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_temple_guardian/temple_guardian_hammer_throw.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_temple_guardian/temple_guardian_hammer_throw.lua
@@ -4,14 +4,15 @@ LinkLuaModifier( "modifier_temple_guardian_hammer_throw", "modifiers/modifier_te
 --------------------------------------------------------------------------------
 
 function temple_guardian_hammer_throw:OnAbilityPhaseStart()
-	if IsServer() then
-		self.nPreviewFX = ParticleManager:CreateParticle( "particles/test_particle/generic_attack_charge.vpcf", PATTACH_CUSTOMORIGIN, self:GetCaster() )
-		ParticleManager:SetParticleControlEnt( self.nPreviewFX, 0, self:GetCaster(), PATTACH_POINT_FOLLOW, "attach_attack2", self:GetCaster():GetOrigin(), true )
+  if IsServer() then
+    local caster = self:GetCaster()
+		self.nPreviewFX = ParticleManager:CreateParticle( "particles/test_particle/generic_attack_charge.vpcf", PATTACH_CUSTOMORIGIN, caster )
+		ParticleManager:SetParticleControlEnt( self.nPreviewFX, 0, caster, PATTACH_POINT_FOLLOW, "attach_attack2", caster:GetOrigin(), true )
 		ParticleManager:SetParticleControl( self.nPreviewFX, 15, Vector( 135, 192, 235 ) )
 		ParticleManager:SetParticleControl( self.nPreviewFX, 16, Vector( 1, 0, 0 ) )
 		ParticleManager:ReleaseParticleIndex( self.nPreviewFX )
 
-		EmitSoundOn( "TempleGuardian.PreAttack", self:GetCaster() )
+		caster:EmitSound("TempleGuardian.PreAttack")
 	end
 
 	return true

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_temple_guardian/temple_guardian_purification.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_temple_guardian/temple_guardian_purification.lua
@@ -54,7 +54,7 @@ function temple_guardian_purification:OnSpellStart()
 		ParticleManager:SetParticleControlEnt( nFXIndex2, 1, hTarget, PATTACH_ABSORIGIN_FOLLOW, nil, hTarget:GetOrigin(), true );
 		ParticleManager:ReleaseParticleIndex( nFXIndex2 );
 
-		EmitSoundOn( "TempleGuardian.Purification", hTarget )
+		hTarget:EmitSound("TempleGuardian.Purification")
 		local enemies = FindUnitsInRadius( self:GetCaster():GetTeamNumber(), hTarget:GetOrigin(), nil, radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES + DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE, FIND_CLOSEST, false )
 		for _,enemy in pairs( enemies ) do
 			if enemy ~= nil and enemy:IsInvulnerable() == false and enemy:IsMagicImmune() == false then

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_temple_guardian/temple_guardian_rage_hammer_smash.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_temple_guardian/temple_guardian_rage_hammer_smash.lua
@@ -5,7 +5,7 @@ temple_guardian_rage_hammer_smash = class(AbilityBaseClass)
 
 function temple_guardian_rage_hammer_smash:OnAbilityPhaseStart()
 	if IsServer() then
-		EmitSoundOn( "TempleGuardian.PreAttack", self:GetCaster() )
+		self:GetCaster():EmitSound("TempleGuardian.PreAttack")
 	end
 	return true
 end

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_temple_guardian/temple_guardian_wrath.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_temple_guardian/temple_guardian_wrath.lua
@@ -36,7 +36,8 @@ end
 -----------------------------------------------------------------------------
 
 function temple_guardian_wrath:OnSpellStart()
-	if IsServer() then
+  if IsServer() then
+    local caster = self:GetCaster()
 		ParticleManager:DestroyParticle( self.nPreviewFX, false )
 
 		self.effect_radius = self:GetSpecialValueFor( "effect_radius" )
@@ -44,8 +45,8 @@ function temple_guardian_wrath:OnSpellStart()
 
 		self.flNextCast = 0.0
 
-		EmitSoundOn( "TempleGuardian.Wrath.Cast", self:GetCaster() )
-		self:GetCaster():AddNewModifier( self:GetCaster(), self, "modifier_omninight_guardian_angel", {} )
+		caster:EmitSound("TempleGuardian.Wrath.Cast")
+		caster:AddNewModifier( caster, self, "modifier_omninight_guardian_angel", {} )
 
 		--local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_skywrath_mage/skywrath_mage_mystic_flare_ambient.vpcf", PATTACH_ABSORIGIN, self:GetCaster() )
 		--ParticleManager:SetParticleControl( nFXIndex, 1, Vector( self.effect_radius, self.channel_duration, 0.0 ) )

--- a/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_werewolf/werewolf_howl.lua
+++ b/game/scripts/vscripts/abilities/siltbreaker/npc_dota_creature_werewolf/werewolf_howl.lua
@@ -8,13 +8,14 @@ LinkLuaModifier( "modifier_werewolf_howl_aura_effect", "modifiers/modifier_werew
 ----------------------------------------
 
 function werewolf_howl:OnSpellStart()
-	EmitSoundOn( "LycanBoss.Howl", self:GetCaster() )
+  local caster = self:GetCaster()
+	caster:EmitSound("LycanBoss.Howl")
 
-	local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_howl_cast.vpcf", PATTACH_ABSORIGIN_FOLLOW, self:GetCaster() )
-	ParticleManager:SetParticleControlEnt( nFXIndex, 1, self:GetCaster(), PATTACH_POINT_FOLLOW, "attach_mouth", self:GetCaster():GetOrigin(), true )
+	local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_howl_cast.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster )
+	ParticleManager:SetParticleControlEnt( nFXIndex, 1, caster, PATTACH_POINT_FOLLOW, "attach_mouth", caster:GetOrigin(), true )
 	ParticleManager:ReleaseParticleIndex( nFXIndex )
 
-	self:GetCaster():AddNewModifier( self:GetCaster(), self, "modifier_werewolf_howl_aura", { duration = self:GetSpecialValueFor( "duration" ) } )
+	caster:AddNewModifier( caster, self, "modifier_werewolf_howl_aura", { duration = self:GetSpecialValueFor( "duration" ) } )
 end
 
 ----------------------------------------

--- a/game/scripts/vscripts/modifiers/modifier_lycan_boss_claw_attack.lua
+++ b/game/scripts/vscripts/modifiers/modifier_lycan_boss_claw_attack.lua
@@ -31,9 +31,10 @@ end
 --------------------------------------------------------------------------------
 
 function modifier_lycan_boss_claw_attack:OnIntervalThink()
-	if IsServer() then
+  if IsServer() then
+    local parent = self:GetParent()
 		if self.bInit == false then
-			self.szSequenceName = self:GetParent():GetSequence()
+			self.szSequenceName = parent:GetSequence()
 			self.attachAttack1 = nil
 			self.attachAttack2 = nil
 			self.vLocation1 = nil
@@ -43,16 +44,16 @@ function modifier_lycan_boss_claw_attack:OnIntervalThink()
 				szParticleName = "particles/test_particle/generic_attack_crit_blur_shapeshift.vpcf"
 			end
 			if self.szSequenceName == "attack_anim" or self.szSequenceName == "attack_alt2_anim" or self.szSequenceName == "attack3_anim" or self.szSequenceName == "attack2_alt_anim"  then
-				self.attachAttack1 = self:GetParent():ScriptLookupAttachment( "attach_attack1" )
+				self.attachAttack1 = parent:ScriptLookupAttachment( "attach_attack1" )
 
-				local nFXIndex = ParticleManager:CreateParticle( szParticleName, PATTACH_CUSTOMORIGIN, self:GetParent() )
-				ParticleManager:SetParticleControlEnt( nFXIndex, 0, self:GetParent(), PATTACH_POINT_FOLLOW, "attach_attack1", self:GetParent():GetOrigin(), true )
+				local nFXIndex = ParticleManager:CreateParticle( szParticleName, PATTACH_CUSTOMORIGIN, parent )
+				ParticleManager:SetParticleControlEnt( nFXIndex, 0, parent, PATTACH_POINT_FOLLOW, "attach_attack1", parent:GetOrigin(), true )
 				ParticleManager:ReleaseParticleIndex( nFXIndex )
 			end
 			if self.szSequenceName == "attack_alt1_anim" or self.szSequenceName == "attack_alt2_anim" or self.szSequenceName == "attack3_anim" or self.szSequenceName == "attack_alt_anim"  then
-				self.attachAttack2 = self:GetParent():ScriptLookupAttachment( "attach_attack2" )
-				local nFXIndex2 = ParticleManager:CreateParticle( szParticleName, PATTACH_CUSTOMORIGIN, self:GetParent() )
-				ParticleManager:SetParticleControlEnt( nFXIndex2, 0, self:GetParent(), PATTACH_POINT_FOLLOW, "attach_attack2", self:GetParent():GetOrigin(), true )
+				self.attachAttack2 = parent:ScriptLookupAttachment( "attach_attack2" )
+				local nFXIndex2 = ParticleManager:CreateParticle( szParticleName, PATTACH_CUSTOMORIGIN, parent )
+				ParticleManager:SetParticleControlEnt( nFXIndex2, 0, parent, PATTACH_POINT_FOLLOW, "attach_attack2", parent:GetOrigin(), true )
 				ParticleManager:ReleaseParticleIndex( nFXIndex2 )
 			end
 			self.bInit = true
@@ -63,16 +64,16 @@ function modifier_lycan_boss_claw_attack:OnIntervalThink()
 		end
 
 		if self.bPlayedSound == false then
-			EmitSoundOn( "Roshan.PreAttack", self:GetParent() )
+			parent:EmitSound("Roshan.PreAttack")
 			self.bPlayedSound = true
 		end
 
-		local vForward = self:GetParent():GetForwardVector()
-		self:GetParent():SetOrigin( self:GetParent():GetOrigin() + vForward * 10 )
+		local vForward = parent:GetForwardVector()
+		parent:SetOrigin( parent:GetOrigin() + vForward * 10 )
 		if self.attachAttack1 ~= nil then
-			self.vLocation1 = self:GetParent():GetAttachmentOrigin( self.attachAttack1 )
+			self.vLocation1 = parent:GetAttachmentOrigin( self.attachAttack1 )
 			--DebugDrawCircle( self.vLocation1, Vector( 0, 255, 0 ), 255, self.damage_radius, false, 1.0 )
-			local enemies1 = FindUnitsInRadius( self:GetParent():GetTeamNumber(), self.vLocation1, self:GetCaster(), self.damage_radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, 0, false )
+			local enemies1 = FindUnitsInRadius( parent:GetTeamNumber(), self.vLocation1, self:GetCaster(), self.damage_radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, 0, false )
 			if #enemies1 > 0 then
 				for _,enemy in pairs( enemies1 ) do
 					if enemy ~= nil and enemy:IsInvulnerable() == false and self:HasHitTarget( enemy ) == false then
@@ -83,9 +84,9 @@ function modifier_lycan_boss_claw_attack:OnIntervalThink()
 		end
 
 		if self.attachAttack2 ~= nil then
-			self.vLocation2 = self:GetParent():GetAttachmentOrigin( self.attachAttack2 )
+			self.vLocation2 = parent:GetAttachmentOrigin( self.attachAttack2 )
 			--DebugDrawCircle( self.vLocation2, Vector( 0, 0, 255 ), 255, self.damage_radius, false, 1.0 )
-			local enemies2 = FindUnitsInRadius( self:GetParent():GetTeamNumber(), self.vLocation2, self:GetCaster(), self.damage_radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, 0, false )
+			local enemies2 = FindUnitsInRadius( parent:GetTeamNumber(), self.vLocation2, self:GetCaster(), self.damage_radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, 0, false )
 			if #enemies2 > 0 then
 				for _,enemy in pairs( enemies2 ) do
 					if enemy ~= nil and enemy:IsInvulnerable() == false and self:HasHitTarget( enemy ) == false then
@@ -96,7 +97,7 @@ function modifier_lycan_boss_claw_attack:OnIntervalThink()
 		end
 
 		--DebugDrawCircle( self.vLocation2, Vector( 0, 0, 255 ), 255, self.damage_radius, false, 1.0 )
-		local enemies3 = FindUnitsInRadius( self:GetParent():GetTeamNumber(), self:GetParent():GetOrigin(), self:GetCaster(), self.damage_radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, 0, false )
+		local enemies3 = FindUnitsInRadius( parent:GetTeamNumber(), parent:GetOrigin(), self:GetCaster(), self.damage_radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, 0, false )
 		if #enemies3 > 0 then
 			for _,enemy in pairs( enemies3 ) do
 				if enemy ~= nil and enemy:IsInvulnerable() == false and self:HasHitTarget( enemy ) == false then
@@ -143,7 +144,7 @@ function modifier_lycan_boss_claw_attack:TryToHitTarget( enemy )
 
 		ApplyDamage( damageInfo )
 		enemy:AddNewModifier( self:GetParent(), self:GetAbility(), "modifier_stunned", { duration = self:GetAbility():GetSpecialValueFor( "stun_duration" ) } )
-		EmitSoundOn( "Roshan.Attack.Post", enemy )
+		enemy:EmitSound("Roshan.Attack.Post")
 	end
 end
 

--- a/game/scripts/vscripts/modifiers/modifier_lycan_boss_shapeshift_transform.lua
+++ b/game/scripts/vscripts/modifiers/modifier_lycan_boss_shapeshift_transform.lua
@@ -3,12 +3,13 @@ modifier_lycan_boss_shapeshift_transform = class(ModifierBaseClass)
 --------------------------------------------------------------------------------
 
 function modifier_lycan_boss_shapeshift_transform:OnCreated( kv )
-	if IsServer() then
-		self:GetParent():StartGesture( ACT_DOTA_OVERRIDE_ABILITY_4 )
-		EmitSoundOn( "LycanBoss.Shapeshift.Cast", self:GetParent() )
+  if IsServer() then
+    local parent = self:GetParent()
+		parent:StartGesture( ACT_DOTA_OVERRIDE_ABILITY_4 )
+		parent:EmitSound("LycanBoss.Shapeshift.Cast")
 
-		local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_shapeshift_cast.vpcf", PATTACH_ABSORIGIN_FOLLOW, self:GetParent() )
-		ParticleManager:SetParticleControlEnt( nFXIndex, 1, self:GetParent(), PATTACH_POINT_FOLLOW, "attach_hitloc", self:GetParent():GetOrigin(), true )
+		local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_lycan/lycan_shapeshift_cast.vpcf", PATTACH_ABSORIGIN_FOLLOW, parent )
+		ParticleManager:SetParticleControlEnt( nFXIndex, 1, parent, PATTACH_POINT_FOLLOW, "attach_hitloc", parent:GetOrigin(), true )
 		ParticleManager:ReleaseParticleIndex( nFXIndex )
 	end
 end

--- a/game/scripts/vscripts/modifiers/modifier_ogre_seer_area_ignite_thinker.lua
+++ b/game/scripts/vscripts/modifiers/modifier_ogre_seer_area_ignite_thinker.lua
@@ -15,14 +15,15 @@ end
 ----------------------------------------------------------------------------------------
 
 function modifier_ogre_seer_area_ignite_thinker:OnImpact()
-	if IsServer() then
+  if IsServer() then
+    local parent = self:GetParent()
 		local nFXIndex = ParticleManager:CreateParticle( "particles/neutral_fx/black_dragon_fireball.vpcf", PATTACH_WORLDORIGIN, nil );
-		ParticleManager:SetParticleControl( nFXIndex, 0, self:GetParent():GetOrigin() );
-		ParticleManager:SetParticleControl( nFXIndex, 1, self:GetParent():GetOrigin() );
+		ParticleManager:SetParticleControl( nFXIndex, 0, parent:GetOrigin() );
+		ParticleManager:SetParticleControl( nFXIndex, 1, parent:GetOrigin() );
 		ParticleManager:SetParticleControl( nFXIndex, 2, Vector( self.area_duration, 0, 0 ) );
 		ParticleManager:ReleaseParticleIndex( nFXIndex );
 
-		EmitSoundOn( "OgreMagi.Ignite.Target", self:GetParent() )
+		parent:EmitSound("OgreMagi.Ignite.Target")
 
 		self:SetDuration( self.area_duration, true )
 		self.bImpact = true

--- a/game/scripts/vscripts/modifiers/modifier_ogre_tank_melee_smash_thinker.lua
+++ b/game/scripts/vscripts/modifiers/modifier_ogre_tank_melee_smash_thinker.lua
@@ -56,7 +56,7 @@ function modifier_ogre_tank_melee_smash_thinker:OnDestroy()
 						ParticleManager:SetParticleControlForward( critParticle, 1, -self:GetCaster():GetForwardVector() )
 						ParticleManager:SetParticleControlEnt( critParticle, 10, enemy, PATTACH_ABSORIGIN_FOLLOW, nil, enemy:GetOrigin(), true )
 
-						EmitSoundOn( "Dungeon.BloodSplatterImpact", enemy )
+						enemy:EmitSound("Dungeon.BloodSplatterImpact")
 					else
 						enemy:AddNewModifier( self:GetCaster(), self:GetAbility(), "modifier_stunned", { duration = self.stun_duration } )
 					end

--- a/game/scripts/vscripts/modifiers/modifier_spider_boss_larval_parasite.lua
+++ b/game/scripts/vscripts/modifiers/modifier_spider_boss_larval_parasite.lua
@@ -53,6 +53,7 @@ end
 
 function modifier_spider_boss_larval_parasite:OnDestroy()
   if IsServer() then
+    local parent = self:GetParent()
 
     -- This should be destroy the particle but is not destroying it
     ParticleManager:DestroyParticle( self.nFXWarningIndex, false )
@@ -62,11 +63,11 @@ function modifier_spider_boss_larval_parasite:OnDestroy()
 			return
 		end
 
-		EmitSoundOn( "Broodmother.LarvalParasite.Burst", self:GetParent() )
+		parent:EmitSound("Broodmother.LarvalParasite.Burst")
 
-		local nFXIndex = ParticleManager:CreateParticle( "particles/test_particle/dungeon_broodmother_debuff_explode.vpcf", PATTACH_ABSORIGIN_FOLLOW, self:GetParent() )
+		local nFXIndex = ParticleManager:CreateParticle( "particles/test_particle/dungeon_broodmother_debuff_explode.vpcf", PATTACH_ABSORIGIN_FOLLOW, parent )
 
-		local hEnemies = FindUnitsInRadius( self:GetCaster():GetTeamNumber(), self:GetParent():GetOrigin(), nil, self.infection_radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_CLOSEST, false )
+		local hEnemies = FindUnitsInRadius( self:GetCaster():GetTeamNumber(), parent:GetOrigin(), nil, self.infection_radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_CLOSEST, false )
 		for _, hEnemy in pairs( hEnemies ) do
 			-- Apply explosion damage
 			local damage = {
@@ -103,7 +104,7 @@ function modifier_spider_boss_larval_parasite:OnDestroy()
 
 			--[[
 			-- Infect other enemies near target, but not victim again
-			if hEnemy ~= self:GetParent() then
+			if hEnemy ~= parent then
 				--print( "modifier_spider_boss_larval_parasite:OnDestroy() - infecting enemy named " .. hEnemy:GetUnitName() )
 				hEnemy:AddNewModifier( self:GetCaster(), self:GetAbility(), "modifier_spider_boss_larval_parasite", { duration = self.buff_duration } )
 			end

--- a/game/scripts/vscripts/modifiers/modifier_spider_boss_rage.lua
+++ b/game/scripts/vscripts/modifiers/modifier_spider_boss_rage.lua
@@ -8,27 +8,29 @@ function modifier_spider_boss_rage:OnCreated( kv )
 	self.bonus_movespeed_pct = self:GetAbility():GetSpecialValueFor( "bonus_movespeed_pct" )
 	self.lifesteal_pct = self:GetAbility():GetSpecialValueFor( "lifesteal_pct" )
 
-	if IsServer() then
-		self:GetParent().bIsEnraged = true
+  if IsServer() then
+    local parent = self:GetParent()
+		parent.bIsEnraged = true
 
-		self:GetParent():SetModelScale( self:GetParent().fOrigModelScale * 1.25 )
+		parent:SetModelScale( parent.fOrigModelScale * 1.25 )
 
-		local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_broodmother/broodmother_hunger_buff.vpcf", PATTACH_CUSTOMORIGIN, self:GetParent() )
-		ParticleManager:SetParticleControlEnt( nFXIndex, 0, self:GetParent(), PATTACH_POINT_FOLLOW, "attach_thorax", self:GetParent():GetAbsOrigin(), true )
+		local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_broodmother/broodmother_hunger_buff.vpcf", PATTACH_CUSTOMORIGIN, parent )
+		ParticleManager:SetParticleControlEnt( nFXIndex, 0, parent, PATTACH_POINT_FOLLOW, "attach_thorax", parent:GetAbsOrigin(), true )
 		self:AddParticle( nFXIndex, false, false, -1, false, false  )
 
-		EmitSoundOn( "Dungeon.SpiderBoss.Rage", self:GetParent() )
+		parent:EmitSound("Dungeon.SpiderBoss.Rage")
 	end
 end
 
 --------------------------------------------------------------------------------
 
 function modifier_spider_boss_rage:OnDestroy()
-	StopSoundOn( "Dungeon.SpiderBoss.Rage", self:GetParent() )
+  local parent = self:GetParent()
+	parent:StopSound("Dungeon.SpiderBoss.Rage")
 
 	if IsServer() then
-		self:GetParent():SetModelScale( self:GetParent().fOrigModelScale )
-		self:GetParent().bIsEnraged = false
+		parent:SetModelScale( parent.fOrigModelScale )
+		parent.bIsEnraged = false
 	end
 end
 

--- a/game/scripts/vscripts/modifiers/modifier_spider_egg_sack.lua
+++ b/game/scripts/vscripts/modifiers/modifier_spider_egg_sack.lua
@@ -76,42 +76,43 @@ end
 -------------------------------------------------------------------
 
 function modifier_spider_egg_sack:Burst( hHero )
-	if IsServer() then
+  if IsServer() then
 		if self.bBurst == true then
 			return
-		end
+    end
 
+    local parent = self:GetParent()
 		local hTarget = hHero
 		if hHero == nil then
-			hTarget = self:GetParent()
+			hTarget = parent
 		end
 
 		for i=0,RandomInt( self.spider_min, self.spider_max ) do
-			local hUnit = CreateUnitByName( "npc_dota_creature_spider_small", self:GetParent():GetOrigin(), true, self:GetParent(), self:GetParent(), self:GetParent():GetTeamNumber() )
+			local hUnit = CreateUnitByName( "npc_dota_creature_spider_small", parent:GetOrigin(), true, parent, parent, parent:GetTeamNumber() )
       hUnit:AddNewModifier(self:GetCaster(), self, "modifier_kill", {duration = self.egg_spider_lifetime })
-			if hUnit ~= nil and self:GetParent().zone ~= nil then
-				self:GetParent().zone:AddEnemyToZone( hUnit )
+			if hUnit ~= nil and parent.zone ~= nil then
+				parent.zone:AddEnemyToZone( hUnit )
 			end
 		end
 		self.bBurst = true
 
 		local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_venomancer/venomancer_poison_nova.vpcf", PATTACH_CUSTOMORIGIN, nil )
-		ParticleManager:SetParticleControl( nFXIndex, 0, self:GetParent():GetOrigin() )
+		ParticleManager:SetParticleControl( nFXIndex, 0, parent:GetOrigin() )
 		ParticleManager:SetParticleControl( nFXIndex, 1, Vector( self.radius / 2, 0.4, self.radius ) )
 		ParticleManager:ReleaseParticleIndex( nFXIndex )
 
-		local enemies = FindUnitsInRadius( self:GetParent():GetTeamNumber(), self:GetParent():GetOrigin(), self:GetParent(), self.radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, 0, false )
+		local enemies = FindUnitsInRadius( parent:GetTeamNumber(), parent:GetOrigin(), parent, self.radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, 0, false )
 		for _,enemy in pairs ( enemies ) do
 			if enemy ~= nil and enemy:IsInvulnerable() == false and enemy:IsMagicImmune() == false then
 				--print( "Add modifier for " .. self.duration )
-				enemy:AddNewModifier( self:GetParent(), self:GetAbility(), "modifier_venomancer_poison_nova", { duration = self.duration } )
+				enemy:AddNewModifier( parent, self:GetAbility(), "modifier_venomancer_poison_nova", { duration = self.duration } )
 			end
 		end
 
-		EmitSoundOn( "Broodmother.LarvalParasite.Burst", self:GetParent() )
-		EmitSoundOn( "EggSack.Burst", self:GetParent() )
-		self:GetParent():AddEffects( EF_NODRAW )
-		self:GetParent():ForceKill( false )
+		parent:EmitSound("Broodmother.LarvalParasite.Burst")
+		parent:EmitSound("EggSack.Burst")
+		parent:AddEffects( EF_NODRAW )
+		parent:ForceKill( false )
 	end
 end
 

--- a/game/scripts/vscripts/modifiers/modifier_spider_web.lua
+++ b/game/scripts/vscripts/modifiers/modifier_spider_web.lua
@@ -31,13 +31,14 @@ end
 --------------------------------------------------------------------------
 
 function modifier_spider_web:OnCreated( kv )
-	self.radius = self:GetAbility():GetSpecialValueFor( "radius" )
+  self.radius = self:GetAbility():GetSpecialValueFor( "radius" )
+  local parent = self:GetParent()
 	if IsServer() then
-		EmitSoundOn( "SpiderRavine.WebLoop", self:GetParent() )
+		parent:EmitSound("SpiderRavine.WebLoop")
 	end
 
 	local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_broodmother/broodmother_web.vpcf", PATTACH_CUSTOMORIGIN, nil )
-	ParticleManager:SetParticleControl( nFXIndex, 0, self:GetParent():GetAbsOrigin() )
+	ParticleManager:SetParticleControl( nFXIndex, 0, parent:GetAbsOrigin() )
 	ParticleManager:SetParticleControl( nFXIndex, 1, Vector( 900, 0, 0 ) )
 	--ParticleManager:SetParticleControl( nFXIndex, 2, Vector( 5528, 5000, 256 ) ) --Bad Ancient
 	--ParticleManager:SetParticleControlEnt( nFXIndex, 3, GetOwnerEntity(), PATTACH_POINT_FOLLOW, "attach_hitloc", GetAbsOrigin() );
@@ -49,7 +50,7 @@ end
 
 function modifier_spider_web:OnDestroy()
 	if IsServer() then
-		StopSoundOn( "SpiderRavine.WebLoop", self:GetParent() )
+		self:GetParent():StopSound("SpiderRavine.WebLoop")
 	end
 
 end

--- a/game/scripts/vscripts/modifiers/modifier_temple_guardian_hammer_throw.lua
+++ b/game/scripts/vscripts/modifiers/modifier_temple_guardian_hammer_throw.lua
@@ -21,7 +21,8 @@ end
 -------------------------------------------------------------------
 
 function modifier_temple_guardian_hammer_throw:OnCreated( kv )
-	if IsServer() then
+  if IsServer() then
+    local caster = self:GetCaster()
 		self.hammer_damage = self:GetAbility():GetSpecialValueFor( "hammer_damage" )
 		self.throw_duration = self:GetAbility():GetSpecialValueFor( "throw_duration" )
 		self.stun_duration = self:GetAbility():GetSpecialValueFor( "stun_duration" )
@@ -36,9 +37,9 @@ function modifier_temple_guardian_hammer_throw:OnCreated( kv )
 		end
 
 		self.hHammer:AddEffects( EF_NODRAW )
-		self.hHammer:AddNewModifier( self:GetCaster(), self:GetAbility(), "modifier_beastmaster_axe_invulnerable", kv )
+		self.hHammer:AddNewModifier( caster, self:GetAbility(), "modifier_beastmaster_axe_invulnerable", kv )
 
-		self.vSourceLoc = self:GetCaster():GetOrigin()
+		self.vSourceLoc = caster:GetOrigin()
 		self.vSourceLoc.z = self.vSourceLoc.z + 180
 		self.vTargetLoc = Vector( kv["x"], kv["y"], self.vSourceLoc.z )
 		self.vToTarget = self.vTargetLoc - self.vSourceLoc
@@ -51,7 +52,7 @@ function modifier_temple_guardian_hammer_throw:OnCreated( kv )
 		self.nFXIndex = ParticleManager:CreateParticle( "particles/test_particle/omniknight_wildaxe.vpcf", PATTACH_CUSTOMORIGIN, nil )
 		ParticleManager:SetParticleControlEnt( self.nFXIndex, 0, self.hHammer, PATTACH_ABSORIGIN_FOLLOW, nil, self.hHammer:GetOrigin(), true )
 
-		EmitSoundOn( "TempleGuardian.HammerThrow", self:GetCaster() )
+		caster:EmitSound("TempleGuardian.HammerThrow")
 
 		self:StartIntervalThink( 0.05 )
 	end
@@ -90,7 +91,7 @@ function modifier_temple_guardian_hammer_throw:OnIntervalThink()
 				}
 				ApplyDamage( damageInfo )
 				enemy:AddNewModifier( self:GetCaster(), self:GetAbility(), "modifier_stunned", { duration = self.stun_duration } )
-				EmitSoundOn( "TempleGuardian.HammerThrow.Damage", enemy )
+				enemy:EmitSound("TempleGuardian.HammerThrow.Damage")
 
 				local nFXIndex = ParticleManager:CreateParticle( "particles/units/heroes/hero_beastmaster/beastmaster_wildaxes_hit.vpcf", PATTACH_CUSTOMORIGIN, nil )
 				ParticleManager:SetParticleControlEnt( nFXIndex, 0, enemy, PATTACH_POINT_FOLLOW, "attach_hitloc", enemy:GetOrigin(), true )

--- a/game/scripts/vscripts/modifiers/modifier_temple_guardian_wrath_thinker.lua
+++ b/game/scripts/vscripts/modifiers/modifier_temple_guardian_wrath_thinker.lua
@@ -22,16 +22,17 @@ end
 -----------------------------------------------------------------------------
 
 function modifier_temple_guardian_wrath_thinker:OnIntervalThink()
-	if IsServer() then
+  if IsServer() then
+    local parent = self:GetParent()
 		local nFXIndex = ParticleManager:CreateParticle( "particles/test_particle/dungeon_generic_blast.vpcf", PATTACH_CUSTOMORIGIN, nil )
-		ParticleManager:SetParticleControl( nFXIndex, 0, self:GetParent():GetOrigin() )
+		ParticleManager:SetParticleControl( nFXIndex, 0, parent:GetOrigin() )
 		ParticleManager:SetParticleControl( nFXIndex, 1, Vector ( self.radius, self.radius, self.radius ) )
 		ParticleManager:SetParticleControl( nFXIndex, 15, Vector( 175, 238, 238 ) )
 		ParticleManager:SetParticleControl( nFXIndex, 16, Vector( 1, 0, 0 ) )
 		ParticleManager:ReleaseParticleIndex( nFXIndex )
 
-		EmitSoundOn( "TempleGuardian.Wrath.Explosion", self:GetParent() )
-		local enemies = FindUnitsInRadius( self:GetParent():GetTeamNumber(), self:GetParent():GetOrigin(), nil, self.radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES + DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE, FIND_CLOSEST, false )
+		parent:EmitSound("TempleGuardian.Wrath.Explosion")
+		local enemies = FindUnitsInRadius( parent:GetTeamNumber(), parent:GetOrigin(), nil, self.radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES + DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE, FIND_CLOSEST, false )
 		for _,enemy in pairs( enemies ) do
 			if enemy ~= nil and enemy:IsInvulnerable() == false then
 				local damageInfo =
@@ -46,7 +47,7 @@ function modifier_temple_guardian_wrath_thinker:OnIntervalThink()
 			end
 		end
 
-		UTIL_Remove( self:GetParent() )
+		UTIL_Remove( parent )
 	end
 end
 

--- a/game/scripts/vscripts/units/ai_spider_boss.lua
+++ b/game/scripts/vscripts/units/ai_spider_boss.lua
@@ -168,22 +168,22 @@ end
 function PlayHungerSpeech()
 	local nSound = RandomInt( 1, 6 )
 	if nSound == 1 then
-		EmitSoundOn( "broodmother_broo_ability_hunger_01", thisEntity )
+		thisEntity:EmitSound("broodmother_broo_ability_hunger_01")
 	end
 	if nSound == 2 then
-		EmitSoundOn( "broodmother_broo_ability_hunger_02", thisEntity )
+		thisEntity:EmitSound("broodmother_broo_ability_hunger_02")
 	end
 	if nSound == 3 then
-		EmitSoundOn( "broodmother_broo_ability_hunger_03", thisEntity )
+		thisEntity:EmitSound("broodmother_broo_ability_hunger_03")
 	end
 	if nSound == 4 then
-		EmitSoundOn( "broodmother_broo_ability_hunger_04", thisEntity )
+		thisEntity:EmitSound("broodmother_broo_ability_hunger_04")
 	end
 	if nSound == 5 then
-		EmitSoundOn( "broodmother_broo_ability_hunger_05", thisEntity )
+		thisEntity:EmitSound("broodmother_broo_ability_hunger_05")
 	end
 	if nSound == 6 then
-		EmitSoundOn( "broodmother_broo_ability_hunger_06", thisEntity )
+		thisEntity:EmitSound("broodmother_broo_ability_hunger_06")
 	end
 end
 


### PR DESCRIPTION
Also refactored a bunch of repeated calls to `GetCaster` and `GetParent` to use local variables instead.

Hopefully I didn't mess anything up in the process.

P.S. @chrisinajar I wonder if we could have automatic checks for `EmitSoundOn`. There are only a handful of places where it should actually be used since it plays sounds without respecting Fog of War.