### PR TITLE
Make respawn time scale lineraly with level

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -53,6 +53,8 @@ globals = { -- these globals can be set and accessed.
 "CAVE_RELEVANCE_FACTOR",
 "CAVE_MAX_MULTIPLIER",
 "XP_PER_LEVEL_TABLE",
+"RESPAWN_NEUTRAL_DEATH_PENALTY",
+"RESPAWN_TIME_TABLE",
 }
 
 read_globals = { -- these globals can only be accessed.

--- a/game/scripts/vscripts/components/player/index.lua
+++ b/game/scripts/vscripts/components/player/index.lua
@@ -1,3 +1,4 @@
 -- Player Module
 
 require('components/player/connection') -- Handle Player Connections
+require('components/player/respawn') -- Handle custom respawn times

--- a/game/scripts/vscripts/components/player/respawn.lua
+++ b/game/scripts/vscripts/components/player/respawn.lua
@@ -1,0 +1,24 @@
+RespawnManager = RespawnManager or {}
+
+function RespawnManager:Init()
+  GameEvents:OnHeroKilled(partial(self.OnHeroKilled, self))
+end
+
+function RespawnManager:OnHeroKilled(keys)
+  local killer = keys.killer
+  local killed = keys.killed
+  local killerTeam = killer:GetTeam()
+  local respawnTime = RESPAWN_TIME_TABLE[killed:GetLevel()]
+
+  if not Duels.currentDuel and killed:GetRespawnsDisabled() then
+    killed:SetRespawnsDisabled(false)
+  end
+
+  if not killed:IsReincarnating() then
+    if killerTeam ~= DOTA_TEAM_NEUTRALS then
+      killed:SetTimeUntilRespawn(respawnTime)
+    else
+      killed:SetTimeUntilRespawn(respawnTime + RESPAWN_NEUTRAL_DEATH_PENALTY)
+    end
+  end
+end

--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -166,6 +166,7 @@ function GameMode:OnPreGame()
   InitModule(HeroKillGold)
   InitModule(EntityStatProvider)
   InitModule(ProtectionAura)
+  InitModule(RespawnManager)
 
   CheckCheatMode()
 end

--- a/game/scripts/vscripts/internal/events.lua
+++ b/game/scripts/vscripts/internal/events.lua
@@ -107,20 +107,9 @@ function GameMode:_OnEntityKilled( keys )
       GameRules:GetGameModeEntity():SetTopBarTeamValue ( DOTA_TEAM_GOODGUYS, GetTeamHeroKills(DOTA_TEAM_GOODGUYS) )
     end
 
-    if not Duels.currentDuel and killedUnit:GetRespawnsDisabled() then
-      killedUnit:SetRespawnsDisabled(false)
-      if not killedUnit:IsReincarnating() then
-        killedUnit:SetTimeUntilRespawn(5)
-      end
-    end
-
-    if killerTeam ~= DOTA_TEAM_BADGUYS and killerTeam ~= DOTA_TEAM_GOODGUYS and not killedUnit:IsReincarnating() then
-      killedUnit:SetTimeUntilRespawn(10)
-    else
-      keys.killer = killerEntity
-      keys.killed = killedUnit
-      GameMode:OnHeroKilled(keys)
-    end
+    keys.killer = killerEntity
+    keys.killed = killedUnit
+    GameMode:OnHeroKilled(keys)
   end
 
   GameMode._reentrantCheck = true

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -3,6 +3,24 @@
 -----------------------------------------------------------------------------------
 -- OAA specific settings
 
+-- Respawn time settings
+RESPAWN_NEUTRAL_DEATH_PENALTY = 5 -- Extra respawn time for dying to neutrals
+RESPAWN_TIME_TABLE = {} -- Lookup table mapping level to respawn time. Can be used to override respawn time for specific levels
+-- Set function to calculate respawn time based on level
+setmetatable(RESPAWN_TIME_TABLE, {
+  __index = function (table, key)
+    local minLevel = 1
+    local maxLevel = 49
+    local minTime = 5
+    local maxTime = 20
+    local clampedLevel = math.min(maxLevel, key)
+    -- Store result instead of recalculating for lookups for the same level
+    -- Linear interpolation between min and max level/time pairs
+    table[key] = math.floor(minTime + (clampedLevel - minLevel) * (maxTime - minTime) / (maxLevel - minLevel))
+    return table[key]
+  end
+})
+
 -- poop wards
 POOP_WARD_DURATION = 360
 POOP_WARD_COOLDOWN = 120
@@ -154,7 +172,7 @@ DISABLE_STASH_PURCHASING = false        -- Should we prevent players from being 
 DISABLE_ANNOUNCER = false               -- Should we disable the announcer from working in the game?
 FORCE_PICKED_HERO = "npc_dota_hero_dummy_dummy" -- What hero should we force all players to spawn as? (e.g. "npc_dota_hero_axe").  Use nil to allow players to pick their own hero.
 
-FIXED_RESPAWN_TIME = 10                 -- What time should we use for a fixed respawn timer?  Use -1 to keep the default dota behavior.
+FIXED_RESPAWN_TIME = -1                 -- What time should we use for a fixed respawn timer?  Use -1 to keep the default dota behavior.
 FOUNTAIN_CONSTANT_MANA_REGEN = -1       -- What should we use for the constant fountain mana regen?  Use -1 to keep the default dota behavior.
 FOUNTAIN_PERCENTAGE_MANA_REGEN = -1     -- What should we use for the percentage fountain mana regen?  Use -1 to keep the default dota behavior.
 FOUNTAIN_PERCENTAGE_HEALTH_REGEN = -1   -- What should we use for the percentage fountain health regen?  Use -1 to keep the default dota behavior.


### PR DESCRIPTION
Scales from 5 seconds at level 1 to 20 seconds at 49. Dying to neutrals incurs an extra 5 seconds.

Closes #1944.