### PR TITLE
Swiper Boss nerf

### DIFF
--- a/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
@@ -40,7 +40,7 @@
             "01"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "3500"
+                "damage"                    "3150"
             }
         }
 

--- a/game/scripts/npc/abilities/swiper/boss_swiper_frontswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_frontswipe.txt
@@ -40,7 +40,7 @@
             "01"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "3500"
+                "damage"                    "3150"
             }
             "02"
             {

--- a/game/scripts/npc/abilities/swiper/boss_swiper_reapers_rush.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_reapers_rush.txt
@@ -74,7 +74,7 @@
             "08"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "max_damage"                "5000"
+                "max_damage"                "4500"
             }
             "09"
             {

--- a/game/scripts/npc/abilities/swiper/boss_swiper_thrust.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_thrust.txt
@@ -54,7 +54,7 @@
             "04"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "3500"
+                "damage"                    "3150"
             }
         }
 

--- a/game/scripts/npc/units/swiper/npc_dota_boss_swiper.txt
+++ b/game/scripts/npc/units/swiper/npc_dota_boss_swiper.txt
@@ -64,7 +64,7 @@
 
     // Status
     //----------------------------------------------------------------
-    "StatusHealth"                                        "7500"    // Base health
+    "StatusHealth"                                        "8500"    // Base health
     "StatusHealthRegen"                                   "10"    // Health regeneration rate.
     "StatusMana"                                          "2500"    // Base mana.
     "StatusManaRegen"                                     "5"    // Mana regeneration rate.

--- a/game/scripts/npc/units/swiper/npc_dota_boss_swiper.txt
+++ b/game/scripts/npc/units/swiper/npc_dota_boss_swiper.txt
@@ -64,7 +64,7 @@
 
     // Status
     //----------------------------------------------------------------
-    "StatusHealth"                                        "8500"    // Base health
+    "StatusHealth"                                        "7500"    // Base health
     "StatusHealthRegen"                                   "10"    // Health regeneration rate.
     "StatusMana"                                          "2500"    // Base mana.
     "StatusManaRegen"                                     "5"    // Mana regeneration rate.


### PR DESCRIPTION
Swiper Boss Damage is a little to high, often making a single mistake will do 70% of your HP as damage. I have decreased the damage on each of his skills by 10%. These changes make the swiper boss a little more forgiving if you make a mistake but the damage is still high enough where you cant just decide to stand still and tank the boss. 