### PR TITLE
Omniknight buffs

### DIFF
--- a/game/scripts/npc/abilities/omniknight_degen_aura.txt
+++ b/game/scripts/npc/abilities/omniknight_degen_aura.txt
@@ -29,7 +29,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "attack_bonus_tooltip"                            "-10 -18 -26 -34 -46 -85"
+        "attack_bonus_tooltip"                            "-10 -18 -26 -34 -68 -102"
         "LinkedSpecialBonus"                              "special_bonus_unique_omniknight_2"
       }
       "03"
@@ -37,7 +37,7 @@
         "var_type"                                        "FIELD_INTEGER"
         "radius"                                          "300"
       }
-      
+
     }
   }
 }

--- a/game/scripts/npc/abilities/omniknight_guardian_angel.txt
+++ b/game/scripts/npc/abilities/omniknight_guardian_angel.txt
@@ -22,7 +22,7 @@
 
     // Time
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "160 150 140 130 120"
+    "AbilityCooldown"                                     "120" //OAA
     "AbilityCastPoint"                                    "0.4"
 
     // Cost
@@ -36,7 +36,7 @@
       "01"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "duration"                                        "4.0 4.5 5.0 5.5 6.0" //OAA
+        "duration"                                        "5.0 5.5 6.0 6.5 7.0" //OAA
       }
       "02"
       {
@@ -46,7 +46,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "duration_scepter"                                "5.0 5.5 6.0 6.5 7.0" //OAA
+        "duration_scepter"                                "6.0 6.5 7.0 7.5 8.0" //OAA
         "RequiresScepter"                                 "1"
       }
       "04"

--- a/game/scripts/npc/heroes/omniknight.txt
+++ b/game/scripts/npc/heroes/omniknight.txt
@@ -7,7 +7,7 @@
   {
     // Abilities
     //-------------------------------------------------------------------------------------------------------------
-    "Ability10"   "special_bonus_armor_4" // replaces special_bonus_gold_income_90
+    "Ability10"   "special_bonus_armor_5" // replaces special_bonus_gold_income_90
     "Ability12"   "special_bonus_mp_regen_4" // replaces special_bonus_exp_boost_35
     "Ability15"   "special_bonus_all_stats_12" // replaces special_bonus_mp_regen_4
   }


### PR DESCRIPTION
Buffed Omniknights ultimate duration and set its cooldown to 120 seconds at all levels. This ultimate is currently completely useless.

Increased Degen Aura attack speed slow to something more noticeable. 
Improved his level 10 armour talent. 

Also why is Omni's W so nerfed? was this before the STR change and it gave around 90% status resitance.

#makeomnigreatagain