### PR TITLE
Improve boss armour

### DIFF
--- a/game/scripts/npc/units/boss/npc_dota_boss_simple_2.txt
+++ b/game/scripts/npc/units/boss/npc_dota_boss_simple_2.txt
@@ -26,7 +26,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "28"      // Physical protection.
     "MagicalResistance"                                   "-50"      // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/boss/npc_dota_boss_tier_4.txt
+++ b/game/scripts/npc/units/boss/npc_dota_boss_tier_4.txt
@@ -27,7 +27,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"        // Physical protection.
+    "ArmorPhysical"                                       "40"        // Physical protection.
     "MagicalResistance"                                   "-50"        // Magical protection.
 
     // Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/charger/npc_dota_boss_charger_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/charger/npc_dota_boss_charger_tier5.txt
@@ -27,7 +27,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"            // Physical protection.
+    "ArmorPhysical"                                       "40"            // Physical protection.
     "MagicalResistance"                                   "-50"           // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_1_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_1_tier5.txt
@@ -26,7 +26,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "40"      // Physical protection.
     "MagicalResistance"                                   "-50"     // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_2_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_2_tier5.txt
@@ -26,7 +26,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "40"      // Physical protection.
     "MagicalResistance"                                   "-50"      // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_3_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_3_tier5.txt
@@ -25,7 +25,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "40"      // Physical protection.
     "MagicalResistance"                                   "-50"      // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_5_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_5_tier5.txt
@@ -26,7 +26,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "40"      // Physical protection.
     "MagicalResistance"                                   "-50"                  // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_6_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_6_tier5.txt
@@ -25,7 +25,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "40"      // Physical protection.
     "MagicalResistance"                                   "-50"      // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_7_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_7_tier5.txt
@@ -24,7 +24,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "40"      // Physical protection.
     "MagicalResistance"                                   "-50"      // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_tier_1_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_tier_1_tier5.txt
@@ -12,7 +12,7 @@
     "vscripts"                                            "units/ai_simple.lua"
     "SoundSet"                                            "Roshan"          // Name of sound set.
     "ModelScale"                                          "1.5"
-    "Level"                                               "60"
+    "Level"                                               "50"
     "IsAncient"                                           "1"
     "ConsideredHero"                                      "1"
     "UseNeutralCreepBehavior"                             "0"
@@ -28,7 +28,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "40"      // Physical protection.
     "MagicalResistance"                                   "-50"     // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/shielder/npc_dota_boss_shielder_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/shielder/npc_dota_boss_shielder_tier5.txt
@@ -25,7 +25,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"            // Physical protection.
+    "ArmorPhysical"                                       "40"            // Physical protection.
     "MagicalResistance"                                   "-50"           // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_lycan_boss_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_lycan_boss_tier5.txt
@@ -39,7 +39,7 @@
 
 		// Armor
 		//----------------------------------------------------------------
-		"ArmorPhysical"				"25"
+		"ArmorPhysical"				"40"
 		"MagicalResistance"                                   "-50"            // Magical protection.
 
 		// Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_ogre_tank_boss_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_ogre_tank_boss_tier5.txt
@@ -33,7 +33,7 @@
 
 		// Armor
 		//----------------------------------------------------------------
-		"ArmorPhysical"				"25"
+		"ArmorPhysical"				"40"
     "MagicalResistance"                                   "-50"            // Magical protection.
 
 		// Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_spider_boss_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_spider_boss_tier5.txt
@@ -31,7 +31,7 @@
 
 		// Armor
 		//----------------------------------------------------------------
-		"ArmorPhysical"				"25"
+		"ArmorPhysical"				"40"
     "MagicalResistance"                                   "-50"        // Magical protection.
 
 		// Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_temple_guardian_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_temple_guardian_tier5.txt
@@ -35,7 +35,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"        // Physical protection.
+    "ArmorPhysical"                                       "40"        // Physical protection.
     "MagicalResistance"                                   "-50"       // Magical protection.
 
     	// Bounty

--- a/game/scripts/npc/units/boss/tier5_bosses/stopfightingyourself/stopfightingyourself_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/stopfightingyourself/stopfightingyourself_tier5.txt
@@ -22,7 +22,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"               // Physical protection.
+    "ArmorPhysical"                                       "40"               // Physical protection.
     "MagicalResistance"                                   "-50"               // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_dumb_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_dumb_tier5.txt
@@ -25,7 +25,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "40"      // Physical protection.
     "MagicalResistance"                                   "-50"     // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_tier5.txt
@@ -25,7 +25,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "40"      // Physical protection.
     "MagicalResistance"                                   "-50"     // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/carapace/npc_dota_boss_carapace.txt
+++ b/game/scripts/npc/units/carapace/npc_dota_boss_carapace.txt
@@ -27,7 +27,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "28"      // Physical protection.
     "MagicalResistance"                                   "-50"     // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/charger/npc_dota_boss_charger.txt
+++ b/game/scripts/npc/units/charger/npc_dota_boss_charger.txt
@@ -27,7 +27,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"            // Physical protection.
+    "ArmorPhysical"                                       "28"            // Physical protection.
     "MagicalResistance"                                   "-50"           // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/shielder/npc_dota_boss_shielder.txt
+++ b/game/scripts/npc/units/shielder/npc_dota_boss_shielder.txt
@@ -25,7 +25,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"            // Physical protection.
+    "ArmorPhysical"                                       "28"            // Physical protection.
     "MagicalResistance"                                   "-50"           // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/siltbreaker/npc_dota_creature_lycan_boss.txt
+++ b/game/scripts/npc/units/siltbreaker/npc_dota_creature_lycan_boss.txt
@@ -39,7 +39,7 @@
 
     	// Armor
    		//----------------------------------------------------------------
-    	"ArmorPhysical"                                       "25"            // Physical protection.
+    	"ArmorPhysical"                                       "33"            // Physical protection.
     	"MagicalResistance"                                   "-50"           // Magical protection (percentage).
 
 		// Attack

--- a/game/scripts/npc/units/siltbreaker/npc_dota_creature_ogre_tank_boss.txt
+++ b/game/scripts/npc/units/siltbreaker/npc_dota_creature_ogre_tank_boss.txt
@@ -33,7 +33,7 @@
 
 		// Armor
 		//----------------------------------------------------------------
-		"ArmorPhysical"				"25"
+		"ArmorPhysical"				"33"
     	"MagicalResistance"        "-50"            // Magical protection.
 
 		// Attack

--- a/game/scripts/npc/units/siltbreaker/npc_dota_creature_temple_guardian.txt
+++ b/game/scripts/npc/units/siltbreaker/npc_dota_creature_temple_guardian.txt
@@ -35,7 +35,7 @@
 
     	// Armor
     	//----------------------------------------------------------------
-    	"ArmorPhysical"                                       "25"        // Physical protection.
+    	"ArmorPhysical"                                       "40"        // Physical protection.
     	"MagicalResistance"                                   "-50"       // Magical protection.
 
         // Bounty

--- a/game/scripts/npc/units/slime/npc_dota_boss_slime.txt
+++ b/game/scripts/npc/units/slime/npc_dota_boss_slime.txt
@@ -28,7 +28,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "28"      // Physical protection.
     "MagicalResistance"                                   "-50"     // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/spiders/npc_dota_boss_spiders.txt
+++ b/game/scripts/npc/units/spiders/npc_dota_boss_spiders.txt
@@ -27,7 +27,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"            // Physical protection.
+    "ArmorPhysical"                                       "33"            // Physical protection.
     "MagicalResistance"                                   "-50"           // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/stopfightingyourself/stopfightingyourself.txt
+++ b/game/scripts/npc/units/stopfightingyourself/stopfightingyourself.txt
@@ -22,7 +22,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"               // Physical protection.
+    "ArmorPhysical"                                       "40"               // Physical protection.
     "MagicalResistance"                                   "-50"              // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/swiper/npc_dota_boss_swiper.txt
+++ b/game/scripts/npc/units/swiper/npc_dota_boss_swiper.txt
@@ -29,7 +29,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "28"      // Physical protection.
     "MagicalResistance"                                   "-50"     // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/twin/npc_dota_boss_twin.txt
+++ b/game/scripts/npc/units/twin/npc_dota_boss_twin.txt
@@ -25,7 +25,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "28"      // Physical protection.
     "MagicalResistance"                                   "-50"     // Magical protection (percentage).
 
     // Attack

--- a/game/scripts/npc/units/twin/npc_dota_boss_twin_dumb.txt
+++ b/game/scripts/npc/units/twin/npc_dota_boss_twin_dumb.txt
@@ -25,7 +25,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"      // Physical protection.
+    "ArmorPhysical"                                       "28"      // Physical protection.
     "MagicalResistance"                                   "-50"     // Magical protection (percentage).
 
     // Attack


### PR DESCRIPTION
With all the scaling minus armour for items and abilities bosses at later tiers die like paper. Therefore I buffed Boss armour. 

I did:
Tier 2 = 25 + 3 Armour (28 Total)
Tier 3 = 28+ 5 Armour (33 Total)
Tier 4/5 = 33 + 7 Armour (40 Total). 
Hopefully this should make bosses take longer to kill at later levels. This will allow for contesting bosses late game to be a more viable strategy then just boss rushing. This also helps reduce the power of minus armour as bosses will take less physical damage. 

(This armour change might make temples and T5 twins too hard to take, but we will see).  