### PR TITLE
Ogre Boss Nerf

### DIFF
--- a/game/scripts/npc/abilities/siltbreaker/ogre_magi_channelled_bloodlust_tier5.txt
+++ b/game/scripts/npc/abilities/siltbreaker/ogre_magi_channelled_bloodlust_tier5.txt
@@ -55,7 +55,7 @@
             "04"
             {
                 "var_type"              "FIELD_INTEGER"
-                "bonus_attack_speed"    "300"
+                "bonus_attack_speed"    "200"
             }
             "05"
             {

--- a/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite.txt
+++ b/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite.txt
@@ -43,7 +43,7 @@
             "02"
             {
                 "var_type"          "FIELD_INTEGER"
-                "burn_damage"       "1000"
+                "burn_damage"       "600"
             }
 
             "03"

--- a/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite.txt
+++ b/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite.txt
@@ -43,7 +43,7 @@
             "02"
             {
                 "var_type"          "FIELD_INTEGER"
-                "burn_damage"       "600"
+                "burn_damage"       "400"
             }
 
             "03"
@@ -65,7 +65,7 @@
             "06"
             {
                 "var_type"              "FIELD_FLOAT"
-                "area_duration"         "5.0" // magi's: 2.0
+                "area_duration"         "8.0" // magi's: 2.0
             }
         }
     }

--- a/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite_tier5.txt
+++ b/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite_tier5.txt
@@ -43,7 +43,7 @@
             "02"
             {
                 "var_type"          "FIELD_INTEGER"
-                "burn_damage"       "2000"
+                "burn_damage"       "1200"
             }
 
             "03"
@@ -65,7 +65,7 @@
             "06"
             {
                 "var_type"              "FIELD_FLOAT"
-                "area_duration"         "10.0" // magi's: 2.0
+                "area_duration"         "5.0" // magi's: 2.0
             }
         }
     }

--- a/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite_tier5.txt
+++ b/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite_tier5.txt
@@ -43,7 +43,7 @@
             "02"
             {
                 "var_type"          "FIELD_INTEGER"
-                "burn_damage"       "1200"
+                "burn_damage"       "800"
             }
 
             "03"
@@ -65,7 +65,7 @@
             "06"
             {
                 "var_type"              "FIELD_FLOAT"
-                "area_duration"         "5.0" // magi's: 2.0
+                "area_duration"         "8.0" // magi's: 2.0
             }
         }
     }

--- a/game/scripts/npc/abilities/siltbreaker/ogre_tank_boss_jump_smash_tier5.txt
+++ b/game/scripts/npc/abilities/siltbreaker/ogre_tank_boss_jump_smash_tier5.txt
@@ -48,7 +48,7 @@
             "03"
             {
                 "var_type"              "FIELD_INTEGER"
-                "damage"                "15000"
+                "damage"                "10000"
             }
             "04"
             {

--- a/game/scripts/npc/abilities/siltbreaker/ogre_tank_boss_melee_smash_tier5.txt
+++ b/game/scripts/npc/abilities/siltbreaker/ogre_tank_boss_melee_smash_tier5.txt
@@ -48,7 +48,7 @@
             "03"
             {
                 "var_type"              "FIELD_INTEGER"
-                "damage"                "10000" // regular version: 750
+                "damage"                "7000" // regular version: 750
             }
             "04"
             {

--- a/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_ogre_tank_boss_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_ogre_tank_boss_tier5.txt
@@ -16,7 +16,7 @@
 		"SoundSet"					"Hero_Ogre"
 		"GameSoundsFile"			"soundevents/game_sounds_creeps.vsndevts"
 		"Level"						"1"
-		"ModelScale" 				"3.1"
+		"ModelScale" 				"2.8"
     "ConsideredHero"    "1"
     "IsAncient"         "1"
     "IsBossMonster"     "1"


### PR DESCRIPTION
These balance changes are aimed at making the Ogre Boss less of an insta kill machine. (Tier 3 Ogre boss is mostly fine.) 
 
**Tier 3**
Reduced Ogre Magi Ingnite Damage and increased the duration from 5 to 8 seconds. This should mean you dont die after being hit by this spell, unless you have a dispel/bkb etc. This also means the spell slow is more annoying, previously the ingnite was bearly noticable. 

**Tier 5**
Reduced Model Size by 10%. This boss is too big, its hard to click around this boss. 
Reduced Melee and Jump Smash Damage. Still very high damage but not an instant kill like before. 
Rreduced Bloodlust attack speed from 300 to 200. Previously if the boss got bloodlusted it would chain stun you until you die. Now you have a small window to move. 
Reduced Ignite Damage and set the duration to 8 seconds. 