### PR TITLE
Phantom Assassin Nerf

### DIFF
--- a/game/scripts/npc/abilities/phantom_assassin_coup_de_grace.txt
+++ b/game/scripts/npc/abilities/phantom_assassin_coup_de_grace.txt
@@ -25,7 +25,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "crit_bonus"                                      "200 325 450 600 750"
+        "crit_bonus"                                      "200 300 400 500 600" //OAA
       }
     }
   }


### PR DESCRIPTION
Nerfed the critical damage from Coup de Grace.
(silver edge needs a buff, invisibility is overrated)