### PR TITLE
make drums not crash the game

### DIFF
--- a/game/scripts/npc/items/item_ancient_janggo_of_endurance.txt
+++ b/game/scripts/npc/items/item_ancient_janggo_of_endurance.txt
@@ -51,7 +51,7 @@
     "ItemShopTags"                                        "str;agi;int;damage;move_speed;attack_speed;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "drum of endurance;drums"
-    "ItemInitialCharges"                                  "322"
+    "ItemInitialCharges"                                  "322" //OAA
     "ItemDisplayCharges"                                  "1"
     "ItemRequiresCharges"                                 "1"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"

--- a/game/scripts/npc/items/item_ancient_janggo_of_endurance.txt
+++ b/game/scripts/npc/items/item_ancient_janggo_of_endurance.txt
@@ -51,10 +51,10 @@
     "ItemShopTags"                                        "str;agi;int;damage;move_speed;attack_speed;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "drum of endurance;drums"
-    "ItemInitialCharges"                                  "6"
+    "ItemInitialCharges"                                  "322"
     "ItemDisplayCharges"                                  "1"
-    "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
     "ItemRequiresCharges"                                 "1"
+    "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/item_ancient_janggo_of_endurance_2.txt
+++ b/game/scripts/npc/items/item_ancient_janggo_of_endurance_2.txt
@@ -54,10 +54,9 @@
     "ItemShopTags"                                        "str;agi;int;damage;move_speed;attack_speed;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "drum of endurance 2;drums 2"
-    //  Infinite Charges:
-    "ItemInitialCharges"                                  "-1"
-    "ItemDisplayCharges"                                  "0"
-    "ItemRequiresCharges"                                 "0"
+    "ItemInitialCharges"                                  "322"
+    "ItemDisplayCharges"                                  "1"
+    "ItemRequiresCharges"                                 "1"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_ancient_janggo_of_endurance_3.txt
+++ b/game/scripts/npc/items/item_ancient_janggo_of_endurance_3.txt
@@ -53,10 +53,9 @@
     "ItemShopTags"                                        "str;agi;int;damage;move_speed;attack_speed;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "drum of endurance 3;drums 3"
-    //  Infinite Charges:
-    "ItemInitialCharges"                                  "-1"
-    "ItemDisplayCharges"                                  "0"
-    "ItemRequiresCharges"                                 "0"
+    "ItemInitialCharges"                                  "322"
+    "ItemDisplayCharges"                                  "1"
+    "ItemRequiresCharges"                                 "1"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_ancient_janggo_of_endurance_4.txt
+++ b/game/scripts/npc/items/item_ancient_janggo_of_endurance_4.txt
@@ -52,10 +52,9 @@
     "ItemShopTags"                                        "str;agi;int;damage;move_speed;attack_speed;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "drum of endurance 4;drums 4"
-    //  Infinite Charges:
-    "ItemInitialCharges"                                  "-1"
-    "ItemDisplayCharges"                                  "0"
-    "ItemRequiresCharges"                                 "0"
+    "ItemInitialCharges"                                  "322"
+    "ItemDisplayCharges"                                  "1"
+    "ItemRequiresCharges"                                 "1"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special

--- a/game/scripts/npc/items/item_ancient_janggo_of_endurance_5.txt
+++ b/game/scripts/npc/items/item_ancient_janggo_of_endurance_5.txt
@@ -50,10 +50,9 @@
     "ItemShopTags"                                        "str;agi;int;damage;move_speed;attack_speed;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "drum of endurance 5;drums 5"
-    //  Infinite Charges:
-    "ItemInitialCharges"                                  "-1"
-    "ItemDisplayCharges"                                  "0"
-    "ItemRequiresCharges"                                 "0"
+    "ItemInitialCharges"                                  "322"
+    "ItemDisplayCharges"                                  "1"
+    "ItemRequiresCharges"                                 "1"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special


### PR DESCRIPTION
"-1" charges don't work with drums
drums don't have an effectwhen activated with 0 charges either, so a high number of charges will be essentially unlimited