### PR TITLE
Fix tinker rearm still draining mana after finishing

### DIFF
--- a/game/scripts/vscripts/abilities/oaa_rearm.lua
+++ b/game/scripts/vscripts/abilities/oaa_rearm.lua
@@ -164,7 +164,8 @@ if IsServer() then
     local totalCooldown, total = self:GetTotalCooldowns()
 
     if total < 1 then
-      self:EndChannel(false)
+      self:EndChannel(true)
+      return
     end
 
     local manaPool = caster:GetMaxMana()
@@ -211,7 +212,7 @@ if IsServer() then
 
     -- saves 0.033s off shift queued stuff
     if total < 1 then
-      self:EndChannel(false)
+      self:EndChannel(true)
     end
   end
 end


### PR DESCRIPTION
needs testing, but the `return` statement should make it work no matter what..