### PR TITLE
Undying Buffs

### DIFF
--- a/game/scripts/npc/abilities/undying_flesh_golem.txt
+++ b/game/scripts/npc/abilities/undying_flesh_golem.txt
@@ -48,7 +48,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "health_bonus"                                    "400 1000 1600 3200 4800"
+        "health_bonus"                                    "400 1600 2800 4000 5200" //OAA
       }
       "05"
       {

--- a/game/scripts/npc/abilities/undying_soul_rip.txt
+++ b/game/scripts/npc/abilities/undying_soul_rip.txt
@@ -46,12 +46,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage_per_unit"                                 "22 29 36 43 85 141"
+        "damage_per_unit"                                 "22 29 36 43 129 215"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "max_units"                                       "8 9 10 11 13 19"
+        "max_units"                                       "8 9 10 11 12 13"
       }
       "03"
       {

--- a/game/scripts/npc/heroes/undying.txt
+++ b/game/scripts/npc/heroes/undying.txt
@@ -7,5 +7,10 @@
   {
     // Abilities
     //-------------------------------------------------------------------------------------------------------------
+    "Ability10"   "special_bonus_cast_range_150"
+    "Ability11"   "special_bonus_hp_regen_8"
+
+    "Ability16"   "special_bonus_reincarnation_180" // replaces special_bonus_reincarnation_250
+    "Ability17"   "special_bonus_unique_undying_2"
   }
 }


### PR DESCRIPTION
Increased Soul Rip heal per target heavily, but reduced the maximum targets aswell. This is to match the dota changes. Also your not going to be hitting 19 targets in most fights. This should make soul rip a much more consistent heal/damage wise. (This spell may need a nerf in damage/heal. At level 6 its nearly 3k heal with maximum targets.) 

Increased Flesh Golem HP levels 2-5. This is to make undying more tanky during ultimate. Currently the bonus health isn't very noticable.  This will also allow him to keep up the early/mid game pressure, which is where he excells the most. 

Improved his level 25 reincarnation talent, reducing the cooldown from 250 to 180 seconds. 