### PR TITLE
Dagon Buffs

### DIFF
--- a/game/scripts/npc/items/item_dagon.txt
+++ b/game/scripts/npc/items/item_dagon.txt
@@ -45,7 +45,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "600 650 700 750 800 850 900 950 1000"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 15.0 15.0 13.0 10.0"
+    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 10.0 10.0 10.0 10.0"
     "AbilitySharedCooldown"                               "dagon"
     "MaxUpgradeLevel"                                     "9"
     "ItemBaseLevel"                                       "1"
@@ -68,12 +68,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 18 21 24 27 35 50 70 90"
+        "bonus_intellect"                                 "15 18 21 24 27 40 60 90 130"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "5"
+        "bonus_all_stats"                                 "5 5 5 5 5 10 15 25 30"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_dagon_2.txt
+++ b/game/scripts/npc/items/item_dagon_2.txt
@@ -45,7 +45,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "600 650 700 750 800 850 900 950 1000"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 15.0 15.0 13.0 10.0"
+    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 10.0 10.0 10.0 10.0"
     "AbilitySharedCooldown"                               "dagon"
     "MaxUpgradeLevel"                                     "9"
     "ItemBaseLevel"                                       "2"
@@ -68,12 +68,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 18 21 24 27 35 50 70 90"
+        "bonus_intellect"                                 "15 18 21 24 27 40 60 90 130"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "5"
+        "bonus_all_stats"                                 "5 5 5 5 5 10 15 25 30"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_dagon_3.txt
+++ b/game/scripts/npc/items/item_dagon_3.txt
@@ -45,7 +45,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "600 650 700 750 800 850 900 950 1000"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 15.0 15.0 13.0 10.0"
+    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 10.0 10.0 10.0 10.0"
     "AbilitySharedCooldown"                               "dagon"
     "MaxUpgradeLevel"                                     "9"
     "ItemBaseLevel"                                       "3"
@@ -68,12 +68,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 18 21 24 27 35 50 70 90"
+        "bonus_intellect"                                 "15 18 21 24 27 40 60 90 130"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "5"
+        "bonus_all_stats"                                 "5 5 5 5 5 10 15 25 30"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_dagon_4.txt
+++ b/game/scripts/npc/items/item_dagon_4.txt
@@ -45,7 +45,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "600 650 700 750 800 850 900 950 1000"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 15.0 15.0 13.0 10.0"
+    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 10.0 10.0 10.0 10.0"
     "AbilitySharedCooldown"                               "dagon"
     "MaxUpgradeLevel"                                     "9"
     "ItemBaseLevel"                                       "4"
@@ -68,12 +68,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 18 21 24 27 35 50 70 90"
+        "bonus_intellect"                                 "15 18 21 24 27 40 60 90 130"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "5"
+        "bonus_all_stats"                                 "5 5 5 5 5 10 15 25 30"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_dagon_5.txt
+++ b/game/scripts/npc/items/item_dagon_5.txt
@@ -45,7 +45,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "600 650 700 750 800 850 900 950 1000"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 15.0 15.0 13.0 10.0"
+    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 10.0 10.0 10.0 10.0"
     "AbilitySharedCooldown"                               "dagon"
     "MaxUpgradeLevel"                                     "9"
     "ItemBaseLevel"                                       "5"
@@ -68,12 +68,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 18 21 24 27 35 50 70 90"
+        "bonus_intellect"                                 "15 18 21 24 27 40 60 90 130"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "5"
+        "bonus_all_stats"                                 "5 5 5 5 5 10 15 25 30"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_dagon_6.txt
+++ b/game/scripts/npc/items/item_dagon_6.txt
@@ -46,7 +46,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "600 650 700 750 800 850 900 950 1000"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 15.0 15.0 13.0 10.0"
+    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 10.0 10.0 10.0 10.0"
     "AbilitySharedCooldown"                               "dagon"
     "MaxUpgradeLevel"                                     "9"
     "ItemBaseLevel"                                       "6"
@@ -69,12 +69,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 18 21 24 27 35 50 70 90"
+        "bonus_intellect"                                 "15 18 21 24 27 40 60 90 130"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "5"
+        "bonus_all_stats"                                 "5 5 5 5 5 10 15 25 30"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_dagon_7.txt
+++ b/game/scripts/npc/items/item_dagon_7.txt
@@ -46,7 +46,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "600 650 700 750 800 850 900 950 1000"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 15.0 15.0 13.0 10.0"
+    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 10.0 10.0 10.0 10.0"
     "AbilitySharedCooldown"                               "dagon"
     "MaxUpgradeLevel"                                     "9"
     "ItemBaseLevel"                                       "7"
@@ -69,12 +69,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 18 21 24 27 35 50 70 90"
+        "bonus_intellect"                                 "15 18 21 24 27 40 60 90 130"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "5"
+        "bonus_all_stats"                                 "5 5 5 5 5 10 15 25 30"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_dagon_8.txt
+++ b/game/scripts/npc/items/item_dagon_8.txt
@@ -46,7 +46,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "600 650 700 750 800 850 900 950 1000"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 15.0 15.0 13.0 10.0"
+    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 10.0 10.0 10.0 10.0"
     "AbilitySharedCooldown"                               "dagon"
     "MaxUpgradeLevel"                                     "9"
     "ItemBaseLevel"                                       "8"
@@ -69,12 +69,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 18 21 24 27 35 50 70 90"
+        "bonus_intellect"                                 "15 18 21 24 27 40 60 90 130"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "5"
+        "bonus_all_stats"                                 "5 5 5 5 5 10 15 25 30"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_dagon_9.txt
+++ b/game/scripts/npc/items/item_dagon_9.txt
@@ -46,7 +46,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "600 650 700 750 800 850 900 950 1000"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 15.0 15.0 13.0 10.0"
+    "AbilityCooldown"                                     "35.0 30.0 25.0 20.0 15.0 10.0 10.0 10.0 10.0"
     "AbilitySharedCooldown"                               "dagon"
     "MaxUpgradeLevel"                                     "9"
     "ItemBaseLevel"                                       "9"
@@ -67,12 +67,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 18 21 24 27 35 50 70 90"
+        "bonus_intellect"                                 "15 18 21 24 27 40 60 90 130"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "5"
+        "bonus_all_stats"                                 "5 5 5 5 5 10 15 25 30"
       }
       "03"
       {


### PR DESCRIPTION
Improved the stats that dagon gives considerably. I also decreased the cooldown at OAA levesl to 10 seconds. This should hopefully give the item better DPS and make heroes who buy dagon les squishy (Pugna comes to mind). 