### PR TITLE
Troll Warlord Buffs

### DIFF
--- a/game/scripts/npc/abilities/troll_warlord_berserkers_rage.txt
+++ b/game/scripts/npc/abilities/troll_warlord_berserkers_rage.txt
@@ -30,7 +30,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_move_speed"                                "10 20 30 40 45 50"
+        "bonus_move_speed"                                "10 20 30 40 50 60"
       }
       "03"
       {
@@ -55,7 +55,7 @@
       "08"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "ensnare_duration"                                "0.8 0.95 1.1 1.25 1.6 2.0" //OAA
+        "ensnare_duration"                                "0.8 1.2 1.6 2.0 2.1 2.2"
       }
     }
   }

--- a/game/scripts/npc/abilities/troll_warlord_fervor.txt
+++ b/game/scripts/npc/abilities/troll_warlord_fervor.txt
@@ -26,7 +26,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "max_stacks"                                      "6 7 8 9 10 12" //OAA
+        "max_stacks"                                      "6 7 8 9 10 11" //OAA
         "LinkedSpecialBonus"                              "special_bonus_unique_troll_warlord_2"
       }
     }

--- a/game/scripts/npc/abilities/troll_warlord_fervor.txt
+++ b/game/scripts/npc/abilities/troll_warlord_fervor.txt
@@ -21,12 +21,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "attack_speed"                                    "5 10 15 20 25 30" //OAA
+        "attack_speed"                                    "15 20 25 30 35 40"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "max_stacks"                                      "10" //OAA
+        "max_stacks"                                      "6 7 8 9 10 12" //OAA
         "LinkedSpecialBonus"                              "special_bonus_unique_troll_warlord_2"
       }
     }

--- a/game/scripts/npc/abilities/troll_warlord_fervor.txt
+++ b/game/scripts/npc/abilities/troll_warlord_fervor.txt
@@ -26,7 +26,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "max_stacks"                                      "6 7 8 9 10 11" //OAA
+        "max_stacks"                                      "9" //OAA
         "LinkedSpecialBonus"                              "special_bonus_unique_troll_warlord_2"
       }
     }

--- a/game/scripts/npc/abilities/troll_warlord_whirling_axes_ranged.txt
+++ b/game/scripts/npc/abilities/troll_warlord_whirling_axes_ranged.txt
@@ -62,7 +62,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "axe_slow_duration"                               "2.5 3 3.5 4 4.5 5.0"
+        "axe_slow_duration"                               "2.5 3 3.5 4 5.5 7.0"
       }
       "06"
       {

--- a/game/scripts/npc/abilities/troll_warlord_whirling_axes_ranged.txt
+++ b/game/scripts/npc/abilities/troll_warlord_whirling_axes_ranged.txt
@@ -62,7 +62,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "axe_slow_duration"                               "2.5 3 3.5 4 5.5 7.0"
+        "axe_slow_duration"                               "2.5 3 3.5 4 4.5 5.0"
       }
       "06"
       {


### PR DESCRIPTION
Buffing troll as this hero isnt good anymore. Even at his peak after the rework I didn think he was particularly overpowered. He was just good when compared to most other carries. There was 2 things he did well, which was farm fairly fast and he was an S tier boss killer thanks the the fevour buff from the rework. This hero still has the same weaknesses, which are easily exploitable in OAA becasue money for items is very easy to come by. 

increased Beserkers rage movespeed at OAA levels and changed the root duration to be the same as in dota. The numbers weren't changed after the bash was changed to a root. (The root is far worse then the bash in most cases.) 

Nerfed the slow duration on whirling axe ranged at OAA levels. 

Reverted the attack speed nerf to Fevour. He needs attack speed to gain more attack speed. Currently fevour is useless when trying to kill heroes because it takes too long to reach maximum stacks. (Troll needs to be a manfighting king). I made the maximum stacks scale up to 11 at level 6.