### PR TITLE
Fixed Bloodstone tooltip

### DIFF
--- a/game/resource/English/ability/items/tooltip_bloodstone.txt
+++ b/game/resource/English/ability/items/tooltip_bloodstone.txt
@@ -3,7 +3,7 @@
 //=============================================================================
 "DOTA_Tooltip_Ability_item_bloodstone_1"                                    "Bloodstone"
 "DOTA_Tooltip_Ability_item_recipe_bloodstone_1"                             "Bloodstone Recipe"
-"DOTA_Tooltip_Ability_item_bloodstone_1_Description"                        "<h1>Active: Pocket Deny</h1>Instantly causes you to die.<br><br>Must ground target to cast.  Cannot self cast.\n<h1>Passive: Bloodpact</h1>Begins with %tooltip_charges% charges, and gains a charge each time an enemy hero dies within %charge_range% range. <br><br>If the bearer dies, the Bloodstone loses a third of its charges."
+"DOTA_Tooltip_Ability_item_bloodstone_1_Description"                        "<h1>Active: Pocket Deny</h1>Instantly causes you to die.<br><br>Must ground target to cast.  Cannot self cast.\n<h1>Passive: Bloodpact</h1>Begins with %tooltip_charges% charges, and gains a charge each time an enemy hero dies within %charge_range% range. <br><br>Each charge grants %mana_per_charge% mana regeneration per second. <br><br>If the bearer dies, the Bloodstone loses a third of its charges."
 "DOTA_Tooltip_Ability_item_bloodstone_1_Lore"                               "The Bloodstone's bright ruby color is unmistakable on the battlefield, as the owner seems to have infinite vitality and spirit."
 "DOTA_Tooltip_Ability_item_bloodstone_1_Note0"                              "Only the first Bloodstone will gain charges."
 "DOTA_Tooltip_Ability_item_bloodstone_1_bonus_health"                       "+$health"


### PR DESCRIPTION
Bloodstone should now display the mana regeneration per charge it gives.