### PR TITLE
Make a bunch of attack modifiers respect process_procs flag

### DIFF
--- a/game/scripts/vscripts/abilities/oaa_arcane_orb.lua
+++ b/game/scripts/vscripts/abilities/oaa_arcane_orb.lua
@@ -47,7 +47,6 @@ function modifier_oaa_arcane_orb:DeclareFunctions()
   return {
     MODIFIER_EVENT_ON_ATTACK_START,
     MODIFIER_EVENT_ON_ATTACK,
-    MODIFIER_EVENT_ON_ATTACK_FINISHED,
     MODIFIER_EVENT_ON_ATTACK_LANDED,
     MODIFIER_EVENT_ON_ATTACK_FAIL
   }
@@ -88,7 +87,8 @@ end
 function modifier_oaa_arcane_orb:OnAttack(keys)
   local parent = self:GetParent()
 
-  if keys.attacker ~= parent then
+  -- process_procs == true in OnAttack means this is an attack that attack modifiers should not apply to
+  if keys.attacker ~= parent or keys.process_procs then
     return
   end
 
@@ -111,17 +111,12 @@ function modifier_oaa_arcane_orb:OnAttack(keys)
     return
   end
 
+  parent:RemoveModifierByName("modifier_oaa_arcane_orb_sound")
+  parent:ChangeAttackProjectile()
+
   ability:CastAbility()
   -- Enable proc for this attack record number
   self.procRecords[keys.record] = true
-end
-
-function modifier_oaa_arcane_orb:OnAttackFinished(keys)
-  local parent = self:GetParent()
-  if keys.attacker == parent then
-    parent:RemoveModifierByName("modifier_oaa_arcane_orb_sound")
-    parent:ChangeAttackProjectile()
-  end
 end
 
 function modifier_oaa_arcane_orb:OnAttackLanded(keys)
@@ -130,7 +125,7 @@ function modifier_oaa_arcane_orb:OnAttackLanded(keys)
   local target = keys.target
   local ability = self:GetAbility()
 
-  if keys.attacker ~= parent or not self.procRecords[attackRecord] then
+  if keys.attacker ~= parent or not self.procRecords[attackRecord] or not keys.process_procs then
     return
   end
 

--- a/game/scripts/vscripts/abilities/oaa_elder_dragon_form.lua
+++ b/game/scripts/vscripts/abilities/oaa_elder_dragon_form.lua
@@ -173,7 +173,7 @@ if IsServer() then
 	function modifier_dragon_knight_elder_dragon_form_oaa:OnAttackLanded( event )
 		local parent = self:GetParent()
 
-		if event.attacker == parent then
+		if event.attacker == parent and event.process_procs then
 			local spell = self:GetAbility()
 
 			if spell:GetLevel() == 4 then

--- a/game/scripts/vscripts/items/farming/greater_phase_boots.lua
+++ b/game/scripts/vscripts/items/farming/greater_phase_boots.lua
@@ -73,8 +73,11 @@ modifier_item_greater_phase_boots_splinter_shot.OnRefresh = modifier_item_greate
 
 function modifier_item_greater_phase_boots_splinter_shot:OnAttackLanded(keys)
   local parent = self:GetParent()
-  if keys.attacker == parent and not self.doReduction then
+  if keys.attacker == parent and keys.process_procs and not self.doReduction then
     local ability = self:GetAbility()
+
+    Debug:EnableDebugging()
+    DebugPrintTable(keys)
 
     local units = FindUnitsInRadius(
       parent:GetTeamNumber(),

--- a/game/scripts/vscripts/items/farming/greater_phase_boots.lua
+++ b/game/scripts/vscripts/items/farming/greater_phase_boots.lua
@@ -76,9 +76,6 @@ function modifier_item_greater_phase_boots_splinter_shot:OnAttackLanded(keys)
   if keys.attacker == parent and keys.process_procs and not self.doReduction then
     local ability = self:GetAbility()
 
-    Debug:EnableDebugging()
-    DebugPrintTable(keys)
-
     local units = FindUnitsInRadius(
       parent:GetTeamNumber(),
       keys.target:GetAbsOrigin(),

--- a/game/scripts/vscripts/items/farming/greater_power_treads.lua
+++ b/game/scripts/vscripts/items/farming/greater_power_treads.lua
@@ -152,7 +152,7 @@ if IsServer() then
 
     -- with lua events, you need to make sure you're actually looking for the right unit's
     -- attacks and stuff
-    if event.attacker == parent then
+    if event.attacker == parent and event.process_procs then
       local target = event.target
 
       -- make sure the initial target is an appropriate unit to split off of

--- a/game/scripts/vscripts/items/transformation/giant_form.lua
+++ b/game/scripts/vscripts/items/transformation/giant_form.lua
@@ -158,7 +158,7 @@ if IsServer() then
 
     -- i can just use code from greater power treads here!
     -- yaaaaay
-    if event.attacker == parent then
+    if event.attacker == parent and event.process_procs then
       local target = event.target
 
       -- make sure the initial target is an appropriate unit to split off of

--- a/game/scripts/vscripts/items/trumps_fists.lua
+++ b/game/scripts/vscripts/items/trumps_fists.lua
@@ -80,7 +80,7 @@ function modifier_item_trumps_fists_passive:OnAttackLanded( kv )
   if IsServer() then
     local attacker = kv.attacker
     local target = kv.target
-    if attacker == self:GetParent() and not attacker:IsIllusion() and not target:IsMagicImmune() then
+    if attacker == self:GetParent() and kv.process_procs and not attacker:IsIllusion() and not target:IsMagicImmune() then
       target:AddNewModifier( self:GetCaster(), self:GetAbility(), "modifier_item_trumps_fists_frostbite", { duration = self.heal_prevent_duration } )
     end
   end


### PR DESCRIPTION
List includes:
* Arcane Orb
* Elder Dragon Form
* Glaives of Wisdom
* Covfefe
* Greater Phase Boots
* Greater Power Treads
* Giant Form

The process_procs flag is what indicates when attacks like Medusa's Split Shot should not have attack modifiers applied to them.