### PR TITLE
Make Dagger of Moriah self-damage unaffected by spell amp.

### DIFF
--- a/game/scripts/vscripts/items/transformation/dagger_of_moriah.lua
+++ b/game/scripts/vscripts/items/transformation/dagger_of_moriah.lua
@@ -114,7 +114,7 @@ function modifier_item_dagger_of_moriah_sangromancy:OnTakeDamage(event)
       attacker = event.attacker,
       damage = event.original_damage * (self.selfDamage / 100),
       damage_type = event.damage_type,
-      damage_flags = bit.bor(event.damage_flags, DOTA_DAMAGE_FLAG_REFLECTION),
+      damage_flags = bit.bor(event.damage_flags, DOTA_DAMAGE_FLAG_REFLECTION, DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION),
       ability = self:GetAbility(),
     }
 


### PR DESCRIPTION
Spell amp is already applied to the event's original_damage, meaning the damage you took was actually amplified *twice*.

Not sure if this needs to be followed up by a balance change or not. If it does, then increasing the self-damage to be higher than 100% should provide a similar effect without being quite so unintuitive.