### PR TITLE
Queen of Pain Talent Buffs

### DIFF
--- a/game/scripts/npc/heroes/queenofpain.txt
+++ b/game/scripts/npc/heroes/queenofpain.txt
@@ -7,6 +7,18 @@
   {
     // Abilities
     //-------------------------------------------------------------------------------------------------------------
-    "Ability13"		"special_bonus_attack_speed_80" // replaces special_bonus_attack_speed_40
+
+
+    "Ability10"   "special_bonus_attack_damage_75" // replaces special_bonus_attack_damage_25
+    "Ability11"   "special_bonus_strength_20" // replaces special_bonus_strength_10
+
+    "Ability12"   "special_bonus_cooldown_reduction_12"
+    "Ability13"   "special_bonus_attack_speed_100" // replaces special_bonus_attack_speed_40
+
+    "Ability14"   "special_bonus_spell_lifesteal_30"
+    "Ability15"   "special_bonus_unique_queen_of_pain"
+
+    "Ability16"   "special_bonus_unique_queen_of_pain_2"
+    "Ability17"   "special_bonus_spell_block_15"
   }
 }


### PR DESCRIPTION
Increased the values of QoP attribute based talents. These buffs are aimed at improving one of QoP's main strengths as a hero which is item flexibility. Currently you are forced into the caster build, heavily relying on your level 25 fear talent to be effective. (Most Hybrid damage heroes have this issue where you have to hard commit to either right click or a caster build, in the process completely forsaking the other part of the hero.)

Increased the level 10 damage talent from +25 to +75. This is to help her dominate midgame skirmishes before her right click damage becomes alot less effective as enemies gain armour. This bonus damage will also improve a bloodthorn build QoP should you opt for that item path. 

Increased the level 10 strength talent from 10 to 20. This is amping up the bonus strength to a more suitable OAA level.

Increased QoP's level 15 attack speed talent from +80 to +100. This now matches both Razor and Brewmasters 100 attack speed talent. Keep in mind that both of the mention heroes have right click steroids whereas QoP doesn't. A QoP who opts for 100 attack speed is probably going for a right click build, so she wont be doing much damage from her spells anymore. 