### PR TITLE
Minor Sohei fixes

### DIFF
--- a/game/scripts/vscripts/abilities/baseclass.lua
+++ b/game/scripts/vscripts/abilities/baseclass.lua
@@ -3,3 +3,7 @@ AbilityBaseClass = class({})
 function AbilityBaseClass:GetAbilityTextureName(brokenAPI)
   return self.BaseClass.GetAbilityTextureName(self)
 end
+
+function AbilityBaseClass:IsHiddenWhenStolen(arg)
+  return self.BaseClass.IsHiddenWhenStolen(self)
+end

--- a/game/scripts/vscripts/abilities/sohei/sohei_dash.lua
+++ b/game/scripts/vscripts/abilities/sohei/sohei_dash.lua
@@ -16,11 +16,12 @@ if IsServer() then
 	function sohei_dash:OnUpgrade()
 		local caster = self:GetCaster()
 		local modifier_charges = caster:FindModifierByName( "modifier_sohei_dash_charges" )
+		local chargesMax = self:GetSpecialValueFor( "max_charges" )
 
 		if not modifier_charges then
 			modifier_charges = caster:AddNewModifier( self:GetCaster(), self, "modifier_sohei_dash_charges", {} )
-			modifier_charges:SetStackCount( self:GetSpecialValueFor( "max_charges" ) )
-		elseif modifier_charges:GetDuration() <= 0 then
+			modifier_charges:SetStackCount( chargesMax )
+		elseif modifier_charges:GetStackCount() < chargesMax then
 			modifier_charges:SetDuration( self:GetChargeRefreshTime(), true )
 			modifier_charges:StartIntervalThink( 0.1 )
 		end
@@ -123,9 +124,9 @@ if IsServer() then
 	function sohei_dash:RefreshCharges()
 		local modifier_charges = self:GetCaster():FindModifierByName( "modifier_sohei_dash_charges" )
 
-    if modifier_charges and not modifier_charges:IsNull() then
-		  modifier_charges:SetStackCount( self:GetSpecialValueFor( "max_charges" ) )
-    end
+		if modifier_charges and not modifier_charges:IsNull() then
+			modifier_charges:SetStackCount( self:GetSpecialValueFor( "max_charges" ) )
+		end
 	end
 end
 
@@ -274,7 +275,7 @@ if IsServer() then
 
 				local spellPalm = self:GetParent():FindAbilityByName( "sohei_palm_of_life" )
 
-				if remainingTime > spellPalm:GetCooldownTimeRemaining() then
+				if spellPalm and not spellPalm:IsStolen() and remainingTime > spellPalm:GetCooldownTimeRemaining() then
 					spellPalm:EndCooldown()
 					spellPalm:StartCooldown( remainingTime )
 				end
@@ -330,7 +331,7 @@ if IsServer() then
 		-- Movement parameters
 		local parent = self:GetParent()
 		self.direction = parent:GetForwardVector()
-		self.distance = event.distance
+		self.distance = event.distance + 1
 		self.speed = event.speed
 		self.tree_radius = event.tree_radius
 
@@ -342,7 +343,7 @@ if IsServer() then
 		-- Trail particle
 		local trail_pfx = ParticleManager:CreateParticle( "particles/econ/items/juggernaut/bladekeeper_omnislash/_dc_juggernaut_omni_slash_trail.vpcf", PATTACH_CUSTOMORIGIN, parent )
 		ParticleManager:SetParticleControl( trail_pfx, 0, parent:GetAbsOrigin() )
-		ParticleManager:SetParticleControl( trail_pfx, 1, parent:GetAbsOrigin() + parent:GetForwardVector() * 300 )
+		ParticleManager:SetParticleControl( trail_pfx, 1, parent:GetAbsOrigin() + parent:GetForwardVector() * self.distance )
 		ParticleManager:ReleaseParticleIndex( trail_pfx )
 	end
 

--- a/game/scripts/vscripts/abilities/sohei/sohei_flurry_of_blows.lua
+++ b/game/scripts/vscripts/abilities/sohei/sohei_flurry_of_blows.lua
@@ -33,6 +33,12 @@ end
 
 --------------------------------------------------------------------------------
 
+function sohei_flurry_of_blows:GetAssociatedSecondaryAbilities()
+  return "sohei_momentum"
+end
+
+--------------------------------------------------------------------------------
+
 function sohei_flurry_of_blows:GetChannelTime()
   --[[
   if self:GetCaster():HasScepter() then

--- a/game/scripts/vscripts/abilities/sohei/sohei_momentum.lua
+++ b/game/scripts/vscripts/abilities/sohei/sohei_momentum.lua
@@ -28,6 +28,12 @@ end
 
 --------------------------------------------------------------------------------
 
+function sohei_momentum:IsHiddenWhenStolen( arg )
+	return true
+end
+
+--------------------------------------------------------------------------------
+
 -- Momentum's passive modifier
 modifier_sohei_momentum_passive = class( ModifierBaseClass )
 
@@ -78,12 +84,6 @@ end
 --------------------------------------------------------------------------------
 
 if IsServer() then
-	function modifier_sohei_momentum_passive:OnRefresh( event )
-		self:SetStackCount( 0 )
-	end
-
---------------------------------------------------------------------------------
-
 	function modifier_sohei_momentum_passive:OnIntervalThink()
 		-- Update position
 		local parent = self:GetParent()
@@ -92,7 +92,7 @@ if IsServer() then
 		self.parentOrigin = parent:GetAbsOrigin()
 
 		if not self:IsMomentumReady() then
-			if spell:IsCooldownReady() then
+			if spell:IsCooldownReady() and not parent:PassivesDisabled() and not spell:IsHidden() then
 				self:SetStackCount( self:GetStackCount() + ( self.parentOrigin - oldOrigin ):Length2D() )
 			end
 		end
@@ -114,8 +114,9 @@ end
 
 if IsServer() then
 	function modifier_sohei_momentum_passive:GetModifierPreAttack_CriticalStrike( event )
+		local parent = self:GetParent()
 		local spell = self:GetAbility()
-		if self:IsMomentumReady() and ( spell:IsCooldownReady() or self:GetParent():HasModifier( "modifier_sohei_flurry_self" ) ) then
+		if self:IsMomentumReady() and ( ( spell:IsCooldownReady() and not parent:PassivesDisabled() and not spell:IsHidden() ) or parent:HasModifier( "modifier_sohei_flurry_self" ) ) then
 
 			-- make sure the target is valid
 			local ufResult = UnitFilter(
@@ -148,7 +149,9 @@ if IsServer() then
 			local spell = self:GetAbility()
 
 			-- Consume the buff
-			self:ForceRefresh()
+			if not attacker:HasModifier( "modifier_sohei_flurry_self" ) then
+				self:SetStackCount( 0 )
+			end
 
 			-- Knock the enemy back
 			local distance = spell:GetSpecialValueFor( "knockback_distance" )

--- a/game/scripts/vscripts/abilities/sohei/sohei_palm_of_life.lua
+++ b/game/scripts/vscripts/abilities/sohei/sohei_palm_of_life.lua
@@ -37,7 +37,7 @@ end
 function sohei_palm_of_life:OnHeroCalculateStatBonus()
 	local caster = self:GetCaster()
 
-	if caster:HasScepter() then
+	if caster:HasScepter() or self:IsStolen() then
 		self:SetHidden( false )
 		if self:GetLevel() <= 0 then
 			self:SetLevel( 1 )
@@ -56,7 +56,7 @@ if IsServer() then
 
 		if modifier_charges and not modifier_charges:IsNull() then
 			-- Perform the dash if there is at least one charge remaining
-			if modifier_charges:GetStackCount() >= 1 then
+			if modifier_charges:GetStackCount() >= 1 and not self:IsStolen() then
 				modifier_charges:SetStackCount( modifier_charges:GetStackCount() - 1 )
 			end
 		end
@@ -76,7 +76,7 @@ if IsServer() then
 		local modMomentum = caster:FindModifierByName( "modifier_sohei_momentum_passive" )
 		local spellMomentum = caster:FindAbilityByName( "sohei_momentum" )
 
-		if ( modMomentum and modMomentum:IsMomentumReady() ) and ( spellMomentum and spellMomentum:IsCooldownReady() ) then
+		if ( ( modMomentum and modMomentum:IsMomentumReady() ) and ( spellMomentum and spellMomentum:IsCooldownReady() ) ) or self:IsStolen() then
 			doHeal = 1
 		end
 


### PR DESCRIPTION
Sohei relevant stuff:
- Momentum can now be broken. It will neither build charges nor be able
to unleash a charged attack. Flurry of Blows ignores this, however.
- Momentum no longer loses its charges when upgrading it.
- Internally increased the distance of Dash by 1, which seems to fix a
precision error leading to it having a distance of 297 instead.
- Flurry of Blows attacks no longer consume Momentum charges.
Rubick relevant stuff:
- Dash no longer gives Rubick a charge beyond the maximum if stolen
while he has max charges.
- Stealing Flurry of Blows will now also steal Momentum, which is now
hidden while stolen and will behave as if it was broken while hidden.
Effectively, Flurry of Blows is now given the Requiem of Souls
treatment.
- Palm of Life now acts independently from Dash and Momentum while
stolen.
- Also added a IsHiddenWhenStolen override to AbilityBaseClass which
calls the ability basest class's IsHiddenWhenStolen without the added
argument. Because for some reason it's called with some sort of table in
C++ but the Lua version hasn't been adapted to that change.