### PR TITLE
Fix drums/lucience/sonic/S&Y upgrade trees

### DIFF
--- a/game/scripts/npc/items/custom/item_lucience_2.txt
+++ b/game/scripts/npc/items/custom/item_lucience_2.txt
@@ -27,6 +27,8 @@
       "02"                                                "item_lucience;item_upgrade_core_4"
       "03"                                                "item_ancient_janggo_3;item_upgrade_core_3"
       "04"                                                "item_ancient_janggo_3;item_upgrade_core_4"
+      "05"                                                "item_sonic;item_upgrade_core_3"
+      "06"                                                "item_sonic;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/custom/item_lucience_3.txt
+++ b/game/scripts/npc/items/custom/item_lucience_3.txt
@@ -25,6 +25,8 @@
     {
       "01"                                                "item_lucience_2;item_upgrade_core_4"
       "02"                                                "item_ancient_janggo_4;item_upgrade_core_4"
+      "03"                                                "item_sonic_2;item_upgrade_core_4"
+      "04"                                                "item_sange_and_yasha_4;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/custom/item_lucience_3.txt
+++ b/game/scripts/npc/items/custom/item_lucience_3.txt
@@ -50,7 +50,7 @@
     "ItemBaseLevel"                                       "3"
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "34615"
+    "ItemCost"                                            "30115"
     "ItemShopTags"                                        "damage"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "lucience 3;lucio 3"

--- a/game/scripts/npc/items/custom/item_sonic_2.txt
+++ b/game/scripts/npc/items/custom/item_sonic_2.txt
@@ -15,9 +15,12 @@
     "ItemResult"          "item_sonic_2"
     "ItemRequirements"
     {
-      "01"                "item_sonic;item_upgrade_core_3"
-      "02"                "item_sonic;item_upgrade_core_4"
-
+      "01"                                                "item_sonic;item_upgrade_core_3"
+      "02"                                                "item_sonic;item_upgrade_core_4"
+      "03"                                                "item_ancient_janggo_3;item_upgrade_core_3"
+      "04"                                                "item_ancient_janggo_3;item_upgrade_core_4"
+      "05"                                                "item_lucience;item_upgrade_core_3"
+      "06"                                                "item_lucience;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/custom/item_sonic_3.txt
+++ b/game/scripts/npc/items/custom/item_sonic_3.txt
@@ -15,8 +15,10 @@
     "ItemResult"          "item_sonic_3"
     "ItemRequirements"
     {
-      "01"                "item_sonic_2;item_upgrade_core_4"
-
+      "01"                                                "item_sonic_2;item_upgrade_core_4"
+      "02"                                                "item_ancient_janggo_4;item_upgrade_core_4"
+      "03"                                                "item_lucience_2;item_upgrade_core_4"
+      "04"                                                "item_sange_and_yasha_4;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/item_ancient_janggo_of_endurance_4.txt
+++ b/game/scripts/npc/items/item_ancient_janggo_of_endurance_4.txt
@@ -19,6 +19,8 @@
       "02"                                                "item_ancient_janggo_3;item_upgrade_core_4"
       "03"                                                "item_lucience;item_upgrade_core_3"
       "04"                                                "item_lucience;item_upgrade_core_4"
+      "05"                                                "item_sonic;item_upgrade_core_3"
+      "06"                                                "item_sonic;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/item_ancient_janggo_of_endurance_5.txt
+++ b/game/scripts/npc/items/item_ancient_janggo_of_endurance_5.txt
@@ -18,6 +18,7 @@
       "01"                                                "item_ancient_janggo_4;item_upgrade_core_4"
       "02"                                                "item_sange_and_yasha_4;item_upgrade_core_4"
       "03"                                                "item_lucience_2;item_upgrade_core_4"
+      "04"                                                "item_sonic_2;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/item_ancient_janggo_of_endurance_5.txt
+++ b/game/scripts/npc/items/item_ancient_janggo_of_endurance_5.txt
@@ -49,7 +49,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "34615"
+    "ItemCost"                                            "30115"
     "ItemShopTags"                                        "str;agi;int;damage;move_speed;attack_speed;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "drum of endurance 5;drums 5"

--- a/game/scripts/npc/items/item_sange_and_yasha_5.txt
+++ b/game/scripts/npc/items/item_sange_and_yasha_5.txt
@@ -25,6 +25,7 @@
       "01"                                                "item_sange_and_yasha_4;item_upgrade_core_4"
       "02"                                                "item_ancient_janggo_4;item_upgrade_core_4"
       "03"                                                "item_lucience_2;item_upgrade_core_4"
+      "04"                                                "item_sonic_2;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/item_sange_and_yasha_5.txt
+++ b/game/scripts/npc/items/item_sange_and_yasha_5.txt
@@ -47,7 +47,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "34615"
+    "ItemCost"                                            "30115"
     "ItemShopTags"                                        "damage;str;agi;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"


### PR DESCRIPTION
currently you can't upgrade back into the items you upgrade from in many cases, such as lucience out of S&Y or converting sonic back into anything other than sonic...