### PR TITLE
Remove all explicit sending of player ID from client to server

### DIFF
--- a/content/panorama/scripts/custom_game/abilitylevels.js
+++ b/content/panorama/scripts/custom_game/abilitylevels.js
@@ -57,7 +57,6 @@ function CheckLevelUpOnSelectionChange (data) {
   if (selectedEntity !== undefined) {
     var level = Entities.GetLevel(selectedEntity);
     GameEvents.SendCustomGameEventToServer('check_level_up_selection', {
-      player: player,
       selectedEntity: selectedEntity,
       level: level
     });

--- a/content/panorama/scripts/custom_game/hero_selection.js
+++ b/content/panorama/scripts/custom_game/hero_selection.js
@@ -813,10 +813,9 @@ function SelectArcana () {
     var data = {
       Hero: selectedArcana.hero,
       Arcana: selectedArcana.setName,
-      PlayerId: Game.GetLocalPlayerID()
     };
 
-    $.Msg('Selecting Arcana ' + data.Arcana + ' for Player #' + data.PlayerId + ' for hero ' + data.Hero);
+    $.Msg('Selecting Arcana ' + data.Arcana + ' for Player #' + Game.GetLocalPlayerID() + ' for hero ' + data.Hero);
     GameEvents.SendCustomGameEventToServer('arcana_selected', data);
   }
 }
@@ -867,9 +866,8 @@ function SelectBottle () {
   }
   var data = {
     BottleId: bottleId,
-    PlayerId: Game.GetLocalPlayerID()
   };
-  $.Msg('Selecting Bottle #' + data.BottleId + ' for Player #' + data.PlayerId);
+  $.Msg('Selecting Bottle #' + data.BottleId + ' for Player #' + Game.GetLocalPlayerID());
   GameEvents.SendCustomGameEventToServer('bottle_selected', data);
 }
 
@@ -903,7 +901,6 @@ function SelectHero (hero) {
     } else {
       $.Msg('Selecting ' + newhero);
       GameEvents.SendCustomGameEventToServer('hero_selected', {
-        PlayerID: Game.GetLocalPlayerID(),
         hero: newhero
       });
     }

--- a/content/panorama/scripts/custom_game/hero_selection.js
+++ b/content/panorama/scripts/custom_game/hero_selection.js
@@ -812,7 +812,7 @@ function SelectArcana () {
 
     var data = {
       Hero: selectedArcana.hero,
-      Arcana: selectedArcana.setName,
+      Arcana: selectedArcana.setName
     };
 
     $.Msg('Selecting Arcana ' + data.Arcana + ' for Player #' + Game.GetLocalPlayerID() + ' for hero ' + data.Hero);
@@ -865,7 +865,7 @@ function SelectBottle () {
     bottleId = $('#Bottle0').GetSelectedButton().bottleId;
   }
   var data = {
-    BottleId: bottleId,
+    BottleId: bottleId
   };
   $.Msg('Selecting Bottle #' + data.BottleId + ' for Player #' + Game.GetLocalPlayerID());
   GameEvents.SendCustomGameEventToServer('bottle_selected', data);

--- a/content/panorama/scripts/custom_game/music.js
+++ b/content/panorama/scripts/custom_game/music.js
@@ -15,7 +15,6 @@ function ToggleMusic () {
     $.GetContextPanel().FindChildTraverse('ToggleMusic').RemoveClass('MusicOn');
     $.GetContextPanel().FindChildTraverse('ToggleMusic').AddClass('MusicOff');
     GameEvents.SendCustomGameEventToServer('music_mute', {
-      playerID: Players.GetLocalPlayer(),
       mute: 1
     });
   } else {
@@ -24,7 +23,6 @@ function ToggleMusic () {
     $.GetContextPanel().FindChildTraverse('ToggleMusic').RemoveClass('MusicOff');
     $.GetContextPanel().FindChildTraverse('ToggleMusic').AddClass('MusicOn');
     GameEvents.SendCustomGameEventToServer('music_mute', {
-      playerID: Players.GetLocalPlayer(),
       mute: 0
     });
   }

--- a/content/panorama/scripts/custom_game/surrender.js
+++ b/content/panorama/scripts/custom_game/surrender.js
@@ -1,4 +1,4 @@
-/* global Game, GameEvents, $ */
+/* global GameEvents, $ */
 
 'use strict';
 

--- a/content/panorama/scripts/custom_game/surrender.js
+++ b/content/panorama/scripts/custom_game/surrender.js
@@ -60,5 +60,5 @@ function SendResult (result) {
 }
 
 function StartSurrenderVote () { // eslint-disable-line no-unused-vars
-  GameEvents.SendCustomGameEventToServer('surrender_start_vote', { playerid: Game.GetLocalPlayerID() });
+  GameEvents.SendCustomGameEventToServer('surrender_start_vote', {});
 }

--- a/content/panorama/scripts/game_length_options.js
+++ b/content/panorama/scripts/game_length_options.js
@@ -24,7 +24,6 @@ function SetPlayerVote (vote) {
 
   console.log(Players.GetLocalPlayer() + ' votes for ' + vote);
   GameEvents.SendCustomGameEventToServer('gamelength_vote', {
-    playerId: Players.GetLocalPlayer(),
     vote: vote
   });
 }

--- a/content/panorama/scripts/playertables/playertables_base.js
+++ b/content/panorama/scripts/playertables/playertables_base.js
@@ -118,7 +118,7 @@ function SendPID () {
     return;
   }
 
-  GameEvents.SendCustomGameEventToServer('PlayerTables_Connected', {pid: pid});
+  GameEvents.SendCustomGameEventToServer('PlayerTables_Connected', {});
 }
 
 function TableFullUpdate (msg) {

--- a/game/scripts/vscripts/components/abilities/level.lua
+++ b/game/scripts/vscripts/components/abilities/level.lua
@@ -11,7 +11,7 @@ function AbilityLevels:Init ()
   GameEvents:OnPlayerLearnedAbility(partial(self.CheckAbilityLevels, self))
   CustomGameEventManager:RegisterListener("check_level_up_selection", function(_, keys)
     -- Change the player ID to an entity index
-    keys.player = PlayerResource:GetPlayer(keys.player):entindex()
+    keys.player = PlayerResource:GetPlayer(keys.PlayerID):entindex()
     self:CheckAbilityLevels(keys)
   end)
 end

--- a/game/scripts/vscripts/components/heroselection/heroselection.lua
+++ b/game/scripts/vscripts/components/heroselection/heroselection.lua
@@ -213,14 +213,14 @@ end
 
 function HeroSelection:OnBottleSelected (selectedBottle)
   if HeroSelection.SelectedBottle == nil then HeroSelection.SelectedBottle = {} end
-  HeroSelection.SelectedBottle[selectedBottle.PlayerId] = selectedBottle.BottleId
+  HeroSelection.SelectedBottle[selectedBottle.PlayerID] = selectedBottle.BottleId
   CustomNetTables:SetTableValue( 'bottlepass', 'selected_bottles', HeroSelection.SelectedBottle )
 end
 
 function HeroSelection:OnArcanaSelected (selectedArcana)
   if HeroSelection.SelectedArcana == nil then HeroSelection.SelectedArcana = {} end
-  if HeroSelection.SelectedArcana[selectedArcana.PlayerId] == nil then HeroSelection.SelectedArcana[selectedArcana.PlayerId] = {} end
-  HeroSelection.SelectedArcana[selectedArcana.PlayerId][selectedArcana.Hero] = selectedArcana.Arcana
+  if HeroSelection.SelectedArcana[selectedArcana.PlayerID] == nil then HeroSelection.SelectedArcana[selectedArcana.PlayerID] = {} end
+  HeroSelection.SelectedArcana[selectedArcana.PlayerID][selectedArcana.Hero] = selectedArcana.Arcana
   CustomNetTables:SetTableValue( 'bottlepass', 'selected_arcanas', HeroSelection.SelectedArcana )
 end
 

--- a/game/scripts/vscripts/components/music/music.lua
+++ b/game/scripts/vscripts/components/music/music.lua
@@ -92,7 +92,7 @@ end
 
 -- Receives mute requests
 function Music:MuteHandler(keys)
-  local playerID = keys.playerID
+  local playerID = keys.PlayerID
   DebugPrintTable(keys)
   --sets his state
   local muteTable = CustomNetTables:GetTableValue('music', 'mute')

--- a/game/scripts/vscripts/components/surrender/surrender.lua
+++ b/game/scripts/vscripts/components/surrender/surrender.lua
@@ -39,12 +39,12 @@ end
 
 
 function SurrenderManager:CheckSurrenderConditions(keys)
-  local teamId = PlayerResource:GetTeam(keys.playerid)
+  local teamId = PlayerResource:GetTeam(keys.PlayerID)
   local now = HudTimer:GetGameTime()
   if SurrenderManager:ScoreAllowsSurrender(teamId) and
-      SurrenderManager:TimeAllowsSurrender(keys.playerid, now) then
+      SurrenderManager:TimeAllowsSurrender(keys.PlayerID, now) then
     lastTimeSurrenderWasCalled = GameRules:GetGameTime()
-    lastTimeSurrenderWasCalledByPlayer[keys.playerid] = now
+    lastTimeSurrenderWasCalledByPlayer[keys.PlayerID] = now
     teamIdToSurrender = teamId
     local timeout = SURRENDER_TIME_TO_DISPLAY
     local text = "#surrender_suggestion"

--- a/game/scripts/vscripts/libraries/playertables.lua
+++ b/game/scripts/vscripts/libraries/playertables.lua
@@ -53,7 +53,7 @@ PLAYERTABLES_VERSION = "0.90"
     -void PlayerTables.GetTableValue(tableName, keyName)
       Returns the current value for the key given by "keyName" if it exists on the table given by "tableName".
       Returns null if no table exists, or undefined if the key does not exist.
-    -int PlayerTables.SubscribeNetTableListener(tableName, callback) 
+    -int PlayerTables.SubscribeNetTableListener(tableName, callback)
       Sets up a callback for when this playertable is changed.  The callback is of the form:
         function(tableName, changesObject, deletionsObject).
           changesObject contains the key-value pairs that were changed
@@ -142,7 +142,7 @@ function PlayerTables:PlayerTables_Connected(args)
   --print('PlayerTables_Connected')
   --PrintTable(args)
 
-  local pid = args.pid
+  local pid = args.PlayerID
   if not pid then
     return
   end
@@ -153,7 +153,7 @@ function PlayerTables:PlayerTables_Connected(args)
 
   for k,v in pairs(PlayerTables.subscriptions) do
     if v[pid] then
-      if player then  
+      if player then
         CustomGameEventManager:Send_ServerToPlayer(player, "pt_fu", {name=k, table=PlayerTables.tables[k]} )
       end
     end
@@ -186,7 +186,7 @@ function PlayerTables:CreateTable(tableName, tableContents, pids)
     if pid >= 0 and pid < DOTA_MAX_TEAM_PLAYERS then
       self.subscriptions[tableName][pid] = true
       local player = PlayerResource:GetPlayer(pid)
-      if player then  
+      if player then
         CustomGameEventManager:Send_ServerToPlayer(player, "pt_fu", {name=tableName, table=tableContents} )
       end
     else
@@ -206,13 +206,13 @@ function PlayerTables:DeleteTable(tableName)
 
   for k,v in pairs(pids) do
     local player = PlayerResource:GetPlayer(k)
-    if player then  
+    if player then
       CustomGameEventManager:Send_ServerToPlayer(player, "pt_fu", {name=tableName, table=nil} )
     end
   end
 
   self.tables[tableName] = nil
-  self.subscriptions[tableName] = nil  
+  self.subscriptions[tableName] = nil
 end
 
 function PlayerTables:TableExists(tableName)
@@ -237,7 +237,7 @@ function PlayerTables:SetPlayerSubscriptions(tableName, pids)
     if pid >= 0 and pid < DOTA_MAX_TEAM_PLAYERS then
       self.subscriptions[tableName][pid] = true
       local player = PlayerResource:GetPlayer(pid)
-      if player and oldPids[pid] == nil then  
+      if player and oldPids[pid] == nil then
         CustomGameEventManager:Send_ServerToPlayer(player, "pt_fu", {name=tableName, table=table} )
       end
     else
@@ -259,7 +259,7 @@ function PlayerTables:AddPlayerSubscription(tableName, pid)
     if pid >= 0 and pid < DOTA_MAX_TEAM_PLAYERS then
       self.subscriptions[tableName][pid] = true
       local player = PlayerResource:GetPlayer(pid)
-      if player then  
+      if player then
         CustomGameEventManager:Send_ServerToPlayer(player, "pt_fu", {name=tableName, table=table} )
       end
     else
@@ -318,7 +318,7 @@ function PlayerTables:DeleteTableKey(tableName, key)
     table[key] = nil
     for pid,v in pairs(pids) do
       local player = PlayerResource:GetPlayer(pid)
-      if player then  
+      if player then
         CustomGameEventManager:Send_ServerToPlayer(player, "pt_kd", {name=tableName, keys={[key]=true}} )
       end
     end
@@ -356,7 +356,7 @@ function PlayerTables:DeleteTableKeys(tableName, keys)
   if notempty then
     for pid,v in pairs(pids) do
       local player = PlayerResource:GetPlayer(pid)
-      if player then  
+      if player then
         CustomGameEventManager:Send_ServerToPlayer(player, "pt_kd", {name=tableName, keys=deletions} )
       end
     end
@@ -366,7 +366,7 @@ end
 function PlayerTables:SetTableValue(tableName, key, value)
   if value == nil then
     self:DeleteTableKey(tableName, key)
-    return 
+    return
   end
   if not self.tables[tableName] then
     print("[playertables.lua] Warning: Table '" .. tableName .. "' does not exist.")
@@ -380,7 +380,7 @@ function PlayerTables:SetTableValue(tableName, key, value)
     table[key] = value
     for pid,v in pairs(pids) do
       local player = PlayerResource:GetPlayer(pid)
-      if player then  
+      if player then
         CustomGameEventManager:Send_ServerToPlayer(player, "pt_uk", {name=tableName, changes={[key]=value}} )
       end
     end
@@ -409,7 +409,7 @@ function PlayerTables:SetTableValues(tableName, changes)
   if notempty then
     for pid,v in pairs(pids) do
       local player = PlayerResource:GetPlayer(pid)
-      if player then  
+      if player then
         CustomGameEventManager:Send_ServerToPlayer(player, "pt_uk", {name=tableName, changes=changes} )
       end
     end


### PR DESCRIPTION
All client to server events automatically have a `PlayerID` key that should be used instead as it should, in theory, not be manipulable by the client.

<sup>inb4 I somehow messed this up and break everything</sup>