### PR TITLE
Manta buffs and Heart Transplant Nerf

### DIFF
--- a/game/scripts/npc/items/custom/item_heart_transplant.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant.txt
@@ -99,13 +99,13 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "135 170"
+        "bonus_strength"                                  "90 120"
       }
       // Heart Parameters
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "1000 1400"
+        "bonus_health"                                    "1900 2400"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_heart_transplant.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant.txt
@@ -89,7 +89,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "transplant_cooldown"                             "7"
+        "transplant_cooldown"                             "20"
       }
       "03"
       {
@@ -99,13 +99,13 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "90 120"
+        "bonus_strength"                                  "40 50"
       }
       // Heart Parameters
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "1900 2400"
+        "bonus_health"                                    "1000 1400"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_heart_transplant_2.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant_2.txt
@@ -79,7 +79,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "transplant_cooldown"                             "7"
+        "transplant_cooldown"                             "20"
       }
       "03"
       {
@@ -89,13 +89,13 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "90 120"
+        "bonus_strength"                                  "40 50"
       }
       // Heart Parameters
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "1900 2400"
+        "bonus_health"                                    "1000 1400"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_heart_transplant_2.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant_2.txt
@@ -89,13 +89,13 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "135 170"
+        "bonus_strength"                                  "90 120"
       }
       // Heart Parameters
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "1000 1400"
+        "bonus_health"                                    "1900 2400"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_manta.txt
+++ b/game/scripts/npc/items/item_manta.txt
@@ -43,22 +43,22 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "10 14 19 25 32"
+        "bonus_strength"                                  "10 15 20 30 40"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "26 31 38 47 58"
+        "bonus_agility"                                   "26 32 44 62 86"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 14 19 25 32"
+        "bonus_intellect"                                 "10 15 20 30 40"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "12 15 20 25 30"
+        "bonus_attack_speed"                              "12 15 18 21 24"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_manta_2.txt
+++ b/game/scripts/npc/items/item_manta_2.txt
@@ -61,22 +61,22 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "10 14 19 25 32"
+        "bonus_strength"                                  "10 15 20 30 40"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "26 31 38 47 58"
+        "bonus_agility"                                   "26 32 44 62 86"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 14 19 25 32"
+        "bonus_intellect"                                 "10 15 20 30 40"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "12 15 20 25 30"
+        "bonus_attack_speed"                              "12 15 18 21 24"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_manta_3.txt
+++ b/game/scripts/npc/items/item_manta_3.txt
@@ -60,22 +60,22 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "10 14 19 25 32"
+        "bonus_strength"                                  "10 15 20 30 40"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "26 31 38 47 58"
+        "bonus_agility"                                   "26 32 44 62 86"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 14 19 25 32"
+        "bonus_intellect"                                 "10 15 20 30 40"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "12 15 20 25 30"
+        "bonus_attack_speed"                              "12 15 18 21 24"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_manta_4.txt
+++ b/game/scripts/npc/items/item_manta_4.txt
@@ -59,22 +59,22 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "10 14 19 25 32"
+        "bonus_strength"                                  "10 15 20 30 40"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "26 31 38 47 58"
+        "bonus_agility"                                   "26 32 44 62 86"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 14 19 25 32"
+        "bonus_intellect"                                 "10 15 20 30 40"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "12 15 20 25 30"
+        "bonus_attack_speed"                              "12 15 18 21 24"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_manta_5.txt
+++ b/game/scripts/npc/items/item_manta_5.txt
@@ -59,22 +59,22 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "10 14 19 25 32"
+        "bonus_strength"                                  "10 15 20 30 40"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "26 31 38 47 58"
+        "bonus_agility"                                   "26 32 44 62 86"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 14 19 25 32"
+        "bonus_intellect"                                 "10 15 20 30 40"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "12 15 20 25 30"
+        "bonus_attack_speed"                              "12 15 18 21 24"
       }
       "05"
       {


### PR DESCRIPTION
Increased manta styles stats across the board. I also nerfed the attack speed scaling on manta a bit because you get alot of bonus agility from it now. This items stats is pathetic which is made worse by the fact that the illusions need stats to be effective. I compared the item to SnY and Skadi for stat scaling. 

Heart Transplant is hilariously overpowered. (I think this item may need a rework). I heavily nerfed the bonus strength this item provides and I gave the item a 20 second cooldown. This means that you can wait out the heart transplant duration and then initiate. There is no way an item this strong should have 100% uptime. 
