### PR TITLE
Azazel building cleanup and bugfixes

### DIFF
--- a/game/scripts/npc/items/item_azazel_tower_defense.txt
+++ b/game/scripts/npc/items/item_azazel_tower_defense.txt
@@ -75,6 +75,11 @@
                 "var_type"                  "FIELD_INTEGER"
                 "tooltip_damage"            "110 410 810 1610"
             }
+            "06"
+            {
+                "var_type"                  "FIELD_INTEGER"
+                "sink_height"               "300"
+            }
         }
         "precache"
         {

--- a/game/scripts/npc/items/item_azazel_tower_defense_2.txt
+++ b/game/scripts/npc/items/item_azazel_tower_defense_2.txt
@@ -74,6 +74,11 @@
                 "var_type"                  "FIELD_INTEGER"
                 "tooltip_damage"            "110 410 810 1610"
             }
+            "06"
+            {
+                "var_type"                  "FIELD_INTEGER"
+                "sink_height"               "300"
+            }
         }
         "precache"
         {

--- a/game/scripts/npc/items/item_azazel_tower_defense_3.txt
+++ b/game/scripts/npc/items/item_azazel_tower_defense_3.txt
@@ -73,6 +73,11 @@
                 "var_type"                  "FIELD_INTEGER"
                 "tooltip_damage"            "110 410 810 1610"
             }
+            "06"
+            {
+                "var_type"                  "FIELD_INTEGER"
+                "sink_height"               "300"
+            }
         }
         "precache"
         {

--- a/game/scripts/npc/items/item_azazel_tower_defense_4.txt
+++ b/game/scripts/npc/items/item_azazel_tower_defense_4.txt
@@ -72,6 +72,11 @@
                 "var_type"                  "FIELD_INTEGER"
                 "tooltip_damage"            "110 410 810 1610"
             }
+            "06"
+            {
+                "var_type"                  "FIELD_INTEGER"
+                "sink_height"               "300"
+            }
         }
         "precache"
         {

--- a/game/scripts/npc/items/item_azazel_tower_watch.txt
+++ b/game/scripts/npc/items/item_azazel_tower_watch.txt
@@ -70,6 +70,11 @@
                 "var_type"                  "FIELD_INTEGER"
                 "tooltip_vision_range"      "1500 2000 2500 3000"
             }
+            "05"
+            {
+                "var_type"                  "FIELD_INTEGER"
+                "sink_height"               "200"
+            }
         }
         "precache"
         {

--- a/game/scripts/npc/items/item_azazel_tower_watch_2.txt
+++ b/game/scripts/npc/items/item_azazel_tower_watch_2.txt
@@ -69,6 +69,11 @@
                 "var_type"                  "FIELD_INTEGER"
                 "tooltip_vision_range"      "1500 2000 2500 3000"
             }
+            "05"
+            {
+                "var_type"                  "FIELD_INTEGER"
+                "sink_height"               "200"
+            }
         }
         "precache"
         {

--- a/game/scripts/npc/items/item_azazel_tower_watch_3.txt
+++ b/game/scripts/npc/items/item_azazel_tower_watch_3.txt
@@ -68,6 +68,11 @@
                 "var_type"                  "FIELD_INTEGER"
                 "tooltip_vision_range"      "1500 2000 2500 3000"
             }
+            "05"
+            {
+                "var_type"                  "FIELD_INTEGER"
+                "sink_height"               "200"
+            }
         }
         "precache"
         {

--- a/game/scripts/npc/items/item_azazel_tower_watch_4.txt
+++ b/game/scripts/npc/items/item_azazel_tower_watch_4.txt
@@ -67,6 +67,11 @@
                 "var_type"                  "FIELD_INTEGER"
                 "tooltip_vision_range"      "1500 2000 2500 3000"
             }
+            "05"
+            {
+                "var_type"                  "FIELD_INTEGER"
+                "sink_height"               "200"
+            }
         }
         "precache"
         {

--- a/game/scripts/npc/items/item_azazel_wall.txt
+++ b/game/scripts/npc/items/item_azazel_wall.txt
@@ -65,6 +65,11 @@
                 "var_type"                  "FIELD_INTEGER"
                 "wall_length"               "800"
             }
+            "04"
+            {
+                "var_type"                  "FIELD_INTEGER"
+                "sink_height"               "200"
+            }
         }
     }
 }

--- a/game/scripts/npc/items/item_azazel_wall_2.txt
+++ b/game/scripts/npc/items/item_azazel_wall_2.txt
@@ -64,6 +64,11 @@
                 "var_type"                  "FIELD_INTEGER"
                 "wall_length"               "800"
             }
+            "04"
+            {
+                "var_type"                  "FIELD_INTEGER"
+                "sink_height"               "200"
+            }
         }
     }
 }

--- a/game/scripts/npc/items/item_azazel_wall_3.txt
+++ b/game/scripts/npc/items/item_azazel_wall_3.txt
@@ -63,6 +63,11 @@
                 "var_type"                  "FIELD_INTEGER"
                 "wall_length"               "800"
             }
+            "04"
+            {
+                "var_type"                  "FIELD_INTEGER"
+                "sink_height"               "200"
+            }
         }
     }
 }

--- a/game/scripts/npc/items/item_azazel_wall_4.txt
+++ b/game/scripts/npc/items/item_azazel_wall_4.txt
@@ -62,6 +62,11 @@
                 "var_type"                  "FIELD_INTEGER"
                 "wall_length"               "800"
             }
+            "04"
+            {
+                "var_type"                  "FIELD_INTEGER"
+                "sink_height"               "200"
+            }
         }
     }
 }

--- a/game/scripts/vscripts/items/azazel_tower_watch.lua
+++ b/game/scripts/vscripts/items/azazel_tower_watch.lua
@@ -1,4 +1,5 @@
 LinkLuaModifier("modifier_watch_tower", "items/azazel_tower_watch.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_building_construction", "modifiers/modifier_building_construction.lua", LUA_MODIFIER_MOTION_NONE)
 
 item_azazel_tower_watch_1 = class(ItemBaseClass)
 
@@ -22,11 +23,14 @@ function item_azazel_tower_watch_1:OnSpellStart()
   local caster = self:GetCaster()
   local location = self:GetCursorPosition()
   local building = CreateUnitByName("npc_azazel_tower_watch", location, true, caster, caster:GetOwner(), caster:GetTeam())
+  building:RemoveModifierByName("modifier_invulnerable")
+  building:SetMaterialGroup('radiant_level' .. self:GetLevel())
   building:SetHullRadius( 60 )
   building:SetOwner(caster)
   GridNav:DestroyTreesAroundPoint(location, building:GetHullRadius(), true)
   building:SetOrigin(location)
-  building:AddNewModifier(building, self, "modifier_watch_tower", {duration = -1})
+  building:AddNewModifier(building, self, "modifier_watch_tower", {})
+  building:AddNewModifier(building, self, "modifier_building_construction", {})
   local charges = self:GetCurrentCharges() - 1
   if charges < 1 then
     caster:RemoveItem(self)
@@ -45,99 +49,65 @@ item_azazel_tower_watch_4 = item_azazel_tower_watch_1
 
 modifier_watch_tower = class(ModifierBaseClass)
 
-local SINK_HEIGHT = 200
 local THINK_INTERVAL = 0.1
 
 function modifier_watch_tower:OnCreated()
   local ab = self:GetAbility()
   self.level = ab:GetLevel()
-  if IsServer() then
-    local target = self:GetParent()
-    local maxhealth = ab:GetSpecialValueFor("health")
-    local location = target:GetOrigin()
-    local time = ab:GetSpecialValueFor("construction_time")
-    target:Attribute_SetIntValue("construction_time", time)
-    target:Attribute_SetIntValue("bonus_damage", ab:GetSpecialValueFor("bonus_damage"))
-    target:Attribute_SetIntValue("bonus_vision_range", ab:GetSpecialValueFor("bonus_vision_range"))
-    target:SetOrigin(GetGroundPosition(location, target) - Vector(0, 0, SINK_HEIGHT))
-    Timers:CreateTimer(0.5, function()
-      target:RemoveModifierByName('modifier_invulnerable')
-      ResolveNPCPositions(location, target:GetHullRadius())
-      target:SetMaxHealth(maxhealth)
-      target:SetHealth(maxhealth * 0.01)
-      target:SetMaterialGroup('radiant_level'..self.level)
-      self:StartIntervalThink(THINK_INTERVAL)
-      self:SetStackCount(math.floor(time / THINK_INTERVAL)) -- `construction_time` should be divisible by `THINK_INTERVAL`!
-    end)
-  end
+  self.bonus_vision_range = ab:GetSpecialValueFor("bonus_vision_range")
+  self:StartIntervalThink(THINK_INTERVAL)
 end
 
 function modifier_watch_tower:OnIntervalThink()
   if IsServer() then
     local target = self:GetParent()
-    local count = self:GetStackCount()
-    if count > 0 then
-      local time = target:Attribute_GetIntValue("construction_time", 10)
-      target:SetOrigin(target:GetOrigin() + Vector(0, 0, SINK_HEIGHT / (time / THINK_INTERVAL)))
-      self:SetStackCount(count - 1)
-    else
-      -- No other way to have unobstructed vision, sorry.
-      AddFOWViewer(target:GetTeam(), target:GetOrigin(), target:GetCurrentVisionRange(), THINK_INTERVAL, false)
-    end
+    -- No other way to have unobstructed vision, sorry.
+    AddFOWViewer(target:GetTeam(), target:GetOrigin(), target:GetCurrentVisionRange(), THINK_INTERVAL, false)
   end
 end
 
-function modifier_watch_tower:GetAttributes()
-  return MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE
-end
 function modifier_watch_tower:IsHidden()
   return true
 end
+
 function modifier_watch_tower:IsDebuff()
   return false
 end
+
 function modifier_watch_tower:IsPurgable()
   return false
 end
-function modifier_watch_tower:CheckState()
-  return {
-    [MODIFIER_STATE_BLIND] = self:GetStackCount() > 0,
-    [MODIFIER_STATE_FROZEN] = self:GetStackCount() > 0 -- animation seem to restart on each `SetOrigin()` call, causing jittery look.
-  }
-end
+
 function modifier_watch_tower:DeclareFunctions()
   return {
     MODIFIER_EVENT_ON_DEATH,
     MODIFIER_PROPERTY_BONUS_DAY_VISION,
     MODIFIER_PROPERTY_BONUS_NIGHT_VISION,
     MODIFIER_PROPERTY_OVERRIDE_ANIMATION,
-    MODIFIER_PROPERTY_TRANSLATE_ACTIVITY_MODIFIERS,
-    MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT
+    MODIFIER_PROPERTY_TRANSLATE_ACTIVITY_MODIFIERS
   }
 end
+
 function modifier_watch_tower:OnDeath(data)
   if data.unit == self:GetParent() then
     data.unit:SetOriginalModel("models/props_structures/tower_upgrade/tower_upgrade_dest.vmdl")
     data.unit:ManageModelChanges()
-    ParticleManager:CreateParticle("particles/world_tower/tower_upgrade/ti7_radiant_tower_lvl1_dest.vpcf", PATTACH_ABSORIGIN, data.unit)
+    local destruction_particle = ParticleManager:CreateParticle("particles/world_tower/tower_upgrade/ti7_radiant_tower_lvl1_dest.vpcf", PATTACH_ABSORIGIN, data.unit)
+    ParticleManager:ReleaseParticleIndex(destruction_particle)
   end
 end
-function modifier_watch_tower:GetModifierConstantHealthRegen()
-  if IsServer() and self:GetStackCount() > 0 then
-    return self:GetParent():GetMaxHealth() / self:GetParent():Attribute_GetIntValue("construction_time", 10)
-  else
-    return 0
-  end
-end
+
 function modifier_watch_tower:GetBonusDayVision()
   if IsServer() then
-    return self:GetParent():Attribute_GetIntValue("bonus_vision_range", 0)
+    return self.bonus_vision_range
   end
 end
 modifier_watch_tower.GetBonusNightVision = modifier_watch_tower.GetBonusDayVision
+
 function modifier_watch_tower:GetOverrideAnimation()
   return ACT_DOTA_CAPTURE
 end
+
 function modifier_watch_tower:GetActivityTranslationModifiers()
   return "level"..self.level
 end

--- a/game/scripts/vscripts/items/azazel_wall.lua
+++ b/game/scripts/vscripts/items/azazel_wall.lua
@@ -1,4 +1,5 @@
 LinkLuaModifier("modifier_wall_segment", "items/azazel_wall.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_building_construction", "modifiers/modifier_building_construction.lua", LUA_MODIFIER_MOTION_NONE)
 
 item_azazel_wall_1 = class(ItemBaseClass)
 
@@ -46,9 +47,9 @@ function item_azazel_wall_1:OnSpellStart()
       local building = CreateUnitByName("npc_azazel_wall_segment", location, true, caster, caster:GetOwner(), caster:GetTeam())
       building:RemoveModifierByName("modifier_invulnerable")
       building:SetOrigin(location)
+      building:SetOwner(caster)
       building:AddNewModifier(building, self, "modifier_building_construction", {})
       building:AddNewModifier(building, self, "modifier_wall_segment", {})
-      building:SetOwner(caster)
     end
   end
   if not spawned then

--- a/game/scripts/vscripts/items/azazel_wall.lua
+++ b/game/scripts/vscripts/items/azazel_wall.lua
@@ -24,7 +24,7 @@ function item_azazel_wall_1:OnSpellStart()
   local segment_count = math.ceil(wall_length / (SEGMENT_RADIUS * 2)) -- Each segment can cover SEGMENT_RADIUS * 2 units
   local origin_caster = caster:GetOrigin()
   -- direction of the wall.
-  local direction = RotatePosition(Vector(0, 0, 0), VectorToAngles(Vector(0, -90, 0)), Vector(target_pos.x - origin_caster.x, target_pos.y - origin_caster.y, target_pos.z)):Normalized() --[[rotate the vector between the cast location and the caster
+  local direction = RotatePosition(Vector(0, 0, 0), VectorToAngles(Vector(0, -1, 0)), Vector(target_pos.x - origin_caster.x, target_pos.y - origin_caster.y, 0)):Normalized() --[[rotate the vector between the cast location and the caster
     by 90 deg to the right, thus geting the *opposite* of the direction we will spawn wall segments in.]]
   if #direction == 0 then
     direction = RandomVector(1)

--- a/game/scripts/vscripts/modifiers/modifier_building_construction.lua
+++ b/game/scripts/vscripts/modifiers/modifier_building_construction.lua
@@ -1,0 +1,79 @@
+-- Modifier for handling construction of Azazel buildings
+-- Expects its parent ability to have "health", "construction_time", "sink_hegiht", and "think_interval" special values
+-- Defaults to not making the building rise from the ground if no "sink_hegiht" is set
+-- Defaults to "think_interval" of 0.1
+
+modifier_building_construction = class(ModifierBaseClass)
+
+function modifier_building_construction:IsHidden()
+  return true
+end
+
+function modifier_building_construction:IsPurgable()
+  return false
+end
+
+if IsServer() then
+  function modifier_building_construction:OnCreated()
+    local parent = self:GetParent()
+    local ability = self:GetAbility()
+    self.constructionTime = ability:GetSpecialValueFor("construction_time")
+    self.maxHealth = ability:GetSpecialValueFor("health")
+    self.initialSinkHeight = ability:GetSpecialValueFor("sink_height")
+    self.thinkInterval = ability:GetSpecialValueFor("think_interval")
+    if self.thinkInterval == 0 then
+      self.thinkInterval = 0.1
+    end
+
+    local origin = parent:GetOrigin()
+    parent:SetOrigin(GetGroundPosition(origin, parent) - Vector(0, 0, self.initialSinkHeight))
+
+    ResolveNPCPositions(origin, parent:GetHullRadius())
+
+    parent:SetMaxHealth(self.maxHealth)
+    parent:SetHealth(self.maxHealth * 0.01)
+
+    self.totalTicks = math.floor(self.constructionTime / self.thinkInterval)
+    self.ticksRemaining = self.totalTicks
+    self:StartIntervalThink(self.thinkInterval)
+  end
+
+  function modifier_building_construction:OnIntervalThink()
+    if self.ticksRemaining <= 0 then
+      self:StartIntervalThink(-1)
+      self:Destroy()
+      return
+    end
+    local parent = self:GetParent()
+
+    -- Setting max health directly after spawning pretty much never works, so this ensures max health gets set corretly
+    if parent:GetMaxHealth() ~= self.maxHealth then
+      parent:SetMaxHealth(self.maxHealth)
+    end
+
+    local origin = parent:GetOrigin()
+    parent:SetOrigin(origin + Vector(0, 0, self.initialSinkHeight / self.totalTicks))
+
+    ResolveNPCPositions(origin, parent:GetHullRadius())
+
+    self.ticksRemaining = self.ticksRemaining - 1
+  end
+end
+
+function modifier_building_construction:CheckState()
+  return {
+    [MODIFIER_STATE_DISARMED] = true,
+    [MODIFIER_STATE_BLIND] = true,
+    [MODIFIER_STATE_FROZEN] = true
+  }
+end
+
+function modifier_building_construction:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT
+  }
+end
+
+function modifier_building_construction:GetModifierConstantHealthRegen()
+  return self.maxHealth * 0.99 / self.constructionTime
+end


### PR DESCRIPTION
Short changelog:
- Fix buildings randomly having less health than they should
- Fix Wall being shorter than intended
  * Side effect: Wall now has 5 segments instead of 6

Refactored all building construction to use a unified modifier and changed the way the max health of the buildings is altered. This should fix issues with buildings randomly having much less health than they should.

Walls had some further rewrites to fix the length of the walls being shorter than specified in the KV. Side effect being that there are only 5 segments now as opposed to the previous 6.