### PR TITLE
Disable BAREBONES_DEBUG_SPEW

### DIFF
--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -4,7 +4,7 @@ BAREBONES_VERSION = "1.00"
 -- Set this to true if you want to see a complete debug output of all events/processes done by barebones
 -- You can also change the cvar 'barebones_spew' at any time to 1 or 0 for output/no output
 -- this overrides per-module logging rules and just opens the floodgates
-BAREBONES_DEBUG_SPEW = true
+BAREBONES_DEBUG_SPEW = false
 
 if GameMode == nil then
     DebugPrint( '[BAREBONES] creating barebones game mode' )


### PR DESCRIPTION
This should never have been enabled in the first place. It spams the console so hard.