### PR TITLE
Fix Greater Tranquil Boots not doing anything

### DIFF
--- a/game/scripts/vscripts/items/farming/greater_tranquil_boots.lua
+++ b/game/scripts/vscripts/items/farming/greater_tranquil_boots.lua
@@ -272,7 +272,10 @@ if IsServer() then
 
 			-- less so is actually making this do anything
 			-- because valve
-			self:SetDuration( spell:GetCooldownTime(), true )
+      local cdRemaining = spell:GetCooldownTimeRemaining()
+      if cdRemaining > 0 then
+        self:SetDuration( cdRemaining, true )
+      end
 		end
 	end
 

--- a/game/scripts/vscripts/items/farming/greater_tranquil_boots.lua
+++ b/game/scripts/vscripts/items/farming/greater_tranquil_boots.lua
@@ -71,8 +71,13 @@ function modifier_item_greater_tranquil_boots:OnCreated( event )
 
 	self.interval = spell:GetSpecialValueFor( "check_interval" )
 
-	if IsServer() then
-		self:SetDuration( spell:GetCooldownTimeRemaining(), true )
+  if IsServer() then
+		local cdRemaining = spell:GetCooldownTimeRemaining()
+    -- Break for any remaining duration (e.g. if item was dropped and picked up)
+    -- Have to check for 0 because setting duration to 0 apparently destroys the modifier even with DestroyOnExpire false
+    if cdRemaining > 0 then
+      self:SetDuration( cdRemaining, true )
+    end
 
 		self:StartIntervalThink( self.interval )
 	end
@@ -102,8 +107,13 @@ function modifier_item_greater_tranquil_boots:OnRefresh( event )
 
 	self.interval = spell:GetSpecialValueFor( "check_interval" )
 
-	if IsServer() then
-		self:SetDuration( spell:GetCooldownTime(), true )
+  if IsServer() then
+    local cdRemaining = spell:GetCooldownTimeRemaining()
+    -- Break for any remaining duration (e.g. if item was dropped and picked up)
+    -- Have to check for 0 because setting duration to 0 apparently destroys the modifier even with DestroyOnExpire false
+    if cdRemaining > 0 then
+      self:SetDuration( cdRemaining, true )
+    end
 
 		self:StartIntervalThink( self.interval )
 	end


### PR DESCRIPTION
Seems like Valve changed the behaviour of SetDuration so that setting it to 0 immediately destroys the modifier even when DestroyOnExpire is false #ThanksValve. Either that, or this has been broken since #1748, but I'm certain I tested it, so that's quite unlikely.