### PR TITLE
Give Yearning Spark passive GPM

### DIFF
--- a/game/scripts/npc/items/custom/item_farming_core.txt
+++ b/game/scripts/npc/items/custom/item_farming_core.txt
@@ -9,6 +9,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "ID"                                                  "3510"      // unique ID
     "BaseClass"                                           "item_datadriven"
+    "ScriptFile"                                          "items/farming/greater_arcane_boots.lua"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
 
     // Stats

--- a/game/scripts/npc/items/custom/item_farming_core.txt
+++ b/game/scripts/npc/items/custom/item_farming_core.txt
@@ -28,5 +28,15 @@
     "ItemStockInitial"                                    "0"
     "ItemStockTime"                                       "1500.0"
 
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_gold_per_minute"                           "500"
+      }
+    }
   }
 }

--- a/game/scripts/vscripts/items/farming/greater_arcane_boots.lua
+++ b/game/scripts/vscripts/items/farming/greater_arcane_boots.lua
@@ -77,3 +77,12 @@ function item_arcane_origin:GetIntrinsicModifierNames()
     --"modifier_creep_bounty"
   }
 end
+
+item_farming_core = class(item_arcane_origin)
+
+function item_arcane_origin:GetIntrinsicModifierNames()
+  return {
+    "modifier_passive_gpm",
+    --"modifier_creep_bounty"
+  }
+end


### PR DESCRIPTION
This makes the yearning spark a bit less of a noob trap by ticking passive GPM from arcane spark when un-upgraded. It does not have the active or anything from the arcane spark, just gives the GPM.