### PR TITLE
Implement core fission, allowing downgrading into two lower level cores.

### DIFF
--- a/game/resource/English/ability/items/tooltip_cores.txt
+++ b/game/resource/English/ability/items/tooltip_cores.txt
@@ -13,22 +13,22 @@
 "DOTA_Tooltip_Ability_item_farming_core_Note1"                                      "Maximum Sparks per player: 1"
 
 "DOTA_Tooltip_Ability_item_upgrade_core"                                            "Upgrade Core 1"
-"DOTA_Tooltip_Ability_item_upgrade_core_Description"                                "<font color='#FFA500'>This item cannot be purchased or sold!</font><br>This item is used for upgrading items, up to Level 2. You can use any higher level core as an Upgrade Core 1. Tier 1 Bosses and tier 1 capture points give you an Upgrade Core 1."
+"DOTA_Tooltip_Ability_item_upgrade_core_Description"                                "<font color='#FFA500'>This item cannot be purchased!</font><br>This item is used for upgrading items, up to Level 2. You can use any higher level core as an Upgrade Core 1. Tier 1 Bosses and tier 1 capture points give you an Upgrade Core 1."
 "DOTA_Tooltip_Ability_item_upgrade_core_Note0"                                      "The level of a core depends upon the strength of the boss."
 "DOTA_Tooltip_Ability_item_upgrade_core_Note1"                                      "Managing your cores and upgrading your items is essential to victory."
 
 "DOTA_Tooltip_Ability_item_upgrade_core_2"                                          "Upgrade Core 2"
-"DOTA_Tooltip_Ability_item_upgrade_core_2_Description"                              "<font color='#FFA500'>This item cannot be purchased or sold!</font><br>This item is used for upgrading items, up to Level 3. You can use any higher level core as an Upgrade Core 2. Tier 2 Bosses and tier 2 capture points give you an Upgrade Core 2."
+"DOTA_Tooltip_Ability_item_upgrade_core_2_Description"                              "<font color='#FFA500'>This item cannot be purchased!</font>\n<h1>Use: Fission</h1> CHANNELED - After channeling for %channel_time% seconds, split this into %core_count% Level 1 Upgrade Cores. <font color='#FFA500'>This cannot be undone.</font>\nThis item is used for upgrading items, up to Level 3. You can use any higher level core as an Upgrade Core 2. Tier 2 Bosses and tier 2 capture points give you an Upgrade Core 2."
 "DOTA_Tooltip_Ability_item_upgrade_core_2_Note0"                                    "The level of a core depends upon the strength of the boss."
 "DOTA_Tooltip_Ability_item_upgrade_core_2_Note1"                                    "Managing your cores and upgrading your items is essential to victory."
 
 "DOTA_Tooltip_Ability_item_upgrade_core_3"                                          "Upgrade Core 3"
-"DOTA_Tooltip_Ability_item_upgrade_core_3_Description"                              "<font color='#FFA500'>This item cannot be purchased or sold!</font><br>This item is used for upgrading items, up to Level 4. You can use any higher level core as an Upgrade Core 3. Tier 3 Bosses and tier 3 capture points give you an Upgrade Core 3."
+"DOTA_Tooltip_Ability_item_upgrade_core_3_Description"                              "<font color='#FFA500'>This item cannot be purchased!</font>\n<h1>Use: Fission</h1> CHANNELED - After channeling for %channel_time% seconds, split this into %core_count% Level 2 Upgrade Cores. <font color='#FFA500'>This cannot be undone.</font>\nThis item is used for upgrading items, up to Level 4. You can use any higher level core as an Upgrade Core 3. Tier 3 Bosses and tier 3 capture points give you an Upgrade Core 3."
 "DOTA_Tooltip_Ability_item_upgrade_core_3_Note0"                                    "The level of a core depends upon the strength of the boss."
 "DOTA_Tooltip_Ability_item_upgrade_core_3_Note1"                                    "Managing your cores and upgrading your items is essential to victory."
 
 "DOTA_Tooltip_Ability_item_upgrade_core_4"                                          "Upgrade Core 4"
-"DOTA_Tooltip_Ability_item_upgrade_core_4_Description"                              "<font color='#FFA500'>This item cannot be purchased or sold!</font><br>This item is used for upgrading items, up to Level 5. Tier 4/5 Bosses and tier 4/5 capture points give you an Upgrade Core 4."
+"DOTA_Tooltip_Ability_item_upgrade_core_4_Description"                              "<font color='#FFA500'>This item cannot be purchased!</font>\n<h1>Use: Fission</h1> CHANNELED - After channeling for %channel_time% seconds, split this into %core_count% Level 3 Upgrade Cores. <font color='#FFA500'>This cannot be undone.</font>\nThis item is used for upgrading items, up to Level 5. Tier 4/5 Bosses and tier 4/5 capture points give you an Upgrade Core 4."
 "DOTA_Tooltip_Ability_item_upgrade_core_4_Note0"                                    "The level of a core depends upon the strength of the boss."
 "DOTA_Tooltip_Ability_item_upgrade_core_4_Note1"                                    "Managing your cores and upgrading your items is essential to victory."
 

--- a/game/scripts/npc/items/custom/item_upgrade_core_2.txt
+++ b/game/scripts/npc/items/custom/item_upgrade_core_2.txt
@@ -8,8 +8,9 @@
     // General
     //-------------------------------------------------------------------------------------------------------------
     "ID"                                                  "3531"      // unique ID
-    "BaseClass"                                           "item_datadriven"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+    "BaseClass"                                           "item_lua"
+    "ScriptFile"                                          "items/upgrade_core.lua"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_CHANNELLED"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
@@ -28,6 +29,19 @@
 
     // Special
     //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "channel_time"                                    "3.0"
+      }
+      "02"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "core_count"                                      "2"
+      }
+	}
     "precache"
     {
       "particle"                  "particles/items/upgrade_2.vpcf"

--- a/game/scripts/npc/items/custom/item_upgrade_core_3.txt
+++ b/game/scripts/npc/items/custom/item_upgrade_core_3.txt
@@ -8,8 +8,9 @@
     // General
     //-------------------------------------------------------------------------------------------------------------
     "ID"                                                  "3532"      // unique ID
-    "BaseClass"                                           "item_datadriven"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+    "BaseClass"                                           "item_lua"
+    "ScriptFile"                                          "items/upgrade_core.lua"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_CHANNELLED"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
@@ -28,6 +29,19 @@
 
     // Special
     //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "channel_time"                                    "3.0"
+      }
+      "02"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "core_count"                                      "2"
+      }
+	}
     "precache"
     {
       "particle"                  "particles/items/upgrade_3.vpcf"

--- a/game/scripts/npc/items/custom/item_upgrade_core_4.txt
+++ b/game/scripts/npc/items/custom/item_upgrade_core_4.txt
@@ -8,8 +8,9 @@
     // General
     //-------------------------------------------------------------------------------------------------------------
     "ID"                                                  "3533"      // unique ID
-    "BaseClass"                                           "item_datadriven"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+    "BaseClass"                                           "item_lua"
+    "ScriptFile"                                          "items/upgrade_core.lua"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_CHANNELLED"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
@@ -28,6 +29,19 @@
 
     // Special
     //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "channel_time"                                    "3.0"
+      }
+      "02"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "core_count"                                      "2"
+      }
+	}
     "precache"
     {
       "particle"                  "particles/items/upgrade_4.vpcf"

--- a/game/scripts/vscripts/components/filters/sellblacklist.lua
+++ b/game/scripts/vscripts/components/filters/sellblacklist.lua
@@ -5,7 +5,7 @@ if SellBlackList == nil then
 end
 
 local ItemSellBlackList = {
-  "item_upgrade_core",
+  --"item_upgrade_core",
   "item_infinite_bottle",
   "item_farming_core"
 }

--- a/game/scripts/vscripts/items/upgrade_core.lua
+++ b/game/scripts/vscripts/items/upgrade_core.lua
@@ -1,0 +1,65 @@
+item_upgrade_core = class( ItemBaseClass )
+
+--------------------------------------------------------------------------------
+
+function item_upgrade_core:GetChannelTime()
+	return self:GetSpecialValueFor( "channel_time" )
+end
+
+--------------------------------------------------------------------------------
+
+function item_upgrade_core:GetSplitCoreType()
+	return nil
+end
+
+--------------------------------------------------------------------------------
+
+function item_upgrade_core:OnSpellStart()
+end
+
+--------------------------------------------------------------------------------
+
+function item_upgrade_core:OnChannelFinish( interrupted )
+	local caster = self:GetCaster()
+	local coreType = self:GetSplitCoreType()
+
+	-- if we didn't get interrupted, destroy the core and give two new ones
+	-- we also want to make sure we're actually getting a core out of this
+	-- in case we somehow started channeling upgrade core 1
+
+	-- this'll be where i learn if ability scripts cancel immediately after their
+	-- ability is destroyed, or will still complete
+	if coreType and not interrupted then
+		local coreCount = self:GetSpecialValueFor( "core_count" )
+
+		caster:RemoveItem( self )
+
+		for i = 1, coreCount do
+			caster:AddItemByName( coreType )
+		end
+	end
+end
+
+--------------------------------------------------------------------------------
+
+item_upgrade_core_2 = class( item_upgrade_core )
+
+function item_upgrade_core_2:GetSplitCoreType()
+	return "item_upgrade_core"
+end
+
+--------------------------------------------------------------------------------
+
+item_upgrade_core_3 = class( item_upgrade_core )
+
+function item_upgrade_core_3:GetSplitCoreType()
+	return "item_upgrade_core_2"
+end
+
+--------------------------------------------------------------------------------
+
+item_upgrade_core_4 = class( item_upgrade_core )
+
+function item_upgrade_core_4:GetSplitCoreType()
+	return "item_upgrade_core_3"
+end

--- a/game/scripts/vscripts/items/upgrade_core.lua
+++ b/game/scripts/vscripts/items/upgrade_core.lua
@@ -31,11 +31,20 @@ function item_upgrade_core:OnChannelFinish( interrupted )
 	-- ability is destroyed, or will still complete
 	if coreType and not interrupted then
 		local coreCount = self:GetSpecialValueFor( "core_count" )
+		-- if we don't make the purchase time persist, then players could split a "stale" core
+		-- into two "fresh" cores that'll sell for more
+		-- that's silly so we're not doing that
+		-- ( could also just set the resulting core's purchase time forwad ten seconds, but
+		-- this is slicker )
+		local purchaseTime = self:GetPurchaseTime()
+		local player = self:GetPurchaser():GetPlayerOwner()
 
 		caster:RemoveItem( self )
 
 		for i = 1, coreCount do
-			caster:AddItemByName( coreType )
+			local item = CreateItem( coreType, player, player )
+			item:SetPurchaseTime( purchaseTime )
+			caster:AddItem( item )
 		end
 	end
 end


### PR DESCRIPTION
Gives the ability to split level 2 or higher cores into two cores of the lower level. Has a 3 second channel time to help prevent accidental splitting.

Doesn't have any sort of feedback, visual or audio, yet, but it probably doesn't need more than, at most, a sound effect or two, all things considered.

Also lets cores be sold, since that's pretty related anyway. For those of you peeking for an exploit, you actually lose money if you split a core, since each level of core costs more than twice as much as the previous one.