### PR TITLE
PA Crit Rebalance

### DIFF
--- a/game/scripts/npc/abilities/phantom_assassin_coup_de_grace.txt
+++ b/game/scripts/npc/abilities/phantom_assassin_coup_de_grace.txt
@@ -19,7 +19,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "crit_chance"                                     "20"
+        "crit_chance"                                     "20" //OAA
         "LinkedSpecialBonus"    "special_bonus_unique_phantom_assassin_2"
       }
       "02"

--- a/game/scripts/npc/abilities/phantom_assassin_coup_de_grace.txt
+++ b/game/scripts/npc/abilities/phantom_assassin_coup_de_grace.txt
@@ -19,13 +19,13 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "crit_chance"                                     "15"
+        "crit_chance"                                     "20"
         "LinkedSpecialBonus"    "special_bonus_unique_phantom_assassin_2"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "crit_bonus"                                      "200 300 400 500 600" //OAA
+        "crit_bonus"                                      "175 250 325 400 475" //OAA
       }
     }
   }

--- a/game/scripts/npc/abilities/phantom_assassin_coup_de_grace.txt
+++ b/game/scripts/npc/abilities/phantom_assassin_coup_de_grace.txt
@@ -25,7 +25,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "crit_bonus"                                      "175 250 325 400 475" //OAA
+        "crit_bonus"                                      "180 260 340 420 500" //OAA
       }
     }
   }


### PR DESCRIPTION
after playing PA alot and calculating her average damage increase from Coup de Grace I have concluded while her average damage increase is fine the amount of damage a single crit can do is too high. When the amount of damage a single crit can do gets too high she becomes exceptionally bursty. Easily being able to dispose of heroes if she double crits. 

(When the critical damage is more then 500% the passive just gets extremly dumb. 500% Critical damage at level 50 should be fine)

I have rescaled the critical strike to deal roughly the same average damage as before. (Worse average damage then PA's crit in Dota at level 18). The cirtical strike damage is lower but the chance is higher. 

The 5% Coup De Grace talent is slighlty worse on this version. 