### PR TITLE
Add wrapper for hero:AddExperience

### DIFF
--- a/game/scripts/vscripts/components/heroselection/ardm.lua
+++ b/game/scripts/vscripts/components/heroselection/ardm.lua
@@ -50,19 +50,6 @@ function ARDMMode:Init (allHeroes)
   self:ReloadHeroPool(DOTA_TEAM_BADGUYS)
 end
 
-function ARDMMode:AddExperienceFilter (npc)
-  local oldAddExperience = npc.AddExperience
-
-  return function (unit, amount, ...)
-    self:ModifyExperienceFilter({
-      experience = amount,
-      player_id_const = npc:GetPlayerID()
-    })
-
-    return oldAddExperience(unit, amount, ...)
-  end
-end
-
 function ARDMMode:ReloadHeroPool (teamId)
   for hero,primaryAttr in pairs(self.allHeroes) do
     self.heroPool[teamId][hero] = true

--- a/game/scripts/vscripts/components/heroselection/ardm.lua
+++ b/game/scripts/vscripts/components/heroselection/ardm.lua
@@ -10,8 +10,6 @@ function ARDMMode:Init (allHeroes)
   self.estimatedExperience = {}
 
   Debug:EnableDebugging()
-  FilterManager:AddFilter(FilterManager.ModifyExperience, self, Dynamic_Wrap(self, 'ModifyExperienceFilter'))
-  GameEvents:OnPlayerLevelUp(partial(self.OnPlayerLevelUp, self))
 
   self:PrecacheAllHeroes(allHeroes, function ()
     DebugPrint('Done precaching')
@@ -31,7 +29,6 @@ function ARDMMode:Init (allHeroes)
     end
 
     npc:AddNewModifier(npc, nil, "modifier_ardm", {})
-    npc.AddExperience = self:AddExperienceFilter(npc)
   end)
 
   GameEvents:OnHeroKilled(function (keys)
@@ -64,21 +61,6 @@ function ARDMMode:AddExperienceFilter (npc)
 
     return oldAddExperience(unit, amount, ...)
   end
-end
-
-function ARDMMode:ModifyExperienceFilter (keys)
-  if self.estimatedExperience[keys.player_id_const] then
-    self.estimatedExperience[keys.player_id_const] = self.estimatedExperience[keys.player_id_const] + keys.experience
-  else
-    self.estimatedExperience[keys.player_id_const] = keys.experience
-  end
-  return true
-end
-
-function ARDMMode:OnPlayerLevelUp (keys)
-  local player = EntIndexToHScript(keys.player)
-
-  self.estimatedExperience[player:GetPlayerID()] = 0
 end
 
 function ARDMMode:ReloadHeroPool (teamId)

--- a/game/scripts/vscripts/libraries/basehero.lua
+++ b/game/scripts/vscripts/libraries/basehero.lua
@@ -7,6 +7,18 @@ function CDOTA_BaseNPC_Hero:ModifyGold (playerID, goldAmmt, reliable, nReason)
   return Gold:ModifyGold(playerID, goldAmmt, reliable, nReason)
 end
 
+CDOTA_BaseNPC_Hero.UnfilteredAddExperience = CDOTA_BaseNPC_Hero.UnfilteredAddExperience or CDOTA_BaseNPC_Hero.AddExperience
+function CDOTA_BaseNPC_Hero:AddExperience(flXP, nReason, bApplyBotDifficultyScaling, bIncrementTotal)
+  local eventData = {
+    experience = flXP,
+    player_id_const = self:GetPlayerOwnerID(),
+    reason_const = nReason
+  }
+  if FilterManager:RunFilterForType(eventData, FilterManager.ModifyExperience) then
+    self:UnfilteredAddExperience(flXP, nReason, bApplyBotDifficultyScaling, bIncrementTotal)
+  end
+end
+
 function CDOTA_BaseNPC_Hero:GetBaseRangedProjectileName()
   if not IsServer() then
     return ""

--- a/game/scripts/vscripts/libraries/basehero.lua
+++ b/game/scripts/vscripts/libraries/basehero.lua
@@ -12,7 +12,8 @@ function CDOTA_BaseNPC_Hero:AddExperience(flXP, nReason, bApplyBotDifficultyScal
   local eventData = {
     experience = flXP,
     player_id_const = self:GetPlayerOwnerID(),
-    reason_const = nReason
+    reason_const = nReason,
+    is_from_method_call = true,
   }
   if FilterManager:RunFilterForType(eventData, FilterManager.ModifyExperience) then
     self:UnfilteredAddExperience(flXP, nReason, bApplyBotDifficultyScaling, bIncrementTotal)

--- a/game/scripts/vscripts/modifiers/modifier_ardm.lua
+++ b/game/scripts/vscripts/modifiers/modifier_ardm.lua
@@ -19,7 +19,7 @@ function modifier_ardm:ReplaceHero ()
   end
 
   Debug:EnableDebugging()
-  local heroXp = ARDMMode.estimatedExperience[playerId]
+  local heroXp = parent:GetCurrentXP()
   local heroLevel = parent:GetLevel()
   DebugPrint('Hero was level ' .. heroLevel .. ' with xp ' .. heroXp)
 
@@ -38,8 +38,7 @@ function modifier_ardm:ReplaceHero ()
     HeroProgression:ProcessAbilityPointGain(newHero, level)
   end
 
-  newHero:AddExperience(XP_PER_LEVEL_TABLE[heroLevel] + heroXp, DOTA_ModifyXP_Unspecified, false, true)
-  ARDMMode.estimatedExperience[playerId] = heroXp
+  newHero:AddExperience(heroXp, DOTA_ModifyXP_Unspecified, false, true)
 
   for i = DOTA_ITEM_SLOT_1, DOTA_ITEM_SLOT_9 do
     local item = newHero:GetItemInSlot(i)


### PR DESCRIPTION
This is to make it go through the ModifyXP filter since for some reason Valve apparently didn't make it do so.

Currently denies any call to `AddExperience` on bots due to their connection state never being "connected". Not sure whether there's a need to fix that.

Also could use some testing to see if granting XP on reconnect still works properly with this change.