### PR TITLE
Rework Heart Transplant slightly

### DIFF
--- a/game/resource/English/ability/items/tooltip_heart_transplant.txt
+++ b/game/resource/English/ability/items/tooltip_heart_transplant.txt
@@ -3,7 +3,7 @@
 //======================================================================
 "DOTA_Tooltip_Ability_item_heart_transplant"                                        "Heart Transplant"
 "DOTA_Tooltip_Ability_item_recipe_heart_transplant"                                 "Heart Transplant Recipe"
-"DOTA_Tooltip_Ability_item_heart_transplant_Description"                            "<h1>Active: Transplant</h1> Gives all bonus Strength, HP, and Regeneration to the selected allied unit for %transplant_duration% seconds. If damage is taken from an enemy hero or Roshan, this Ability is disabled for %cooldown_melee% seconds for melee heroes, or %cooldown_ranged_tooltip% seconds for ranged heroes.<br><br>Range: %transplant_range_tooltip%\n<h1>Passive: Health Regeneration</h1>Restores %health_regen_rate%%% of max health per second. Health Regeneration is also disabled by damage as described above."
+"DOTA_Tooltip_Ability_item_heart_transplant_Description"                            "<h1>Active: Transplant</h1> Gives all bonus Strength, HP, and Regeneration to the selected allied unit for %transplant_duration% seconds. If damage is taken from an enemy hero, the transplanted regeneration is disabled for %transplant_break_cooldown% seconds.<br><br>Range: %transplant_range_tooltip%\n<h1>Passive: Health Regeneration</h1>Restores %health_regen_rate%%% of max health per second. If damage is taken from an enemy hero, this ability is disabled for %cooldown_melee% seconds for melee heroes, or %cooldown_ranged_tooltip% seconds for ranged heroes."
 "DOTA_Tooltip_Ability_item_heart_transplant_Lore"                                   "A talisman containing a beautiful priestess's soul."
 "DOTA_Tooltip_Ability_item_heart_transplant_bonus_strength"                         "+$str"
 "DOTA_Tooltip_Ability_item_heart_transplant_bonus_health"                           "+$health"
@@ -20,3 +20,5 @@
 "DOTA_Tooltip_modifier_item_heart_transplant_debuff_Description"                    "All the benefits of your Heart are being given to another unit"
 "DOTA_Tooltip_modifier_item_heart_transplant_buff"                                  "Donated Heart"
 "DOTA_Tooltip_modifier_item_heart_transplant_buff_Description"                      "Strength increased by %dMODIFIER_PROPERTY_STATS_STRENGTH_BONUS%, Health increased by %dMODIFIER_PROPERTY_HEALTH_BONUS%, and healing %dMODIFIER_PROPERTY_HEALTH_REGEN_PERCENTAGE%%% HP per second"
+
+"oaa_hud_error_only_one_transplant"                                                 "Can't cast multiple Heart Transplants simultaneously"

--- a/game/scripts/npc/items/custom/item_heart_transplant.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant.txt
@@ -92,28 +92,33 @@
         "var_type"                                        "FIELD_INTEGER"
         "transplant_range_tooltip"                        "700"
       }
-      // Heart Parameters
       "04"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "transplant_break_cooldown"                       "5"
+      }
+      // Heart Parameters
+      "05"
       {
         "var_type"                                        "FIELD_INTEGER"
         "bonus_strength"                                  "80 85"
       }
-      "05"
+      "06"
       {
         "var_type"                                        "FIELD_INTEGER"
         "bonus_health"                                    "2300 3400"
       }
-      "06"
+      "07"
       {
         "var_type"                                        "FIELD_FLOAT"
         "health_regen_rate"                               "4.5"
       }
-      "07"
+      "08"
       {
         "var_type"                                        "FIELD_INTEGER"
         "cooldown_melee"                                  "5"
       }
-      "08"
+      "09"
       {
         "var_type"                                        "FIELD_INTEGER"
         "cooldown_ranged_tooltip"                         "7"

--- a/game/scripts/npc/items/custom/item_heart_transplant_2.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant_2.txt
@@ -83,28 +83,33 @@
         "var_type"                                        "FIELD_INTEGER"
         "transplant_range_tooltip"                        "700"
       }
-      // Heart Parameters
       "04"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "transplant_break_cooldown"                       "5"
+      }
+      // Heart Parameters
+      "05"
       {
         "var_type"                                        "FIELD_INTEGER"
         "bonus_strength"                                  "80 85"
       }
-      "05"
+      "06"
       {
         "var_type"                                        "FIELD_INTEGER"
         "bonus_health"                                    "2300 3400"
       }
-      "06"
+      "07"
       {
         "var_type"                                        "FIELD_FLOAT"
         "health_regen_rate"                               "4.5"
       }
-      "07"
+      "08"
       {
         "var_type"                                        "FIELD_INTEGER"
         "cooldown_melee"                                  "5"
       }
-      "08"
+      "09"
       {
         "var_type"                                        "FIELD_INTEGER"
         "cooldown_ranged_tooltip"                         "7"

--- a/game/scripts/vscripts/items/heart_transplant.lua
+++ b/game/scripts/vscripts/items/heart_transplant.lua
@@ -152,6 +152,10 @@ end
 
 modifier_item_heart_transplant_buff = class(ModifierBaseClass)
 
+function modifier_item_heart_transplant_buff:IsPurgable()
+  return false
+end
+
 function modifier_item_heart_transplant_buff:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_STATS_STRENGTH_BONUS,

--- a/game/scripts/vscripts/items/heart_transplant.lua
+++ b/game/scripts/vscripts/items/heart_transplant.lua
@@ -1,6 +1,7 @@
 LinkLuaModifier( "modifier_item_heart_transplant", "items/heart_transplant.lua", LUA_MODIFIER_MOTION_NONE )
 LinkLuaModifier( "modifier_item_heart_transplant_debuff", "items/heart_transplant.lua", LUA_MODIFIER_MOTION_NONE )
 LinkLuaModifier( "modifier_item_heart_transplant_buff", "items/heart_transplant.lua", LUA_MODIFIER_MOTION_NONE )
+LinkLuaModifier( "modifier_item_heart_transplant_buff_break", "items/heart_transplant.lua", LUA_MODIFIER_MOTION_NONE )
 
 local heartTransplantDebuffName = "modifier_item_heart_transplant_debuff"
 
@@ -15,7 +16,7 @@ function item_heart_transplant:CastFilterResultTarget(target)
   local defaultFilterResult = self.BaseClass.CastFilterResultTarget(self, target)
   if defaultFilterResult ~= UF_SUCCESS then
     return defaultFilterResult
-  elseif target == caster then
+  elseif target == caster or (IsServer() and caster:FindModifierByName(heartTransplantDebuffName) and caster:FindModifierByName(heartTransplantDebuffName) ~= self.transplanted_modifier) then
     return UF_FAIL_CUSTOM
   end
 end
@@ -24,6 +25,8 @@ function item_heart_transplant:GetCustomCastErrorTarget(target)
   local caster = self:GetCaster()
   if target == caster then
     return "#dota_hud_error_cant_cast_on_self"
+  elseif IsServer() and caster:FindModifierByName(heartTransplantDebuffName) and caster:FindModifierByName(heartTransplantDebuffName) ~= self.transplanted_modifier then
+    return "#oaa_hud_error_only_one_transplant"
   end
 end
 
@@ -35,12 +38,20 @@ function item_heart_transplant:OnSpellStart()
 
   self:StartCooldown(transplant_cooldown)
 
-  target:AddNewModifier(caster, self, "modifier_item_heart_transplant_buff", {
+  -- Only allow one active transfer
+  if self.transferred_buff and not self.transferred_buff:IsNull() then
+    self.transferred_buff:Destroy()
+  end
+
+  self.transferred_buff = target:AddNewModifier(caster, self, "modifier_item_heart_transplant_buff", {
     duration = duration
   })
-  caster:AddNewModifier(caster, self, "modifier_item_heart_transplant_debuff", {
+  self.transplanted_modifier = caster:AddNewModifier(caster, self, heartTransplantDebuffName, {
     duration = duration
   })
+
+  -- Store target so that the regen can be disabled when taking damage
+  self.target = target
 end
 
 item_heart_transplant_2 = item_heart_transplant
@@ -70,10 +81,14 @@ function modifier_item_heart_transplant:GetAttributes()
   return MODIFIER_ATTRIBUTE_MULTIPLE
 end
 
+function modifier_item_heart_transplant:OnCreated()
+  self:GetAbility().intrinsic_modifier = self
+end
+
 function modifier_item_heart_transplant:GetModifierBonusStats_Strength()
   local parent = self:GetParent()
 
-  if parent:HasModifier(heartTransplantDebuffName) then
+  if self.disabled then
     return 0
   else
     return self:GetAbility():GetSpecialValueFor("bonus_strength")
@@ -83,24 +98,26 @@ end
 function modifier_item_heart_transplant:GetModifierHealthBonus()
   local parent = self:GetParent()
 
-  if parent:HasModifier(heartTransplantDebuffName) then
+  if self.disabled then
     return 0
   else
     return self:GetAbility():GetSpecialValueFor("bonus_health")
   end
 end
 
-function modifier_item_heart_transplant:GetModifierHealthRegenPercentage()
-  local parent = self:GetParent()
-  local heart = self:GetAbility()
-  local parentHasHeart = parent:HasModifier("modifier_item_heart")
-  local parentHasGivenHeartAway = parent:HasModifier("modifier_item_heart_transplant_debuff")
-  local isFirstHeartTransplantModifier = parent:FindModifierByName(self:GetName()) == self
+if IsServer() then
+  function modifier_item_heart_transplant:GetModifierHealthRegenPercentage()
+    local parent = self:GetParent()
+    local heart = self:GetAbility()
+    local parentHasHeart = parent:HasModifier("modifier_item_heart")
+    local parentHasGivenHeartAway = self.disabled
+    local isFirstHeartTransplantModifier = parent:FindModifierByName(self:GetName()) == self
 
-  if heart:IsCooldownReady() and not parent:IsIllusion() and not parentHasGivenHeartAway and not parentHasHeart and isFirstHeartTransplantModifier then
-    return heart:GetSpecialValueFor("health_regen_rate")
-  else
-    return 0
+    if heart:IsCooldownReady() and not parent:IsIllusion() and not parentHasGivenHeartAway and not parentHasHeart and isFirstHeartTransplantModifier then
+      return heart:GetSpecialValueFor("health_regen_rate")
+    else
+      return 0
+    end
   end
 end
 
@@ -114,6 +131,11 @@ function modifier_item_heart_transplant:OnTakeDamage(keys)
 
   if keys.damage > 0 and keys.unit == parent and keys.attacker ~= parent and not keys.attacker:IsNeutralUnitType() and not keys.attacker:IsCreature() then
     heart:StartCooldown(breakDuration)
+    -- Disable regen on transplanted target
+    if heart.target then
+      local targetBreakDuration = heart:GetSpecialValueFor("transplant_break_cooldown")
+      heart.target:AddNewModifier(parent, heart, "modifier_item_heart_transplant_buff_break", {duration = targetBreakDuration})
+    end
   end
 end
 
@@ -133,20 +155,22 @@ function modifier_item_heart_transplant_debuff:IsPurgeException()
   return false
 end
 
--- function modifier_item_heart_transplant_debuff:DeclareFunctions()
---   return {
---     MODIFIER_PROPERTY_STATS_STRENGTH_BONUS,
---     MODIFIER_PROPERTY_HEALTH_BONUS
---   }
--- end
+function modifier_item_heart_transplant_debuff:OnCreated()
+  local intrinsic_modifier = self:GetAbility().intrinsic_modifier
+  if intrinsic_modifier and not intrinsic_modifier:IsNull() then
+    intrinsic_modifier.disabled = true
+    self:GetParent():CalculateStatBonus()
+  end
+end
 
--- function modifier_item_heart_transplant_debuff:GetModifierBonusStats_Strength()
---   return 0 - self:GetAbility():GetSpecialValueFor("bonus_strength")
--- end
-
--- function modifier_item_heart_transplant_debuff:GetModifierHealthBonus()
---   return 0 - self:GetAbility():GetSpecialValueFor("bonus_health")
--- end
+function modifier_item_heart_transplant_debuff:OnDestroy()
+  local intrinsic_modifier = self:GetAbility().intrinsic_modifier
+  if intrinsic_modifier and not intrinsic_modifier:IsNull() then
+    intrinsic_modifier.disabled = false
+    self:GetParent():CalculateStatBonus()
+  end
+  self:GetAbility().transplanted_modifier = nil
+end
 
 ------------------------------------------------------------------------------------------
 
@@ -154,6 +178,10 @@ modifier_item_heart_transplant_buff = class(ModifierBaseClass)
 
 function modifier_item_heart_transplant_buff:IsPurgable()
   return false
+end
+
+function modifier_item_heart_transplant_buff:GetAttributes()
+  return MODIFIER_ATTRIBUTE_MULTIPLE
 end
 
 function modifier_item_heart_transplant_buff:DeclareFunctions()
@@ -177,6 +205,12 @@ end
 
 function modifier_item_heart_transplant_buff:OnDestroy(  )
   if IsServer() then
+    local parent_item = self:GetAbility()
+    -- Remove stored target handle on item
+    parent_item.target = nil
+    -- Remove stored modifier handle on item
+    parent_item.transferred_buff = nil
+
     ParticleManager:DestroyParticle( self.nPreviewFX, true )
     ParticleManager:ReleaseParticleIndex(self.nPreviewFX)
     self.nPreviewFX = nil
@@ -192,7 +226,43 @@ function modifier_item_heart_transplant_buff:GetModifierHealthBonus()
 end
 
 function modifier_item_heart_transplant_buff:GetModifierHealthRegenPercentage()
-  local heart = self:GetAbility()
+  if self.disabled then
+    return 0
+  else
+    return self:GetAbility():GetSpecialValueFor("health_regen_rate")
+  end
+end
 
-  return heart:GetSpecialValueFor("health_regen_rate")
+------------------------------------------------------------------------------------------
+
+-- Flag modifier to disable regen on transplanted target
+modifier_item_heart_transplant_buff_break = class(ModifierBaseClass)
+
+function modifier_item_heart_transplant_buff_break:IsHidden()
+  return true
+end
+
+function modifier_item_heart_transplant_buff_break:IsDebuff()
+  return true
+end
+
+function modifier_item_heart_transplant_buff_break:IsPurgable()
+  return false
+end
+
+function modifier_item_heart_transplant_buff_break:GetAttributes()
+  return MODIFIER_ATTRIBUTE_MULTIPLE
+end
+
+function modifier_item_heart_transplant_buff_break:OnCreated()
+  self.transplant_buff = self:GetAbility().transferred_buff
+  if self.transplant_buff and not self.transplant_buff:IsNull() then
+    self.transplant_buff.disabled = true
+  end
+end
+
+function modifier_item_heart_transplant_buff_break:OnDestroy()
+  if self.transplant_buff and not self.transplant_buff:IsNull() then
+    self.transplant_buff.disabled = false
+  end
 end


### PR DESCRIPTION
* Transplant buff is no longer purgable
* Only one active transplant is allowed (reusing the same Transplant item will end the old transplant)
* When the owner takes damage, transplant regen will be disabled for a duration set by a new key in KV (5 seconds currently)
* Multiple transplants from different heroes are allowed to stack on one target
* Prevent use of multiple Heart Transplant item actives from a single hero