### PR TITLE
Move MKB and Mjollnir into the same Tree

### DIFF
--- a/game/scripts/npc/items/item_mjollnir_2.txt
+++ b/game/scripts/npc/items/item_mjollnir_2.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_mjollnir;item_upgrade_core"
+      "02"                                                "item_monkey_king_bar;item_upgrade_core"
     }
   }
 

--- a/game/scripts/npc/items/item_mjollnir_3.txt
+++ b/game/scripts/npc/items/item_mjollnir_3.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_mjollnir_2;item_upgrade_core_2"
+      "02"                                                "item_monkey_king_bar_2;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/item_mjollnir_4.txt
+++ b/game/scripts/npc/items/item_mjollnir_4.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_mjollnir_3;item_upgrade_core_3"
+      "02"                                                "item_monkey_king_bar_3;item_upgrade_core_3"
     }
   }
 

--- a/game/scripts/npc/items/item_mjollnir_5.txt
+++ b/game/scripts/npc/items/item_mjollnir_5.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_mjollnir_4;item_upgrade_core_4"
+      "02"                                                "item_monkey_king_bar_4;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/item_monkey_king_bar_2.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_2.txt
@@ -23,6 +23,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_monkey_king_bar;item_upgrade_core"
+      "02"                                                "item_mjollnir;item_upgrade_core"
     }
   }
 

--- a/game/scripts/npc/items/item_monkey_king_bar_3.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_3.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_monkey_king_bar_2;item_upgrade_core_2"
+      "01"                                                "item_mjollnir_2;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/item_monkey_king_bar_4.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_4.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_monkey_king_bar_3;item_upgrade_core_3"
+      "02"                                                "item_mjollnir_3;item_upgrade_core_3"
     }
   }
 

--- a/game/scripts/npc/items/item_monkey_king_bar_5.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_5.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_monkey_king_bar_4;item_upgrade_core_4"
+      "01"                                                "item_mjollnir_4;item_upgrade_core_4"
     }
   }
 


### PR DESCRIPTION
Based on Larnells issue (Recently closed.)
Grouped MKB and Mjollnir together because they are simillar items. Some players may wish to swicth to Mjollnir if enemies swap out their evasion items to something else. 