### PR TITLE
Spectre Shadow Step Fix and Buffs

### DIFF
--- a/game/scripts/npc/abilities/spectre_desolate.txt
+++ b/game/scripts/npc/abilities/spectre_desolate.txt
@@ -29,7 +29,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "radius"                                          "500"
+        "radius"                                          "375" //OAA
       }
       "03"
       {

--- a/game/scripts/npc/abilities/spectre_haunt_single.txt
+++ b/game/scripts/npc/abilities/spectre_haunt_single.txt
@@ -38,17 +38,17 @@
 			"01"
 			{
 				"var_type"					"FIELD_FLOAT"
-				"duration"					"4.0 5.0 6.0 7.0 8.0" //OAA
+				"duration"					"5.0 6.0 7.0 7.5 8.0"
 			}
 			"02"
 			{
 				"var_type"					"FIELD_INTEGER"
-				"illusion_damage_outgoing"	"-60 -40 -20 -10 0"
+				"illusion_damage_outgoing"	"-60 -40 -20 -0 20"
 			}
 			"03"
 			{
 				"var_type"					"FIELD_INTEGER"
-				"tooltip_outgoing"	"40 60 80 90 100"
+				"tooltip_outgoing"	        "40 60 80 100 120"
 				"LinkedSpecialBonus"		"special_bonus_unique_spectre_4"
 			}
 			"04"


### PR DESCRIPTION
Renamed Shadow Step KV file to Haunt_single because the abilitiy wasn't getting overidden. (Only had 3 levels). I also set it to the same duration as haunt in OAA.

Reverted desolate search radius from 500 to 375 (this is what it was before the dota nerf) because in general people are much closer together in OAA then Dota because of most fights happening at duels or bosses, where people will be clumped together. 