### PR TITLE
Increase maximum number of owned items

### DIFF
--- a/game/scripts/vscripts/gamemode.lua
+++ b/game/scripts/vscripts/gamemode.lua
@@ -239,6 +239,9 @@ function GameMode:InitGameMode()
   InitModule(ChatCommand)
   InitModule(DevCheats)
 
+  -- Increase maximum owned item limit
+  Convars:SetInt('dota_max_physical_items_purchase_limit', 64)
+
   -- Commands can be registered for debugging purposes or as functions that can be called by the custom Scaleform UI
   -- Convars:RegisterCommand( "command_example", Dynamic_Wrap(GameMode, 'ExampleConsoleCommand'), "A console command example", FCVAR_CHEAT )
 


### PR DESCRIPTION
Turns out there's a convar for this... Tested changing it via console on a local server and it seems to work. Makes me wonder why they didn't bother to have a proper error message for it when there's a configurable variable for it and not just some hardcoded thing.