### PR TITLE
Fix missing concat operators in hero_kills.lua

### DIFF
--- a/game/scripts/vscripts/components/gold/hero_kills.lua
+++ b/game/scripts/vscripts/components/gold/hero_kills.lua
@@ -227,7 +227,7 @@ function HeroKillGold:HeroDeathHandler (keys)
     local killedPlayerIDsString = reduce(catWithComma, head(killedPlayerIDs), tail(killedPlayerIDs))
     killedTeamNWString = "[" .. killedTeamNWString .. "]"
     D2CustomLogging:sendPayloadForTracking(D2CustomLogging.LOG_LEVEL_INFO, "COULD NOT FIND KILLED HERO NW", {
-      ErrorMessage = "Killed team networth list: " .. killedTeamNWString ", killed player ID: " .. killedPlayerID ", killed team player IDs: " .. killedPlayerIDsString,
+      ErrorMessage = "Killed team networth list: " .. killedTeamNWString .. ", killed player ID: " .. killedPlayerID .. ", killed team player IDs: " .. killedPlayerIDsString,
       ErrorTime = GetSystemDate() .. " " .. GetSystemTime(),
       GameVersion = GAME_VERSION,
       DedicatedServers = (IsDedicatedServer() and 1) or 0,


### PR DESCRIPTION
Once again, this would have been a syntax error in linters if only the no brackets call syntax didn't exist. *mumble* *grumble*