### PR TITLE
Duel start invulnerability

### DIFF
--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -2,6 +2,7 @@ local HeroState = require("components/duels/savestate")
 local SafeTeleportAll = require("components/duels/teleport").SafeTeleportAll
 
 LinkLuaModifier("modifier_out_of_duel", "modifiers/modifier_out_of_duel.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_duel_invulnerability", "modifiers/modifier_duel_invulnerability", LUA_MODIFIER_MOTION_NONE)
 
 DUEL_IS_STARTING = 21
 
@@ -444,6 +445,23 @@ function Duels:ActuallyStartDuel(options)
     end
   end
 
+  --duel start invulnerability
+  --Invulnerability Duration/ Should probably move this to options
+  local invulnerabilityduration = 3.0
+  --Invulnerability Duration
+  for _,player in ipairs(badPlayers) do
+    if player.assigned ~= nil then
+      local hero = PlayerResource:GetSelectedHeroEntity(player.id)
+      hero:AddNewModifier(nil, nil, "modifier_duel_invulnerability", {duration = invulnerabilityduration})
+    end
+  end
+  for _,player in ipairs(goodPlayers) do
+    if player.assigned ~= nil then
+      local hero = PlayerResource:GetSelectedHeroEntity(player.id)
+      hero:AddNewModifier(nil, nil, "modifier_duel_invulnerability", {duration = invulnerabilityduration})
+    end
+  end
+  
   self.currentDuel = {
     goodLiving1 = playerSplitOffset,
     badLiving1 = playerSplitOffset,
@@ -457,7 +475,7 @@ function Duels:ActuallyStartDuel(options)
     goodPlayerIndex = goodPlayerIndex
   }
   DuelStartEvent.broadcast(self.currentDuel)
-
+  
   if options.timeout == nil then
     options.timeout = DUEL_TIMEOUT
   end

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -447,7 +447,7 @@ function Duels:ActuallyStartDuel(options)
 
   --duel start invulnerability
   --Invulnerability Duration/ Should probably move this to options
-  local invulnerabilityduration = 3.0
+  local invulnerabilityduration = 2.0
   --Invulnerability Duration
   for _,player in ipairs(badPlayers) do
     if player.assigned ~= nil then

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -475,7 +475,7 @@ function Duels:ActuallyStartDuel(options)
     goodPlayerIndex = goodPlayerIndex
   }
   DuelStartEvent.broadcast(self.currentDuel)
-  
+
   if options.timeout == nil then
     options.timeout = DUEL_TIMEOUT
   end

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -446,19 +446,16 @@ function Duels:ActuallyStartDuel(options)
   end
 
   --duel start invulnerability
-  --Invulnerability Duration/ Should probably move this to options
-  local invulnerabilityduration = 2.0
-  --Invulnerability Duration
   for _,player in ipairs(badPlayers) do
     if player.assigned ~= nil then
       local hero = PlayerResource:GetSelectedHeroEntity(player.id)
-      hero:AddNewModifier(nil, nil, "modifier_duel_invulnerability", {duration = invulnerabilityduration})
+      hero:AddNewModifier(nil, nil, "modifier_duel_invulnerability", {duration = DUEL_START_PROTECTION_TIME})
     end
   end
   for _,player in ipairs(goodPlayers) do
     if player.assigned ~= nil then
       local hero = PlayerResource:GetSelectedHeroEntity(player.id)
-      hero:AddNewModifier(nil, nil, "modifier_duel_invulnerability", {duration = invulnerabilityduration})
+      hero:AddNewModifier(nil, nil, "modifier_duel_invulnerability", {duration = DUEL_START_PROTECTION_TIME})
     end
   end
   

--- a/game/scripts/vscripts/modifiers/modifier_duel_invulnerability.lua
+++ b/game/scripts/vscripts/modifiers/modifier_duel_invulnerability.lua
@@ -10,11 +10,3 @@ end
 function modifier_duel_invulnerability:IsHidden() return true end
 function modifier_duel_invulnerability:IsPurgable()	return false end
 function modifier_duel_invulnerability:DestroyOnExpire() return true end
-
-
-function modifier_duel_invulnerability:OnCreated(kv) 
-	if IsServer() then
-		self.duration = kv.duration
-		self:SetDuration(self.duration, true)
-	end
-end

--- a/game/scripts/vscripts/modifiers/modifier_duel_invulnerability.lua
+++ b/game/scripts/vscripts/modifiers/modifier_duel_invulnerability.lua
@@ -1,0 +1,20 @@
+modifier_duel_invulnerability = class({})
+
+function modifier_duel_invulnerability:CheckState()
+	return {
+	[MODIFIER_STATE_INVULNERABLE] = true,
+	[MODIFIER_STATE_MAGIC_IMMUNE] = true,
+	}
+end
+
+function modifier_duel_invulnerability:IsHidden() return false end
+function modifier_duel_invulnerability:IsPurgable()	return false end
+function modifier_duel_invulnerability:DestroyOnExpire() return true end
+
+
+function modifier_duel_invulnerability:OnCreated(kv) 
+	if IsServer() then
+		self.duration = kv.duration
+		self:SetDuration(self.duration, true)
+	end
+end

--- a/game/scripts/vscripts/modifiers/modifier_duel_invulnerability.lua
+++ b/game/scripts/vscripts/modifiers/modifier_duel_invulnerability.lua
@@ -7,7 +7,7 @@ function modifier_duel_invulnerability:CheckState()
 	}
 end
 
-function modifier_duel_invulnerability:IsHidden() return false end
+function modifier_duel_invulnerability:IsHidden() return true end
 function modifier_duel_invulnerability:IsPurgable()	return false end
 function modifier_duel_invulnerability:DestroyOnExpire() return true end
 

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -56,6 +56,7 @@ FINAL_DUEL_TIMEOUT = 300                -- Timeout for the final duel, the game 
 DUEL_END_COUNTDOWN = 10                 -- How many seconds to count down before a duel can timeout (added as a delay before the duel times out)
 DUEL_RUNE_TIMER = 30                    -- how long until the highground object becomes active in duels
 DUEL_INTERVAL = 300                     -- time from duel ending until dnext duel countdown begins
+DUEL_START_PROTECTION_TIME = 2          -- duel start protection duration
 
 -- CapturePoints
 INITIAL_CAPTURE_POINT_DELAY = 900       -- how long after the clock hits 0 should the CapturePoint duel start countind down


### PR DESCRIPTION
Should work unless I completely misunderstood how to get players in the active duel
(I was not able to test it since I cannot start a duel alone)

The modifier cannot be purged by Nullifier unlike the default `modifier_invulnerable`

- Probably needs some ParticleFX since it would confuse people who dont read changelogs and find it weird when enemies walk out of their perfectly placed chronosphere