### PR TITLE
Fix Fountain not dealing damage

### DIFF
--- a/game/scripts/vscripts/abilities/fountain_attack.lua
+++ b/game/scripts/vscripts/abilities/fountain_attack.lua
@@ -92,7 +92,7 @@ function modifier_fountain_attack_aura:OnIntervalThink()
     local targetMaxMana = target:GetMaxMana()
     local manaReductionAmount = targetMaxMana / killTicks
 
-    target:MakeVisibleDueToAttack(teamID)
+    target:MakeVisibleDueToAttack(teamID, 0)
     target:Purge(true, false, false, false, true)
     target:ReduceMana(manaReductionAmount)
     if targetHealth - healthReductionAmount < 1 then


### PR DESCRIPTION
Valve apparently added a radius parameter. I'm unsure what the behaviour was before, so I just set the radius to 0, which I think gives vision of just the hero, like Track.