### PR TITLE
Temple Guardian Nerf

### DIFF
--- a/game/scripts/npc/abilities/siltbreaker/temple_guardian_wrath.txt
+++ b/game/scripts/npc/abilities/siltbreaker/temple_guardian_wrath.txt
@@ -38,7 +38,7 @@
       "01"
       {
         "var_type"                  "FIELD_INTEGER"
-        "effect_radius"             "1500"
+        "effect_radius"             "1200" // Was 1500, which goes far outside the boss pit
       }
       "02"
       {

--- a/game/scripts/npc/abilities/siltbreaker/temple_guardian_wrath_tier5.txt
+++ b/game/scripts/npc/abilities/siltbreaker/temple_guardian_wrath_tier5.txt
@@ -38,7 +38,7 @@
       "01"
       {
         "var_type"                  "FIELD_INTEGER"
-        "effect_radius"             "1500"
+        "effect_radius"             "1200" // Was 1500, which goes outside the boss bit
       }
       "02"
       {

--- a/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_temple_guardian_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_temple_guardian_tier5.txt
@@ -70,7 +70,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				  "17000"
+		"StatusHealth"				  "16000"
 		"StatusHealthRegen"			"55" // they can spam heal bombs for effective 500 hp/s heals
 		"StatusMana"				    "5000"
 		"StatusManaRegen"			  "30"

--- a/game/scripts/npc/units/siltbreaker/npc_dota_creature_temple_guardian.txt
+++ b/game/scripts/npc/units/siltbreaker/npc_dota_creature_temple_guardian.txt
@@ -37,7 +37,7 @@
     	//----------------------------------------------------------------
     	"ArmorPhysical"                                       "25"        // Physical protection.
     	"MagicalResistance"                                   "-50"       // Magical protection.
-        
+
         // Bounty
    		//----------------------------------------------------------------
     	"BountyXP"                                            "4000"  // Experience earn.
@@ -70,7 +70,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				  "11000"
+		"StatusHealth"				  "10000"
 		"StatusHealthRegen"			"25" // they can spam heal bombs for effective 500 hp/s heals
 		"StatusMana"				    "5000"
 		"StatusManaRegen"			  "30"


### PR DESCRIPTION
Temple Guardians are still harder then any other boss in the game. Still players will avoid Temple Guardians because they take a very long time to do and require the most kiting out of any boss. 

I decreased both the tier 4 and 5 health by 1000, this should make them more managable. 
I also decreased the Wrath radius from 1500 to 1200. 1500 will hit enemies far outside the boss pit. At 1200 this means you are safe as soon as you leave the boss pit. (The enitre fight shoudlnt be any bigger then the boss pit.)