### PR TITLE
Merge MKB and Mjollnir trees

### DIFF
--- a/game/scripts/npc/items/item_mjollnir.txt
+++ b/game/scripts/npc/items/item_mjollnir.txt
@@ -93,7 +93,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "static_damage"                                   "200 250 300 400 500"
+        "static_damage"                                   "200 300 400 500 600"
       }
       "07"
       {
@@ -123,7 +123,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "chain_damage"                                    "170 200 250 350 450"
+        "chain_damage"                                    "170 200 325 450 575"
       }
       "13"
       {

--- a/game/scripts/npc/items/item_mjollnir.txt
+++ b/game/scripts/npc/items/item_mjollnir.txt
@@ -68,7 +68,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "24 36 56 84 120"
+        "bonus_damage"                                    "24 36 60 96 144"
       }
       "02"
       {
@@ -123,7 +123,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "chain_damage"                                    "170 200 325 450 575"
+        "chain_damage"                                    "170 210 290 410 570"
       }
       "13"
       {

--- a/game/scripts/npc/items/item_mjollnir_2.txt
+++ b/game/scripts/npc/items/item_mjollnir_2.txt
@@ -71,7 +71,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "24 36 56 84 120"
+        "bonus_damage"                                    "24 36 60 96 144"
       }
       "02"
       {
@@ -126,7 +126,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "chain_damage"                                    "170 200 325 450 575"
+        "chain_damage"                                    "170 210 290 410 570"
       }
       "13"
       {

--- a/game/scripts/npc/items/item_mjollnir_2.txt
+++ b/game/scripts/npc/items/item_mjollnir_2.txt
@@ -96,7 +96,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "static_damage"                                   "200 250 300 400 500"
+        "static_damage"                                   "200 300 400 500 600"
       }
       "07"
       {
@@ -126,7 +126,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "chain_damage"                                    "170 200 250 350 450"
+        "chain_damage"                                    "170 200 325 450 575"
       }
       "13"
       {

--- a/game/scripts/npc/items/item_mjollnir_2.txt
+++ b/game/scripts/npc/items/item_mjollnir_2.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_mjollnir;item_upgrade_core"
+      "02"                                                "item_monkey_king_bar;item_upgrade_core"
     }
   }
 

--- a/game/scripts/npc/items/item_mjollnir_2.txt
+++ b/game/scripts/npc/items/item_mjollnir_2.txt
@@ -57,7 +57,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "50"
-    "ItemCost"                                            "7100"
+    "ItemCost"                                            "5675"
     "ItemShopTags"                                        "damage;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"

--- a/game/scripts/npc/items/item_mjollnir_3.txt
+++ b/game/scripts/npc/items/item_mjollnir_3.txt
@@ -71,7 +71,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "24 36 56 84 120"
+        "bonus_damage"                                    "24 36 60 96 144"
       }
       "02"
       {
@@ -126,7 +126,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "chain_damage"                                    "170 200 325 450 575"
+        "chain_damage"                                    "170 210 290 410 570"
       }
       "13"
       {

--- a/game/scripts/npc/items/item_mjollnir_3.txt
+++ b/game/scripts/npc/items/item_mjollnir_3.txt
@@ -96,7 +96,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "static_damage"                                   "200 250 300 400 500"
+        "static_damage"                                   "200 300 400 500 600"
       }
       "07"
       {
@@ -126,7 +126,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "chain_damage"                                    "170 200 250 350 450"
+        "chain_damage"                                    "170 200 325 450 575"
       }
       "13"
       {

--- a/game/scripts/npc/items/item_mjollnir_3.txt
+++ b/game/scripts/npc/items/item_mjollnir_3.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_mjollnir_2;item_upgrade_core_2"
+      "02"                                                "item_monkey_king_bar_2;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/item_mjollnir_3.txt
+++ b/game/scripts/npc/items/item_mjollnir_3.txt
@@ -57,7 +57,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "50"
-    "ItemCost"                                            "10600"
+    "ItemCost"                                            "9175"
     "ItemShopTags"                                        "damage;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"

--- a/game/scripts/npc/items/item_mjollnir_4.txt
+++ b/game/scripts/npc/items/item_mjollnir_4.txt
@@ -71,7 +71,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "24 36 56 84 120"
+        "bonus_damage"                                    "24 36 60 96 144"
       }
       "02"
       {
@@ -126,7 +126,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "chain_damage"                                    "170 200 325 450 575"
+        "chain_damage"                                    "170 210 290 410 570"
       }
       "13"
       {

--- a/game/scripts/npc/items/item_mjollnir_4.txt
+++ b/game/scripts/npc/items/item_mjollnir_4.txt
@@ -96,7 +96,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "static_damage"                                   "200 250 300 400 500"
+        "static_damage"                                   "200 300 400 500 600"
       }
       "07"
       {
@@ -126,7 +126,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "chain_damage"                                    "170 200 250 350 450"
+        "chain_damage"                                    "170 200 325 450 575"
       }
       "13"
       {

--- a/game/scripts/npc/items/item_mjollnir_4.txt
+++ b/game/scripts/npc/items/item_mjollnir_4.txt
@@ -57,7 +57,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "50"
-    "ItemCost"                                            "18600"
+    "ItemCost"                                            "17175"
     "ItemShopTags"                                        "damage;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"

--- a/game/scripts/npc/items/item_mjollnir_4.txt
+++ b/game/scripts/npc/items/item_mjollnir_4.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_mjollnir_3;item_upgrade_core_3"
+      "02"                                                "item_monkey_king_bar_3;item_upgrade_core_3"
     }
   }
 

--- a/game/scripts/npc/items/item_mjollnir_5.txt
+++ b/game/scripts/npc/items/item_mjollnir_5.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_mjollnir_4;item_upgrade_core_4"
+      "02"                                                "item_monkey_king_bar_4;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/item_mjollnir_5.txt
+++ b/game/scripts/npc/items/item_mjollnir_5.txt
@@ -56,7 +56,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "50"
-    "ItemCost"                                            "38600"
+    "ItemCost"                                            "37175"
     "ItemShopTags"                                        "damage;attack_speed;unique"
     "ItemQuality"                                         "artifact"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"

--- a/game/scripts/npc/items/item_mjollnir_5.txt
+++ b/game/scripts/npc/items/item_mjollnir_5.txt
@@ -70,7 +70,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "24 36 56 84 120"
+        "bonus_damage"                                    "24 36 60 96 144"
       }
       "02"
       {
@@ -125,7 +125,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "chain_damage"                                    "170 200 325 450 575"
+        "chain_damage"                                    "170 210 290 410 570"
       }
       "13"
       {

--- a/game/scripts/npc/items/item_mjollnir_5.txt
+++ b/game/scripts/npc/items/item_mjollnir_5.txt
@@ -95,7 +95,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "static_damage"                                   "200 250 300 400 500"
+        "static_damage"                                   "200 300 400 500 600"
       }
       "07"
       {
@@ -125,7 +125,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "chain_damage"                                    "170 200 250 350 450"
+        "chain_damage"                                    "170 200 325 450 575"
       }
       "13"
       {

--- a/game/scripts/npc/items/item_monkey_king_bar.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar.txt
@@ -54,7 +54,7 @@
 			"01"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_damage"      "52 95 140 210 285"
+        "bonus_damage"      "52 82 122 182 252"
 			}
 			"02"
 			{
@@ -69,7 +69,7 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_chance_damage"     "100 160 220 280 340"
+        "bonus_chance_damage"     "100 125 175 250 350"
 			}
     }
   }

--- a/game/scripts/npc/items/item_monkey_king_bar.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar.txt
@@ -69,7 +69,7 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_chance_damage"     "100 130 185 260 370"
+        "bonus_chance_damage"     "100 160 220 280 340"
 			}
     }
   }

--- a/game/scripts/npc/items/item_monkey_king_bar_2.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_2.txt
@@ -72,7 +72,7 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_chance_damage"     "100 130 185 260 370"
+        "bonus_chance_damage"     "100 160 220 280 340"
 			}
     }
   }

--- a/game/scripts/npc/items/item_monkey_king_bar_2.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_2.txt
@@ -23,6 +23,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_monkey_king_bar;item_upgrade_core"
+      "02"                                                "item_mjollnir;item_upgrade_core"
     }
   }
 

--- a/game/scripts/npc/items/item_monkey_king_bar_2.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_2.txt
@@ -57,7 +57,7 @@
 			"01"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_damage"      "52 95 140 210 285"
+        "bonus_damage"      "52 82 122 182 252"
 			}
 			"02"
 			{
@@ -72,7 +72,7 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_chance_damage"     "100 160 220 280 340"
+        "bonus_chance_damage"     "100 125 175 250 350"
 			}
     }
   }

--- a/game/scripts/npc/items/item_monkey_king_bar_3.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_3.txt
@@ -73,7 +73,7 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_chance_damage"     "100 130 185 260 370"
+        "bonus_chance_damage"     "100 160 220 280 340"
 			}
     }
   }

--- a/game/scripts/npc/items/item_monkey_king_bar_3.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_3.txt
@@ -58,7 +58,7 @@
 			"01"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_damage"      "52 95 140 210 285"
+        "bonus_damage"      "52 82 122 182 252"
 			}
 			"02"
 			{
@@ -73,7 +73,7 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_chance_damage"     "100 160 220 280 340"
+        "bonus_chance_damage"     "100 125 175 250 350"
 			}
     }
   }

--- a/game/scripts/npc/items/item_monkey_king_bar_3.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_3.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_monkey_king_bar_2;item_upgrade_core_2"
+      "02"                                                "item_mjollnir_2;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/item_monkey_king_bar_4.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_4.txt
@@ -73,7 +73,7 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_chance_damage"     "100 130 185 260 370"
+        "bonus_chance_damage"     "100 160 220 280 340"
 			}
     }
   }

--- a/game/scripts/npc/items/item_monkey_king_bar_4.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_4.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_monkey_king_bar_3;item_upgrade_core_3"
+      "02"                                                "item_mjollnir_3;item_upgrade_core_3"
     }
   }
 

--- a/game/scripts/npc/items/item_monkey_king_bar_4.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_4.txt
@@ -58,7 +58,7 @@
 			"01"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_damage"      "52 95 140 210 285"
+        "bonus_damage"      "52 82 122 182 252"
 			}
 			"02"
 			{
@@ -73,7 +73,7 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_chance_damage"     "100 160 220 280 340"
+        "bonus_chance_damage"     "100 125 175 250 350"
 			}
     }
   }

--- a/game/scripts/npc/items/item_monkey_king_bar_5.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_5.txt
@@ -24,6 +24,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_monkey_king_bar_4;item_upgrade_core_4"
+      "02"                                                "item_mjollnir_4;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/item_monkey_king_bar_5.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_5.txt
@@ -73,7 +73,7 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_chance_damage"     "100 130 185 260 370"
+        "bonus_chance_damage"     "100 160 220 280 340"
 			}
     }
   }

--- a/game/scripts/npc/items/item_monkey_king_bar_5.txt
+++ b/game/scripts/npc/items/item_monkey_king_bar_5.txt
@@ -58,7 +58,7 @@
 			"01"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_damage"      "52 95 140 210 285"
+        "bonus_damage"      "52 82 122 182 252"
 			}
 			"02"
 			{
@@ -73,7 +73,7 @@
 			"04"
 			{
 				"var_type"				"FIELD_INTEGER"
-        "bonus_chance_damage"     "100 160 220 280 340"
+        "bonus_chance_damage"     "100 125 175 250 350"
 			}
     }
   }


### PR DESCRIPTION
Based on Larnells Issue #2653
 Merged MKB and Mjollnir into the same tree as these items are simillar. Also some players may wish to swap out MKB for a Mjollnir and Vice Versa depending on the amount of evasion in the game. 