### PR TITLE
Natures Prophet Teleport Nerf

### DIFF
--- a/game/scripts/npc/abilities/furion_teleportation.txt
+++ b/game/scripts/npc/abilities/furion_teleportation.txt
@@ -15,8 +15,8 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "0"
-    "AbilityCastPoint"                                    "3 3 3 3 1.9 0.8"
+    "AbilityCastPoint"                                    "3 3 3 3 2.25 1.5"
     "AbilityCooldown"                                     "50 40 30 20 15 10"
-    "AbilityManaCost"                                     "50 50 50 50"
+    "AbilityManaCost"                                     "50"
   }
 }


### PR DESCRIPTION
Increased cast time on teleport levels 5 and 6. At level 6 it has the same cast time as meepo poof. Currently this spell at level 6 is just global blink, which is very OP. 