### PR TITLE
Increase time to select hero in CM after picks

### DIFF
--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -35,7 +35,7 @@ SCAN_DURATION = 14
 -- PICK SCREEN
 CAPTAINS_MODE_CAPTAIN_TIME = 20           -- how long players have to claim the captain chair
 CAPTAINS_MODE_PICK_BAN_TIME = 30          -- how long you have to do each pick/ban
-CAPTAINS_MODE_HERO_PICK_TIME = 20         -- time to choose which hero you're going to play
+CAPTAINS_MODE_HERO_PICK_TIME = 45         -- time to choose which hero you're going to play
 CAPTAINS_MODE_RESERVE_TIME = 130          -- total bonus time that can be used throughout any selection
 
 -- Game timings


### PR DESCRIPTION
Currently you only get 20 seconds to choose which hero you're playing, this will likely cause rehosts in tournament settings. Increased to 45.