### PR TITLE
Fix Assault Cuirass 5 cast range

### DIFF
--- a/game/scripts/npc/items/item_assault_5.txt
+++ b/game/scripts/npc/items/item_assault_5.txt
@@ -37,7 +37,7 @@
     "ID"                                                  "3846"    // unique ID
     "BaseClass"                                           "item_assault"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
-    "AbilityCastRange"                                    "25"
+    "AbilityCastRange"                                    "900"
     "AbilityTextureName"                                  "custom/assault_cuirass_5"
     // Item Info
     //-------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
 Assault Cuirass 5 should have a cast range of 900, not 25. Fixes #1917 