### PR TITLE
Make Infinity Bottles non-sellable at KV level

### DIFF
--- a/game/scripts/npc/items/custom/item_infinite_bottle.txt
+++ b/game/scripts/npc/items/custom/item_infinite_bottle.txt
@@ -27,7 +27,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "650"
     "ItemStackable"                                       "1"
-    "ItemSellable"                                        "1"
+    "ItemSellable"                                        "0"
     "ItemPermanent"                                       "1"
     "ItemInitialCharges"                                  "3"
     "IsTempestDoubleClonable"                             "0"


### PR DESCRIPTION
Up to this point, they've been blocked from being sold by the sell blacklist order filter. There seems to be something causing our order filters to break though (there have been reports of Bottles being sellable and Poop Wards casting Glyph). I don't think there's actually a reason for Bottles to not just be non-sellable from KV in the first place anyway.

@chrisinajar Could you dig into the logs and see if you can identify any possible causes for order filter breakage?