### PR TITLE
Rebalance Armlet

### DIFF
--- a/game/scripts/npc/items/item_armlet.txt
+++ b/game/scripts/npc/items/item_armlet.txt
@@ -71,7 +71,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "4 6 9 12 16"
+        "bonus_health_regen"                              "4 8 12 16 20"
       }
       "05"
       {
@@ -86,7 +86,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_bonus_strength"                           "25 45 65 90 120"
+        "unholy_bonus_strength"                           "25 55 85 110 140"
       }
       "08"
       {
@@ -96,17 +96,17 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_health_drain_per_tick"                    "6 7 10 15 20"
+        "unholy_health_drain_per_tick"                    "6 11 15 19 22"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_health_drain_per_second_tooltip"          "54 63 90 135 180"
+        "unholy_health_drain_per_second_tooltip"          "54 100 140 175 200"
       }
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "toggle_cooldown"                                 "0.036f"
+        "toggle_cooldown"                                 "0.036"
       }
     }
   }

--- a/game/scripts/npc/items/item_armlet.txt
+++ b/game/scripts/npc/items/item_armlet.txt
@@ -106,7 +106,7 @@
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "toggle_cooldown"                                 "0.036"
+        "toggle_cooldown"                                 "0.036f"
       }
     }
   }

--- a/game/scripts/npc/items/item_armlet_2.txt
+++ b/game/scripts/npc/items/item_armlet_2.txt
@@ -76,7 +76,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "4 6 9 12 16"
+        "bonus_health_regen"                              "4 8 12 16 20"
       }
       "05"
       {
@@ -91,7 +91,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_bonus_strength"                           "25 45 65 90 120"
+        "unholy_bonus_strength"                           "25 55 85 110 140"
       }
       "08"
       {
@@ -101,17 +101,17 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_health_drain_per_tick"                    "6 7 10 15 20"
+        "unholy_health_drain_per_tick"                    "6 11 15 19 22"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_health_drain_per_second_tooltip"          "54 63 90 135 180"
+        "unholy_health_drain_per_second_tooltip"          "54 100 140 175 200"
       }
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "toggle_cooldown"                                 "0.036f"
+        "toggle_cooldown"                                 "0.036"
       }
     }
   }

--- a/game/scripts/npc/items/item_armlet_2.txt
+++ b/game/scripts/npc/items/item_armlet_2.txt
@@ -111,7 +111,7 @@
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "toggle_cooldown"                                 "0.036"
+        "toggle_cooldown"                                 "0.036f"
       }
     }
   }

--- a/game/scripts/npc/items/item_armlet_3.txt
+++ b/game/scripts/npc/items/item_armlet_3.txt
@@ -77,7 +77,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "4 6 9 12 16"
+        "bonus_health_regen"                              "4 8 12 16 20"
       }
       "05"
       {
@@ -92,7 +92,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_bonus_strength"                           "25 45 65 90 120"
+        "unholy_bonus_strength"                           "25 55 85 110 140"
       }
       "08"
       {
@@ -102,17 +102,17 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_health_drain_per_tick"                    "6 7 10 15 20"
+        "unholy_health_drain_per_tick"                    "6 11 15 19 22"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_health_drain_per_second_tooltip"          "54 63 90 135 180"
+        "unholy_health_drain_per_second_tooltip"          "54 100 140 175 200"
       }
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "toggle_cooldown"                                 "0.036f"
+        "toggle_cooldown"                                 "0.036"
       }
     }
   }

--- a/game/scripts/npc/items/item_armlet_3.txt
+++ b/game/scripts/npc/items/item_armlet_3.txt
@@ -112,7 +112,7 @@
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "toggle_cooldown"                                 "0.036"
+        "toggle_cooldown"                                 "0.036f"
       }
     }
   }

--- a/game/scripts/npc/items/item_armlet_4.txt
+++ b/game/scripts/npc/items/item_armlet_4.txt
@@ -76,7 +76,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "4 6 9 12 16"
+        "bonus_health_regen"                              "4 8 12 16 20"
       }
       "05"
       {
@@ -91,7 +91,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_bonus_strength"                           "25 45 65 90 120"
+        "unholy_bonus_strength"                           "25 55 85 110 140"
       }
       "08"
       {
@@ -101,17 +101,17 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_health_drain_per_tick"                    "6 7 10 15 20"
+        "unholy_health_drain_per_tick"                    "6 11 15 19 22"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_health_drain_per_second_tooltip"          "54 63 90 135 180"
+        "unholy_health_drain_per_second_tooltip"          "54 100 140 175 200"
       }
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "toggle_cooldown"                                 "0.036f"
+        "toggle_cooldown"                                 "0.036"
       }
     }
   }

--- a/game/scripts/npc/items/item_armlet_4.txt
+++ b/game/scripts/npc/items/item_armlet_4.txt
@@ -111,7 +111,7 @@
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "toggle_cooldown"                                 "0.036"
+        "toggle_cooldown"                                 "0.036f"
       }
     }
   }

--- a/game/scripts/npc/items/item_armlet_5.txt
+++ b/game/scripts/npc/items/item_armlet_5.txt
@@ -74,7 +74,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "4 6 9 12 16"
+        "bonus_health_regen"                              "4 8 12 16 20"
       }
       "05"
       {
@@ -89,7 +89,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_bonus_strength"                           "25 45 65 90 120"
+        "unholy_bonus_strength"                           "25 55 85 110 140"
       }
       "08"
       {
@@ -99,17 +99,17 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_health_drain_per_tick"                    "6 7 10 15 20"
+        "unholy_health_drain_per_tick"                    "6 11 15 19 22"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_health_drain_per_second_tooltip"          "54 63 90 135 180"
+        "unholy_health_drain_per_second_tooltip"          "54 100 140 175 200"
       }
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "toggle_cooldown"                                 "0.036f"
+        "toggle_cooldown"                                 "0.036"
       }
     }
   }

--- a/game/scripts/npc/items/item_armlet_5.txt
+++ b/game/scripts/npc/items/item_armlet_5.txt
@@ -109,7 +109,7 @@
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "toggle_cooldown"                                 "0.036"
+        "toggle_cooldown"                                 "0.036f"
       }
     }
   }


### PR DESCRIPTION
rebalanced Armlet. Overall this is a minor buff to regen and unholy strength, as well as all benefits from the addition of strength. Most importantly, the calculated number of seconds it takes to degen all Unholy Bonus HP goes 9/10/11/12/13 instead of what it was before 9/14/14/13/13.

My calculations:
![graph](https://user-images.githubusercontent.com/13878439/44417199-e1d41f80-a542-11e8-8686-2191c190277b.png)

