### PR TITLE
Battlefury Buffs

### DIFF
--- a/game/scripts/npc/items/item_bfury.txt
+++ b/game/scripts/npc/items/item_bfury.txt
@@ -53,7 +53,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "45 60 120 180 240"
+        "bonus_damage"                                    "45 65 95 135 185"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_bfury.txt
+++ b/game/scripts/npc/items/item_bfury.txt
@@ -68,7 +68,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cleave_damage_percent"                           "40 50 60 70 80"	//OAA
+        "cleave_damage_percent"                           "60 70 80 90 100"	//OAA
       }
       "05"
       {

--- a/game/scripts/npc/items/item_bfury.txt
+++ b/game/scripts/npc/items/item_bfury.txt
@@ -53,7 +53,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "45 60 85 125 180"
+        "bonus_damage"                                    "45 60 120 180 240"
       }
       "02"
       {
@@ -73,12 +73,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "quelling_bonus"                                  "24"
+        "quelling_bonus"                                  "24 30 90 150 210"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "quelling_bonus_ranged"                           "24"	//OAA
+        "quelling_bonus_ranged"                           "24 30 90 150 210"	//OAA
       }
       "07"
       {

--- a/game/scripts/npc/items/item_bfury_2.txt
+++ b/game/scripts/npc/items/item_bfury_2.txt
@@ -56,7 +56,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "45 60 120 180 240"
+        "bonus_damage"                                    "45 65 95 135 185"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_bfury_2.txt
+++ b/game/scripts/npc/items/item_bfury_2.txt
@@ -56,7 +56,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "45 60 85 125 180"
+        "bonus_damage"                                    "45 60 120 180 240"
       }
       "02"
       {
@@ -76,12 +76,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "quelling_bonus"                                  "24"
+        "quelling_bonus"                                  "24 30 90 150 210"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "quelling_bonus_ranged"                           "24"	//OAA
+        "quelling_bonus_ranged"                           "24 30 90 150 210"	//OAA
       }
       "07"
       {

--- a/game/scripts/npc/items/item_bfury_2.txt
+++ b/game/scripts/npc/items/item_bfury_2.txt
@@ -71,7 +71,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cleave_damage_percent"                           "40 50 60 70 80"	//OAA
+        "cleave_damage_percent"                           "60 70 80 90 100"	//OAA
       }
       "05"
       {

--- a/game/scripts/npc/items/item_bfury_3.txt
+++ b/game/scripts/npc/items/item_bfury_3.txt
@@ -57,7 +57,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "45 60 120 180 240"
+        "bonus_damage"                                    "45 65 95 135 185"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_bfury_3.txt
+++ b/game/scripts/npc/items/item_bfury_3.txt
@@ -72,7 +72,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cleave_damage_percent"                           "40 50 60 70 80"	//OAA
+        "cleave_damage_percent"                           "60 70 80 90 100"	//OAA
       }
       "05"
       {

--- a/game/scripts/npc/items/item_bfury_3.txt
+++ b/game/scripts/npc/items/item_bfury_3.txt
@@ -57,7 +57,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "45 60 85 125 180"
+        "bonus_damage"                                    "45 60 120 180 240"
       }
       "02"
       {
@@ -77,12 +77,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "quelling_bonus"                                  "24"
+        "quelling_bonus"                                  "24 30 90 150 210"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "quelling_bonus_ranged"                           "24"	//OAA
+        "quelling_bonus_ranged"                           "24 30 90 150 210"	//OAA
       }
       "07"
       {

--- a/game/scripts/npc/items/item_bfury_4.txt
+++ b/game/scripts/npc/items/item_bfury_4.txt
@@ -58,7 +58,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "45 60 120 180 240"
+        "bonus_damage"                                    "45 65 95 135 185"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_bfury_4.txt
+++ b/game/scripts/npc/items/item_bfury_4.txt
@@ -58,7 +58,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "45 60 85 125 180"
+        "bonus_damage"                                    "45 60 120 180 240"
       }
       "02"
       {
@@ -78,12 +78,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "quelling_bonus"                                  "24"
+        "quelling_bonus"                                  "24 30 90 150 210"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "quelling_bonus_ranged"                           "24"	//OAA
+        "quelling_bonus_ranged"                           "24 30 90 150 210"	//OAA
       }
       "07"
       {

--- a/game/scripts/npc/items/item_bfury_4.txt
+++ b/game/scripts/npc/items/item_bfury_4.txt
@@ -73,7 +73,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cleave_damage_percent"                           "40 50 60 70 80"	//OAA
+        "cleave_damage_percent"                           "60 70 80 90 100"	//OAA
       }
       "05"
       {

--- a/game/scripts/npc/items/item_bfury_5.txt
+++ b/game/scripts/npc/items/item_bfury_5.txt
@@ -57,7 +57,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "45 60 120 180 240"
+        "bonus_damage"                                    "45 65 95 135 185"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_bfury_5.txt
+++ b/game/scripts/npc/items/item_bfury_5.txt
@@ -72,7 +72,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cleave_damage_percent"                           "40 50 60 70 80"	//OAA
+        "cleave_damage_percent"                           "60 70 80 90 100"	//OAA
       }
       "05"
       {

--- a/game/scripts/npc/items/item_bfury_5.txt
+++ b/game/scripts/npc/items/item_bfury_5.txt
@@ -57,7 +57,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "45 60 85 125 180"
+        "bonus_damage"                                    "45 60 120 180 240"
       }
       "02"
       {
@@ -77,12 +77,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "quelling_bonus"                                  "24"
+        "quelling_bonus"                                  "24 30 90 150 210"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "quelling_bonus_ranged"                           "24"	//OAA
+        "quelling_bonus_ranged"                           "24 30 90 150 210"	//OAA
       }
       "07"
       {


### PR DESCRIPTION
Buffed battlefury. I am trying to make level 3-5 battlefury a viable item if you need the cleave vs alot of summons or illusions. The main strenght of this item allowing you to flash farm is irrelevant past 10 minutes. I increased the damage on BF heavilty from levels 3-5 to make is damage more comparable to other damage items. I also increased the Quell Damage. There is a huge increase levels 3-5. This should hopefully make the item a strong pickup if you need to clear summons as a right click carry.

PS; I am assuming level 1 battlefury is still OP and level 2 battlefury is viable. 