### PR TITLE
Reduce Bloodstone Cooldown

### DIFF
--- a/game/scripts/npc/items/item_bloodstone.txt
+++ b/game/scripts/npc/items/item_bloodstone.txt
@@ -37,7 +37,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "250.0"
+    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone"
 

--- a/game/scripts/npc/items/item_bloodstone.txt
+++ b/game/scripts/npc/items/item_bloodstone.txt
@@ -37,7 +37,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
+    "AbilityCooldown"                                     "120.0 110.0 100.0 90.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone"
 

--- a/game/scripts/npc/items/item_bloodstone.txt
+++ b/game/scripts/npc/items/item_bloodstone.txt
@@ -37,7 +37,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "120.0 110.0 100.0 90.0 80.0" //OAA
+    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone"
 
@@ -115,7 +115,7 @@
       "11"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "mana_cost_percentage"                            "30 40 50 60 70"
+        "mana_cost_percentage"                            "30"
       }
       "12"
       {

--- a/game/scripts/npc/items/item_bloodstone_2.txt
+++ b/game/scripts/npc/items/item_bloodstone_2.txt
@@ -36,7 +36,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "250.0"
+    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone_2"
 

--- a/game/scripts/npc/items/item_bloodstone_2.txt
+++ b/game/scripts/npc/items/item_bloodstone_2.txt
@@ -36,7 +36,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "120.0 110.0 100.0 90.0 80.0" //OAA
+    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone_2"
 
@@ -114,7 +114,7 @@
       "11"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "mana_cost_percentage"                            "30 40 50 60 70"
+        "mana_cost_percentage"                            "30"
       }
       "12"
       {

--- a/game/scripts/npc/items/item_bloodstone_2.txt
+++ b/game/scripts/npc/items/item_bloodstone_2.txt
@@ -36,7 +36,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
+    "AbilityCooldown"                                     "120.0 110.0 100.0 90.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone_2"
 

--- a/game/scripts/npc/items/item_bloodstone_3.txt
+++ b/game/scripts/npc/items/item_bloodstone_3.txt
@@ -36,7 +36,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "250.0"
+    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone_3"
 

--- a/game/scripts/npc/items/item_bloodstone_3.txt
+++ b/game/scripts/npc/items/item_bloodstone_3.txt
@@ -36,7 +36,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
+    "AbilityCooldown"                                     "120.0 110.0 100.0 90.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone_3"
 

--- a/game/scripts/npc/items/item_bloodstone_3.txt
+++ b/game/scripts/npc/items/item_bloodstone_3.txt
@@ -36,7 +36,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "120.0 110.0 100.0 90.0 80.0" //OAA
+    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone_3"
 
@@ -114,7 +114,7 @@
       "11"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "mana_cost_percentage"                            "30 40 50 60 70"
+        "mana_cost_percentage"                            "30"
       }
       "12"
       {

--- a/game/scripts/npc/items/item_bloodstone_4.txt
+++ b/game/scripts/npc/items/item_bloodstone_4.txt
@@ -37,7 +37,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "250.0"
+    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone_4"
 

--- a/game/scripts/npc/items/item_bloodstone_4.txt
+++ b/game/scripts/npc/items/item_bloodstone_4.txt
@@ -37,7 +37,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "120.0 110.0 100.0 90.0 80.0" //OAA
+    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone_4"
 
@@ -115,7 +115,7 @@
       "11"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "mana_cost_percentage"                            "30 40 50 60 70"
+        "mana_cost_percentage"                            "30"
       }
       "12"
       {

--- a/game/scripts/npc/items/item_bloodstone_4.txt
+++ b/game/scripts/npc/items/item_bloodstone_4.txt
@@ -37,7 +37,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
+    "AbilityCooldown"                                     "120.0 110.0 100.0 90.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone_4"
 

--- a/game/scripts/npc/items/item_bloodstone_5.txt
+++ b/game/scripts/npc/items/item_bloodstone_5.txt
@@ -37,7 +37,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
+    "AbilityCooldown"                                     "120.0 110.0 100.0 90.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone_5"
 

--- a/game/scripts/npc/items/item_bloodstone_5.txt
+++ b/game/scripts/npc/items/item_bloodstone_5.txt
@@ -37,7 +37,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "120.0 110.0 100.0 90.0 80.0" //OAA
+    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone_5"
 
@@ -114,7 +114,7 @@
       "11"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "mana_cost_percentage"                            "30 40 50 60 70"
+        "mana_cost_percentage"                            "30"
       }
       "12"
       {

--- a/game/scripts/npc/items/item_bloodstone_5.txt
+++ b/game/scripts/npc/items/item_bloodstone_5.txt
@@ -37,7 +37,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "250.0"
+    "AbilityCooldown"                                     "160.0 140.0 120.0 100.0 80.0" //OAA
     "AbilitySharedCooldown"                               "bloodstone"
     "AbilityTextureName"                                  "custom/bloodstone_5"
 


### PR DESCRIPTION
I have reduced the astronomical cooldown on Bloodstone to something actually usable in OAA. It is still a once per fight item, and at early levels you may have to fight without bloodstone active being up but is much better then bloodstones 250 second cooldown. 