### PR TITLE
Spirit Vessel Nerf

### DIFF
--- a/game/scripts/npc/items/item_spirit_vessel.txt
+++ b/game/scripts/npc/items/item_spirit_vessel.txt
@@ -74,7 +74,7 @@
       "04"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_all_stats"             "2 10 20 30 40"
+        "bonus_all_stats"             "2 15 30 45 60"
       }
       "05"
       {
@@ -119,7 +119,7 @@
       "13"
       {
         "var_type"                    "FIELD_FLOAT"
-        "enemy_hp_drain"              "4 4.25 4.5 4.75 5.0"
+        "enemy_hp_drain"              "4"
       }
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel.txt
+++ b/game/scripts/npc/items/item_spirit_vessel.txt
@@ -64,7 +64,7 @@
       "02"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_movement_speed"        "20 22 28 34 40"
+        "bonus_movement_speed"        "20 25 30 35 40"
       }
       "03"
       {
@@ -74,7 +74,7 @@
       "04"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_all_stats"             "2 15 30 45 60"
+        "bonus_all_stats"             "2 10 20 30 40"
       }
       "05"
       {
@@ -104,7 +104,7 @@
       "10"
       {
         "var_type"                    "FIELD_INTEGER"
-        "soul_damage_amount"          "25 40 80 160 320"
+        "soul_damage_amount"          "25 40 65 100 145"
       }
       "11"
       {
@@ -119,7 +119,7 @@
       "13"
       {
         "var_type"                    "FIELD_FLOAT"
-        "enemy_hp_drain"              "4"
+        "enemy_hp_drain"              "4 4.25 4.5 4.75 5.0"
       }
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel_2.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_2.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_movement_speed"        "20 22 28 34 40"
+        "bonus_movement_speed"        "20 25 30 35 40"
       }
       "03"
       {
@@ -79,7 +79,7 @@
       "04"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_all_stats"             "2 15 30 45 60"
+        "bonus_all_stats"             "2 10 20 30 40"
       }
       "05"
       {
@@ -109,7 +109,7 @@
       "10"
       {
         "var_type"                    "FIELD_INTEGER"
-        "soul_damage_amount"          "25 40 80 160 320"
+        "soul_damage_amount"          "25 40 65 100 145"
       }
       "11"
       {
@@ -124,7 +124,7 @@
       "13"
       {
         "var_type"                    "FIELD_FLOAT"
-        "enemy_hp_drain"              "4"
+        "enemy_hp_drain"              "4 4.25 4.5 4.75 5.0"
       }
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel_2.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_2.txt
@@ -79,7 +79,7 @@
       "04"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_all_stats"             "2 10 20 30 40"
+        "bonus_all_stats"             "2 15 30 45 60"
       }
       "05"
       {
@@ -124,7 +124,7 @@
       "13"
       {
         "var_type"                    "FIELD_FLOAT"
-        "enemy_hp_drain"              "4 4.25 4.5 4.75 5.0"
+        "enemy_hp_drain"              "4"
       }
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel_3.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_3.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_movement_speed"        "20 22 28 34 40"
+        "bonus_movement_speed"        "20 25 30 35 40"
       }
       "03"
       {
@@ -79,7 +79,7 @@
       "04"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_all_stats"             "2 15 30 45 60"
+        "bonus_all_stats"             "2 10 20 30 40"
       }
       "05"
       {
@@ -109,7 +109,7 @@
       "10"
       {
         "var_type"                    "FIELD_INTEGER"
-        "soul_damage_amount"          "25 40 80 160 320"
+        "soul_damage_amount"          "25 40 65 100 145"
       }
       "11"
       {
@@ -124,7 +124,7 @@
       "13"
       {
         "var_type"                    "FIELD_FLOAT"
-        "enemy_hp_drain"              "4"
+        "enemy_hp_drain"              "4 4.25 4.5 4.75 5.0"
       }
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel_3.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_3.txt
@@ -79,7 +79,7 @@
       "04"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_all_stats"             "2 10 20 30 40"
+        "bonus_all_stats"             "2 15 30 45 60"
       }
       "05"
       {
@@ -124,7 +124,7 @@
       "13"
       {
         "var_type"                    "FIELD_FLOAT"
-        "enemy_hp_drain"              "4 4.25 4.5 4.75 5.0"
+        "enemy_hp_drain"              "4"
       }
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel_4.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_4.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_movement_speed"        "20 22 28 34 40"
+        "bonus_movement_speed"        "20 25 30 35 40"
       }
       "03"
       {
@@ -79,7 +79,7 @@
       "04"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_all_stats"             "2 15 30 45 60"
+        "bonus_all_stats"             "2 10 20 30 40"
       }
       "05"
       {
@@ -109,7 +109,7 @@
       "10"
       {
         "var_type"                    "FIELD_INTEGER"
-        "soul_damage_amount"          "25 40 80 160 320"
+        "soul_damage_amount"          "25 40 65 100 145"
       }
       "11"
       {
@@ -124,7 +124,7 @@
       "13"
       {
         "var_type"                    "FIELD_FLOAT"
-        "enemy_hp_drain"              "4"
+        "enemy_hp_drain"              "4 4.25 4.5 4.75 5.0"
       }
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel_4.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_4.txt
@@ -79,7 +79,7 @@
       "04"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_all_stats"             "2 10 20 30 40"
+        "bonus_all_stats"             "2 15 30 45 60"
       }
       "05"
       {
@@ -124,7 +124,7 @@
       "13"
       {
         "var_type"                    "FIELD_FLOAT"
-        "enemy_hp_drain"              "4 4.25 4.5 4.75 5.0"
+        "enemy_hp_drain"              "4"
       }
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel_5.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_5.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_movement_speed"        "20 22 28 34 40"
+        "bonus_movement_speed"        "20 25 30 35 40"
       }
       "03"
       {
@@ -79,7 +79,7 @@
       "04"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_all_stats"             "2 15 30 45 60"
+        "bonus_all_stats"             "2 10 20 30 40"
       }
       "05"
       {
@@ -109,7 +109,7 @@
       "10"
       {
         "var_type"                    "FIELD_INTEGER"
-        "soul_damage_amount"          "25 40 80 160 320"
+        "soul_damage_amount"          "25 40 65 100 145"
       }
       "11"
       {
@@ -124,7 +124,7 @@
       "13"
       {
         "var_type"                    "FIELD_FLOAT"
-        "enemy_hp_drain"              "4"
+        "enemy_hp_drain"              "4 4.25 4.5 4.75 5.0"
       }
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel_5.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_5.txt
@@ -79,7 +79,7 @@
       "04"
       {
         "var_type"                    "FIELD_INTEGER"
-        "bonus_all_stats"             "2 10 20 30 40"
+        "bonus_all_stats"             "2 15 30 45 60"
       }
       "05"
       {
@@ -124,7 +124,7 @@
       "13"
       {
         "var_type"                    "FIELD_FLOAT"
-        "enemy_hp_drain"              "4 4.25 4.5 4.75 5.0"
+        "enemy_hp_drain"              "4"
       }
     }
   }


### PR DESCRIPTION
After greaves not being mandatory on most heroes, spirit vessel recieved a large indirect buff. Now this item is oppressive allowing any hero to deal high damage. 

Reduced the base damage on spirit vessel. 