### PR TITLE
Fixed abandon message saying that MMR will not be counted.

### DIFF
--- a/game/scripts/vscripts/components/player/connection.lua
+++ b/game/scripts/vscripts/components/player/connection.lua
@@ -54,7 +54,7 @@ function PlayerConnection:Init()
 
   GameEvents:OnPlayerAbandon(function (keys)
     DebugPrint('A player has abandoned!')
-    if self.isValid and HudTimer:GetGameTime() < MIN_MATCH_TIME and HeroSelection.isRanked then
+    if self.isValid and HudTimer:GetGameTime() < MIN_MATCH_TIME and ( HeroSelection.isRanked or HeroSelection.isCM ) then
       self.isValid = false
       Notifications:TopToAll({
         text="#abandon_game_invalid",

--- a/game/scripts/vscripts/components/player/connection.lua
+++ b/game/scripts/vscripts/components/player/connection.lua
@@ -54,7 +54,7 @@ function PlayerConnection:Init()
 
   GameEvents:OnPlayerAbandon(function (keys)
     DebugPrint('A player has abandoned!')
-    if self.isValid and HudTimer:GetGameTime() < MIN_MATCH_TIME then
+    if self.isValid and HudTimer:GetGameTime() < MIN_MATCH_TIME and HeroSelection.isRanked then
       self.isValid = false
       Notifications:TopToAll({
         text="#abandon_game_invalid",


### PR DESCRIPTION
Use `#abandon_game_invalid` instead of `#player_has_abandoned`.
`#abandon_game_invalid` = "A player has abandoned before 3 minutes, this game will not count for MMR"
`#player_has_abandoned` = "A player has abandoned"

From `Max Power#3085` on OAA Community Discord (`#report-for-devs` 2018/08/17 10:56 AM).

(not tested)