### PR TITLE
Dagger of Moriah should not amplify self damage

### DIFF
--- a/game/scripts/vscripts/items/transformation/dagger_of_moriah.lua
+++ b/game/scripts/vscripts/items/transformation/dagger_of_moriah.lua
@@ -114,7 +114,7 @@ function modifier_item_dagger_of_moriah_sangromancy:OnTakeDamage(event)
       attacker = event.attacker,
       damage = event.original_damage * (self.selfDamage / 100),
       damage_type = event.damage_type,
-      damage_flags = bit.bor(event.damage_flags, DOTA_DAMAGE_FLAG_REFLECTION),
+      damage_flags = bit.bor(event.damage_flags, DOTA_DAMAGE_FLAG_REFLECTION, DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION),
       ability = self:GetAbility(),
     }
 


### PR DESCRIPTION
My brain hurt while reading the code for this.

`bit.band(event.damage_flags, DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION) == 0` should be the same as `not bit.band(event.damage_flags, DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION) = DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION` , am I right?
