### PR TITLE
Fix various cases where Duel high ground would not get contested properly

### DIFF
--- a/game/scripts/vscripts/components/duels/runes.lua
+++ b/game/scripts/vscripts/components/duels/runes.lua
@@ -81,8 +81,10 @@ function DuelRunes:StartTouch(event)
 [   VScript  ]:     triggerHandler: function: 0x002d1300
 [   VScript  ]: outputid: 0
 ]]
-  event.activator:AddNewModifier(event.activator, nil, "modifier_duel_rune_hill", {})
+  local modifier = event.activator:AddNewModifier(event.activator, nil, "modifier_duel_rune_hill", {})
+  modifier.zone = event.caller
 end
+
 function DuelRunes:EndTouch(event)
   event.activator:RemoveModifierByName("modifier_duel_rune_hill")
 end

--- a/game/scripts/vscripts/modifiers/modifier_duel_rune_hill.lua
+++ b/game/scripts/vscripts/modifiers/modifier_duel_rune_hill.lua
@@ -29,11 +29,11 @@ function modifier_duel_rune_hill:GetAuraSearchTeam()
 end
 
 function modifier_duel_rune_hill:GetAuraSearchFlags()
-  return DOTA_UNIT_TARGET_FLAG_INVULNERABLE
+  return bit.bor(DOTA_UNIT_TARGET_FLAG_INVULNERABLE, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES)
 end
 
 function modifier_duel_rune_hill:GetAuraRadius()
-  return 350
+  return 2000
 end
 
 function modifier_duel_rune_hill:GetModifierAura()
@@ -41,8 +41,11 @@ function modifier_duel_rune_hill:GetModifierAura()
 end
 
 function modifier_duel_rune_hill:GetAuraEntityReject(entity)
-  self:SetStackCount(0)
-  return false
+  if not self.zone then
+    return true
+  else
+    return not self.zone:IsTouching(entity)
+  end
 end
 
 --------------------------------------------------------------------------

--- a/game/scripts/vscripts/modifiers/modifier_duel_rune_hill.lua
+++ b/game/scripts/vscripts/modifiers/modifier_duel_rune_hill.lua
@@ -28,6 +28,10 @@ function modifier_duel_rune_hill:GetAuraSearchTeam()
   return DOTA_UNIT_TARGET_TEAM_ENEMY
 end
 
+function modifier_duel_rune_hill:GetAuraSearchFlags()
+  return DOTA_UNIT_TARGET_FLAG_INVULNERABLE
+end
+
 function modifier_duel_rune_hill:GetAuraRadius()
   return 350
 end


### PR DESCRIPTION
* No longer have to be within 350 units of enemy hero to contest them. Anywhere in the zone should work
* Fix Song of the Siren and spell immunity potentially preventing contesting

Other half of fixing #1941. I couldn't actually reproduce Song of the Siren negating the contesting or earning of Duel high ground, but it did cause it to act up a little, and likely only the weird 
bit in `GetAuraEntityReject` setting the stack count to 0 was the only thing preventing the stacks from incrementing.