### PR TITLE
Change Viper silence talent

### DIFF
--- a/game/resource/English/ability/units/tooltip_viper_viper_strike_oaa.txt
+++ b/game/resource/English/ability/units/tooltip_viper_viper_strike_oaa.txt
@@ -1,0 +1,22 @@
+//=============================================================================
+// Viper Viper Strike
+//=============================================================================
+
+"DOTA_Tooltip_ability_viper_viper_strike_oaa"                            "#{DOTA_Tooltip_ability_viper_viper_strike}"
+"DOTA_Tooltip_ability_viper_viper_strike_oaa_Description"                "{DOTA_Tooltip_ability_viper_viper_strike_Description}"
+"DOTA_Tooltip_ability_viper_viper_strike_oaa_Lore"                       "#{DOTA_Tooltip_ability_viper_viper_strike_Lore}"
+"DOTA_Tooltip_ability_viper_viper_strike_oaa_Note0"                      "#{DOTA_Tooltip_ability_viper_viper_strike_Note0}"
+"DOTA_Tooltip_ability_viper_viper_strike_oaa_duration"                   "#{DOTA_Tooltip_ability_viper_viper_strike_duration}"
+"DOTA_Tooltip_ability_viper_viper_strike_oaa_damage"                     "#{DOTA_Tooltip_ability_viper_viper_strike_damage}"
+"DOTA_Tooltip_ability_viper_viper_strike_oaa_bonus_movement_speed"       "#{DOTA_Tooltip_ability_viper_viper_strike_bonus_movement_speed}"
+"DOTA_Tooltip_ability_viper_viper_strike_oaa_bonus_attack_speed"         "#{DOTA_Tooltip_ability_viper_viper_strike_bonus_attack_speed}"
+"DOTA_Tooltip_ability_viper_viper_strike_oaa_cast_range_scepter"         "#{DOTA_Tooltip_ability_viper_viper_strike_cast_range_scepter}"
+"DOTA_Tooltip_ability_viper_viper_strike_oaa_mana_cost_scepter"          "#{DOTA_Tooltip_ability_viper_viper_strike_mana_cost_scepter}"
+"DOTA_Tooltip_ability_viper_viper_strike_oaa_cooldown_scepter"           "#{DOTA_Tooltip_ability_viper_viper_strike_cooldown_scepter}"
+"DOTA_Tooltip_ability_viper_viper_strike_oaa_aghanim_description"        "#{DOTA_Tooltip_ability_viper_viper_strike_aghanim_description}"
+
+
+"DOTA_Tooltip_ability_special_bonus_unique_viper_3_oaa"                  "#{DOTA_Tooltip_ability_viper_viper_strike} Silences"
+
+"DOTA_Tooltip_modifier_viper_viper_strike_silence"                       "Viper Strike Slow"
+"DOTA_Tooltip_modifier_viper_viper_strike_silence_Description"           "Silenced. Applied by talent"

--- a/game/scripts/npc/abilities/viper_viper_strike_oaa.txt
+++ b/game/scripts/npc/abilities/viper_viper_strike_oaa.txt
@@ -1,0 +1,121 @@
+"DOTAAbilities"
+{
+"viper_viper_strike_oaa"
+  {
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "ID"                                                  "85221"                            // unique ID number for this ability.  Do not change this once established or it will invalidate collected stats.
+    "BaseClass"                                           "ability_lua"
+    "ScriptFile"                                          "abilities/oaa_viper_strike.lua"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+    "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
+    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+    "AbilityType"                                         "DOTA_ABILITY_TYPE_ULTIMATE"
+    "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+    "AbilityTextureName"                                  "viper_viper_strike"
+    "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_YES"
+    "SpellDispellableType"                                "SPELL_DISPELLABLE_NO"
+    "AbilityUnitDamageType"                               "DAMAGE_TYPE_MAGICAL"
+    "FightRecapLevel"                                     "2"
+    "MaxLevel"                                            "5"
+
+    "HasScepterUpgrade"                                   "1"
+
+    // Casting
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCastRange"                                    "500"
+    "AbilityCastPoint"                                    "0.3"
+
+    // Time
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCooldown"                                     "50 40 30 30 30"
+
+    // Cost
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityManaCost"                                     "125 175 250 550 875"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "duration"                                        "5"
+      }
+      "02"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "damage"                                          "60 100 145 370 595"
+        "LinkedSpecialBonus"                              "special_bonus_unique_viper_2"
+      }
+      "03"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_movement_speed"                            "-40 -60 -80 -80 -80"
+      }
+      "04"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_attack_speed"                              "-40 -60 -80 -180 -280"
+      }
+      "05"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "mana_cost_scepter"                               "125"
+      }
+      "06"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "cooldown_scepter"                                "10"
+      }
+      "07"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "cast_range_scepter"                              "900"
+      }
+      "08"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "projectile_speed"                                "1200"
+      }
+      "09"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "max_charges"                                     "2"
+      }
+      "10"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "charge_restore_time"                             "30.0"
+      }
+    }
+    "AbilityCastAnimation"                                "ACT_DOTA_CAST_ABILITY_4"
+  }
+
+  // maybe this shouldn't go here?
+  // but then again where else would it
+  //=================================================================================================================
+  // Ability: Special Bonus
+  //=================================================================================================================
+  "special_bonus_unique_viper_3_oaa"
+  {
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "BaseClass"             "special_bonus_undefined"
+    "ID"                    "86819"														// unique ID number for this ability.  Do not change this once established or it will invalidate collected stats.
+    "AbilityType"           "DOTA_ABILITY_TYPE_ATTRIBUTES"
+    "AbilityBehavior"       "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "value"                     "1"
+      }
+    }
+  }
+}

--- a/game/scripts/npc/heroes/viper.txt
+++ b/game/scripts/npc/heroes/viper.txt
@@ -7,7 +7,7 @@
   {
     // Abilities
     //-------------------------------------------------------------------------------------------------------------
-    "Ability6"		"viper_viper_strike_oaa"
+    "Ability6"		"viper_viper_strike_oaa" // replaces viper_viper_strike
     "Ability15"		"special_bonus_mp_regen_4" // replaces special_bonus_unique_viper_4
     "Ability16"		"special_bonus_unique_viper_3_oaa" // replaces special_bonus_unique_viper_3
   }

--- a/game/scripts/npc/heroes/viper.txt
+++ b/game/scripts/npc/heroes/viper.txt
@@ -7,6 +7,8 @@
   {
     // Abilities
     //-------------------------------------------------------------------------------------------------------------
+    "Ability6"		"viper_viper_strike_oaa"
     "Ability15"		"special_bonus_mp_regen_4" // replaces special_bonus_unique_viper_4
+    "Ability16"		"special_bonus_unique_viper_3_oaa" // replaces special_bonus_unique_viper_3
   }
 }

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -479,7 +479,7 @@
 #base "abilities/viper_corrosive_skin.txt"
 #base "abilities/viper_nethertoxin.txt"
 #base "abilities/viper_poison_attack.txt"
-#base "abilities/viper_viper_strike.txt"
+#base "abilities/viper_viper_strike_oaa.txt"
 #base "abilities/visage_gravekeepers_cloak.txt"
 #base "abilities/visage_grave_chill.txt"
 #base "abilities/visage_soul_assumption.txt"

--- a/game/scripts/vscripts/abilities/oaa_viper_strike.lua
+++ b/game/scripts/vscripts/abilities/oaa_viper_strike.lua
@@ -1,0 +1,135 @@
+viper_viper_strike_oaa = class( AbilityBaseClass )
+
+LinkLuaModifier( "modifier_viper_viper_strike_silence", "abilities/oaa_viper_strike.lua", LUA_MODIFIER_MOTION_NONE )
+
+--------------------------------------------------------------------------------
+
+function viper_viper_strike_oaa:OnAbilityPhaseStart()
+	local caster = self:GetCaster()
+	local originCaster = caster:GetAbsOrigin()
+
+	-- show the particle
+	self.partCast = ParticleManager:CreateParticle( "particles/units/heroes/hero_viper/viper_viper_strike_warmup.vpcf", PATTACH_POINT_FOLLOW, caster )
+	for i = 1, 4 do
+		ParticleManager:SetParticleControlEnt( self.partCast, i, caster, PATTACH_POINT_FOLLOW, "attach_wing_barb_" .. i, originCaster, true )
+	end
+
+	return true
+end
+
+function viper_viper_strike_oaa:OnAbilityPhaseInterrupted()
+	if self.partCast then
+		ParticleManager:DestroyParticle( self.partCast, false )
+		ParticleManager:ReleaseParticleIndex( self.partCast )
+	end
+end
+
+--------------------------------------------------------------------------------
+
+function viper_viper_strike_oaa:OnProjectileHit_ExtraData( target, loc, data )
+	local caster = self:GetCaster()
+	local duration = self:GetSpecialValueFor( "duration" )
+
+	-- play the sound
+	target:EmitSound( "Hero_Viper.ViperStrike.Target" )
+
+	-- apply the standard viper strike modifier
+	target:AddNewModifier( caster, self, "modifier_viper_viper_strike_slow", {
+		duration = duration,
+	} )
+
+	-- apply the silence modifier if the talent is picked
+	local talent = caster:FindAbilityByName( "special_bonus_unique_viper_3_oaa" )
+
+	if talent and talent:GetLevel() > 0 then
+		target:AddNewModifier( caster, self, "modifier_viper_viper_strike_silence", {
+			duration = duration,
+		} )
+	end
+
+	-- due to the unique way the projectile part works
+	-- we manually destroy and clean it up here
+	ParticleManager:DestroyParticle( data.part, false )
+	ParticleManager:ReleaseParticleIndex( data.part )
+end
+
+--------------------------------------------------------------------------------
+
+function viper_viper_strike_oaa:OnSpellStart()
+	local caster = self:GetCaster()
+	local target = self:GetCursorTarget()
+	local originCaster = caster:GetAbsOrigin()
+
+	-- clean up cast particle
+	if self.partCast then
+		ParticleManager:ReleaseParticleIndex( self.partCast )
+	end
+
+	-- play the sounds
+	caster:EmitSound( "Hero_Viper.ViperStrike" )
+
+	local speed = self:GetSpecialValueFor( "projectile_speed" )
+
+	-- show the particle
+	-- due to the nature of viper strike's projectile, its particle is handled this way
+	local part = ParticleManager:CreateParticle( "particles/units/heroes/hero_viper/viper_viper_strike_beam.vpcf", PATTACH_CUSTOMORIGIN, target )
+	ParticleManager:SetParticleControlEnt( part, 1, target, PATTACH_POINT_FOLLOW, "attach_hitloc", target:GetAbsOrigin(), true )
+	for i = 1, 4 do
+		ParticleManager:SetParticleControlEnt( part, i + 1, caster, PATTACH_POINT, "attach_wing_barb_" .. i, originCaster, true )
+	end
+	ParticleManager:SetParticleControl( part, 6, Vector( speed, 0, 0 ) )
+
+	-- make the projectile
+	ProjectileManager:CreateTrackingProjectile( {
+		Target = target,
+		Source = caster,
+		Ability = self,
+		--EffectName = "particles/units/heroes/hero_viper/viper_viper_strike.vpcf",
+		iMoveSpeed = speed,
+		vSourceLoc = originCaster,
+		bDodgeable = true,
+		ExtraData = {
+			part = part,
+		},
+	} )
+end
+
+--------------------------------------------------------------------------------
+
+-- this could probably be the basic silence modifier
+-- but this makes it easier to decide on whether or not it should be purgable
+modifier_viper_viper_strike_silence = class( ModifierBaseClass )
+
+--------------------------------------------------------------------------------
+
+function modifier_viper_viper_strike_silence:IsHidden()
+	return false
+end
+
+function modifier_viper_viper_strike_silence:IsDebuff()
+	return true
+end
+
+function modifier_viper_viper_strike_silence:IsPurgable()
+	return false
+end
+
+--------------------------------------------------------------------------------
+
+function modifier_viper_viper_strike_silence:GetEffectName()
+	return "particles/generic_gameplay/generic_silenced.vpcf"
+end
+
+function modifier_viper_viper_strike_silence:GetEffectAttachType()
+	return PATTACH_OVERHEAD_FOLLOW
+end
+
+--------------------------------------------------------------------------------
+
+function modifier_viper_viper_strike_silence:CheckState()
+	local state = {
+		[MODIFIER_STATE_SILENCED] = true,
+	}
+
+	return state
+end


### PR DESCRIPTION
Now applies to Viper Strike instead of Nethertoxin. Currently uses the
same rules as the rest of the ability, i.e. pieces BKB, but this is
changable and this seems fair anyway given that it's moving from 8
seconds in an AoE to 5 seconds on a single target