### PR TITLE
Radiance Adjustment

### DIFF
--- a/game/scripts/npc/items/item_radiance.txt
+++ b/game/scripts/npc/items/item_radiance.txt
@@ -55,17 +55,17 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "65 80 100 125 160"
+        "bonus_damage"                                    "65 80 120 160 200"
       }
       "03" //has to be wrong in this case else dota will get confused
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_damage"                                     "60 90 150 240 360" 
+        "aura_damage"                                     "60 75 150 240 360"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_damage_illusions"                           "35 52 87 140 210"
+        "aura_damage_illusions"                           "35 50 90 140 210"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_radiance_2.txt
+++ b/game/scripts/npc/items/item_radiance_2.txt
@@ -58,17 +58,17 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "65 80 100 125 160"
+        "bonus_damage"                                    "65 80 120 160 200"
       }
       "03" //has to be wrong in this case else dota will get confused
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_damage"                                     "60 90 150 240 360" 
+        "aura_damage"                                     "60 75 150 240 360"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_damage_illusions"                           "35 52 87 140 210"
+        "aura_damage_illusions"                           "35 50 90 140 210"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_radiance_3.txt
+++ b/game/scripts/npc/items/item_radiance_3.txt
@@ -58,17 +58,17 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "65 80 100 125 160"
+        "bonus_damage"                                    "65 80 120 160 200"
       }
       "03" //has to be wrong in this case else dota will get confused
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_damage"                                     "60 90 150 240 360" 
+        "aura_damage"                                     "60 75 150 240 360"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_damage_illusions"                           "35 52 87 140 210"
+        "aura_damage_illusions"                           "35 50 90 140 210"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_radiance_4.txt
+++ b/game/scripts/npc/items/item_radiance_4.txt
@@ -58,17 +58,17 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "65 80 100 125 160"
+        "bonus_damage"                                    "65 80 120 160 200"
       }
       "03" //has to be wrong in this case else dota will get confused
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_damage"                                     "60 90 150 240 360"
+        "aura_damage"                                     "60 75 150 240 360"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_damage_illusions"                           "35 52 87 140 210"
+        "aura_damage_illusions"                           "35 50 90 140 210"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_radiance_5.txt
+++ b/game/scripts/npc/items/item_radiance_5.txt
@@ -57,17 +57,17 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "65 80 100 125 160"
+        "bonus_damage"                                    "65 80 120 160 200"
       }
       "03" //has to be wrong in this case else dota will get confused
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_damage"                                     "60 90 150 240 360"
+        "aura_damage"                                     "60 75 150 240 360"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_damage_illusions"                           "35 52 87 140 210"
+        "aura_damage_illusions"                           "35 50 90 140 210"
       }
       "05"
       {


### PR DESCRIPTION
Nerfed the level 2 Radiance Cheese
Increased the damage this item gives level 3-5. It now matches other items such as desolator and nullifier with 200 damage. This will help improve the items viability on heroes such as spectre (not by much but more damage is more damage). 