### PR TITLE
Tier 5 Twins nerf

### DIFF
--- a/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_dumb_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_dumb_tier5.txt
@@ -34,8 +34,8 @@
     "AttackDamageType"                                    "DAMAGE_TYPE_ArmorPhysical"
     "AttackRate"                                          "0.75"      // Speed of attack.
     "AttackAnimationPoint"                                "0.3"    // Normalized time in animation cycle to attack.
-    "AttackAcquisitionRange"                              "350"    // Range within a target can be acquired.
-    "AttackRange"                                         "528"    // Range within a target can be attacked.
+    "AttackAcquisitionRange"                              "150"    // Range within a target can be acquired.
+    "AttackRange"                                         "960"    // Range within a target can be attacked.
     "ProjectileModel"                                     "particles/items2_fx/necronomicon_archer_projectile.vpcf"
     "ProjectileSpeed"                                     "1000"
 

--- a/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_dumb_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_dumb_tier5.txt
@@ -32,7 +32,7 @@
     "AttackDamageMin"                                     "6500"    // Damage range min.
     "AttackDamageMax"                                     "6550"    // Damage range max.
     "AttackDamageType"                                    "DAMAGE_TYPE_ArmorPhysical"
-    "AttackRate"                                          "0.35"      // Speed of attack.
+    "AttackRate"                                          "0.75"      // Speed of attack.
     "AttackAnimationPoint"                                "0.3"    // Normalized time in animation cycle to attack.
     "AttackAcquisitionRange"                              "350"    // Range within a target can be acquired.
     "AttackRange"                                         "528"    // Range within a target can be attacked.

--- a/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_tier5.txt
@@ -34,7 +34,7 @@
     "AttackDamageMin"                                     "6000"    // Damage range min.
     "AttackDamageMax"                                     "6500"    // Damage range max.
     "AttackDamageType"                                    "DAMAGE_TYPE_ArmorPhysical"
-    "AttackRate"                                          "0.35"      // Speed of attack.
+    "AttackRate"                                          "0.75"      // Speed of attack.
     "AttackAnimationPoint"                                "0.3"    // Normalized time in animation cycle to attack.
     "AttackAcquisitionRange"                              "350"    // Range within a target can be acquired.
     "AttackRange"                                         "528"    // Range within a target can be attacked.

--- a/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_tier5.txt
@@ -36,8 +36,8 @@
     "AttackDamageType"                                    "DAMAGE_TYPE_ArmorPhysical"
     "AttackRate"                                          "0.75"      // Speed of attack.
     "AttackAnimationPoint"                                "0.3"    // Normalized time in animation cycle to attack.
-    "AttackAcquisitionRange"                              "350"    // Range within a target can be acquired.
-    "AttackRange"                                         "528"    // Range within a target can be attacked.
+    "AttackAcquisitionRange"                              "150"    // Range within a target can be acquired.
+    "AttackRange"                                         "128"    // Range within a target can be attacked.
 
     // Bounty
     //----------------------------------------------------------------


### PR DESCRIPTION
This is a very long overdue nerf to Tier 5 twins. I set the base attack time and attack range to the same as tier 2 twins. Their damage output makes it impossible for most team compostions to kill them. Addtionally their weird attack range at level 5 makes it impossible to separate them. 