### PR TITLE
Terroblade Boss Nerf

### DIFF
--- a/game/scripts/npc/units/boss/tier5_bosses/stopfightingyourself/stopfightingyourself_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/stopfightingyourself/stopfightingyourself_tier5.txt
@@ -31,7 +31,7 @@
     "AttackDamageMin"                                     "1000"              // Damage range min.
     "AttackDamageMax"                                     "1000"              // Damage range max.
     "AttackDamageType"                                    "DAMAGE_TYPE_ArmorPhysical"
-    "AttackRate"                                          "0.5"               // Speed of attack.
+    "AttackRate"                                          "0.9"               // Speed of attack.
     "AttackAnimationPoint"                                "0.0"               // Normalized time in animation cycle to attack.
     "AttackAcquisitionRange"                              "650"               // Range within a target can be acquired.
     "AttackRange"                                         "600"               // Range within a target can be attacked.

--- a/game/scripts/npc/units/stopfightingyourself/stopfightingyourself.txt
+++ b/game/scripts/npc/units/stopfightingyourself/stopfightingyourself.txt
@@ -31,7 +31,7 @@
     "AttackDamageMin"                                     "1000"              // Damage range min.
     "AttackDamageMax"                                     "1000"              // Damage range max.
     "AttackDamageType"                                    "DAMAGE_TYPE_ArmorPhysical"
-    "AttackRate"                                          "0.5"               // Speed of attack.
+    "AttackRate"                                          "0.9"               // Speed of attack.
     "AttackAnimationPoint"                                "0.0"               // Normalized time in animation cycle to attack.
     "AttackAcquisitionRange"                              "650"               // Range within a target can be acquired.
     "AttackRange"                                         "600"               // Range within a target can be attacked.


### PR DESCRIPTION
Increased his base attack time from 0.5 to 0.9. This should hopefully mean he wont get a rampage every time he gets a carries item slot. 