### PR TITLE
Actually (maybe) make capture points always visible to spectators

### DIFF
--- a/game/scripts/vscripts/components/boss/ai.lua
+++ b/game/scripts/vscripts/components/boss/ai.lua
@@ -155,6 +155,9 @@ function BossAI:DeathHandler (state, keys)
   local capturePointThinker = CreateModifierThinker(state.handle, nil, "modifier_boss_capture_point", nil, state.origin, DOTA_TEAM_SPECTATOR, false)
   local capturePointModifier = capturePointThinker:FindModifierByName("modifier_boss_capture_point")
   capturePointModifier:SetCallback(partial(self.RewardBossKill, self, state, keys))
+  -- Give the thinker some vision so that spectators can always see the capture point
+  capturePointThinker:SetDayTimeVisionRange(1)
+  capturePointThinker:SetNightTimeVisionRange(1)
 
   state.handle = nil
 end

--- a/game/scripts/vscripts/components/capturepoints/capturepoints.lua
+++ b/game/scripts/vscripts/components/capturepoints/capturepoints.lua
@@ -231,9 +231,16 @@ function CapturePoints:ActuallyStartCapture()
   local capturePointThinker1 = CreateModifierThinker(nil, nil, "modifier_standard_capture_point", nil, leftVector, DOTA_TEAM_SPECTATOR, false)
   local capturePointModifier1 = capturePointThinker1:FindModifierByName("modifier_standard_capture_point")
   capturePointModifier1:SetCallback(partial(self.Reward, self))
+  -- Give the thinker some vision so that spectators can always see the capture point
+  capturePointThinker1:SetDayTimeVisionRange(1)
+  capturePointThinker1:SetNightTimeVisionRange(1)
+
   local capturePointThinker2 = CreateModifierThinker(nil, nil, "modifier_standard_capture_point", nil,  rightVector, DOTA_TEAM_SPECTATOR, false)
   local capturePointModifier2 = capturePointThinker2:FindModifierByName("modifier_standard_capture_point")
   capturePointModifier2:SetCallback(partial(self.Reward, self))
+  -- Give the thinker some vision so that spectators can always see the capture point
+  capturePointThinker2:SetDayTimeVisionRange(1)
+  capturePointThinker2:SetNightTimeVisionRange(1)
 end
 
 function CapturePoints:EndCapture ()

--- a/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
+++ b/game/scripts/vscripts/modifiers/modifier_boss_capture_point.lua
@@ -10,6 +10,13 @@ function modifier_boss_capture_point:IsHidden()
   return true
 end
 
+-- Allow the capture point thinker to have vision so that spectators can always see the capture point
+function modifier_boss_capture_point:CheckState()
+  return {
+    [MODIFIER_STATE_PROVIDES_VISION] = true
+  }
+end
+
 -- Looks up the name on self and cleans up the particle and index
 function modifier_boss_capture_point:DestroyParticleByName(particleName)
   local particleIndex = self[particleName]

--- a/game/scripts/vscripts/modifiers/modifier_standard_capture_point.lua
+++ b/game/scripts/vscripts/modifiers/modifier_standard_capture_point.lua
@@ -10,6 +10,13 @@ function modifier_standard_capture_point:IsHidden()
   return true
 end
 
+-- Allow the capture point thinker to have vision so that spectators can always see the capture point
+function modifier_standard_capture_point:CheckState()
+  return {
+    [MODIFIER_STATE_PROVIDES_VISION] = true
+  }
+end
+
 -- Looks up the name on self and cleans up the particle and index
 function modifier_standard_capture_point:DestroyParticleByName(particleName)
   local particleIndex = self[particleName]


### PR DESCRIPTION
Tested this by setting the thinker unit to the Radiant team. So hopefully it'll work the same when it's on the spectator team.

P.S. I keep debating whether to unify the capture points to use one modifier. Only real problem I can see is if the random ones need to be changed to speed up more for additional heroes.