### PR TITLE
Butterfly and Diffusal Blade Changes

### DIFF
--- a/game/scripts/npc/items/item_butterfly.txt
+++ b/game/scripts/npc/items/item_butterfly.txt
@@ -56,7 +56,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 30 55 90 135"
+        "bonus_damage"                                    "25 30 45 70 105"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_butterfly.txt
+++ b/game/scripts/npc/items/item_butterfly.txt
@@ -51,7 +51,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "35 40 50 65 85"
+        "bonus_agility"                                   "35 40 50 70 90"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_butterfly.txt
+++ b/game/scripts/npc/items/item_butterfly.txt
@@ -56,17 +56,17 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 33 41 50 60"
+        "bonus_damage"                                    "25 30 55 90 135"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_evasion"                                   "20 25 30 35 35" //OAA
+        "bonus_evasion"                                   "35 40 45 50 55"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "20 25 35 45 55"	//OAA
+        "bonus_attack_speed"                              "25 30 35 40 45"
       }
     }
   }

--- a/game/scripts/npc/items/item_butterfly_2.txt
+++ b/game/scripts/npc/items/item_butterfly_2.txt
@@ -60,7 +60,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 30 55 90 135"
+        "bonus_damage"                                    "25 30 45 70 105"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_butterfly_2.txt
+++ b/game/scripts/npc/items/item_butterfly_2.txt
@@ -55,7 +55,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "35 40 50 65 85"
+        "bonus_agility"                                   "35 40 50 70 90"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_butterfly_2.txt
+++ b/game/scripts/npc/items/item_butterfly_2.txt
@@ -17,7 +17,7 @@
     "ItemCost"                                            "1500"
     "ItemRequirements"
     {
-      "01"                                                "item_diffusal_blade;item_upgrade_core"
+      "01"                                                "item_butterfly;item_upgrade_core"
     }
   }
 
@@ -60,17 +60,17 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 33 41 50 60"
+        "bonus_damage"                                    "25 30 55 90 135"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_evasion"                                   "20 25 30 35 35" //OAA
+        "bonus_evasion"                                   "35 40 45 50 55"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "20 25 35 45 55"	//OAA
+        "bonus_attack_speed"                              "25 30 35 40 45"
       }
     }
   }

--- a/game/scripts/npc/items/item_butterfly_3.txt
+++ b/game/scripts/npc/items/item_butterfly_3.txt
@@ -60,7 +60,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 30 55 90 135"
+        "bonus_damage"                                    "25 30 45 70 105"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_butterfly_3.txt
+++ b/game/scripts/npc/items/item_butterfly_3.txt
@@ -55,7 +55,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "35 40 50 65 85"
+        "bonus_agility"                                   "35 40 50 70 90"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_butterfly_3.txt
+++ b/game/scripts/npc/items/item_butterfly_3.txt
@@ -18,7 +18,6 @@
     "ItemRequirements"
     {
       "01"                                                "item_butterfly_2;item_upgrade_core_2"
-      "02"                                                "item_diffusal_blade_2;item_upgrade_core_2"
     }
   }
 
@@ -61,17 +60,17 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 33 41 50 60"
+        "bonus_damage"                                    "25 30 55 90 135"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_evasion"                                   "20 25 30 35 35" //OAA
+        "bonus_evasion"                                   "35 40 45 50 55"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "20 25 35 45 55"	//OAA
+        "bonus_attack_speed"                              "25 30 35 40 45"
       }
     }
   }

--- a/game/scripts/npc/items/item_butterfly_4.txt
+++ b/game/scripts/npc/items/item_butterfly_4.txt
@@ -60,7 +60,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 30 55 90 135"
+        "bonus_damage"                                    "25 30 45 70 105"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_butterfly_4.txt
+++ b/game/scripts/npc/items/item_butterfly_4.txt
@@ -55,7 +55,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "35 40 50 65 85"
+        "bonus_agility"                                   "35 40 50 70 90"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_butterfly_4.txt
+++ b/game/scripts/npc/items/item_butterfly_4.txt
@@ -18,7 +18,6 @@
     "ItemRequirements"
     {
       "01"                                                "item_butterfly_3;item_upgrade_core_3"
-      "02"                                                "item_diffusal_blade_3;item_upgrade_core_3"
     }
   }
 
@@ -61,17 +60,17 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 33 41 50 60"
+        "bonus_damage"                                    "25 30 55 90 135"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_evasion"                                   "20 25 30 35 35" //OAA
+        "bonus_evasion"                                   "35 40 45 50 55"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "20 25 35 45 55"	//OAA
+        "bonus_attack_speed"                              "25 30 35 40 45"
       }
     }
   }

--- a/game/scripts/npc/items/item_butterfly_5.txt
+++ b/game/scripts/npc/items/item_butterfly_5.txt
@@ -60,7 +60,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 30 55 90 135"
+        "bonus_damage"                                    "25 30 45 70 105"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_butterfly_5.txt
+++ b/game/scripts/npc/items/item_butterfly_5.txt
@@ -55,7 +55,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "35 40 50 65 85"
+        "bonus_agility"                                   "35 40 50 70 90"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_butterfly_5.txt
+++ b/game/scripts/npc/items/item_butterfly_5.txt
@@ -18,7 +18,6 @@
     "ItemRequirements"
     {
       "01"                                                "item_butterfly_4;item_upgrade_core_4"
-      "02"                                                "item_diffusal_blade_4;item_upgrade_core_4"
     }
   }
 
@@ -61,17 +60,17 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 33 41 50 60"
+        "bonus_damage"                                    "25 30 55 90 135"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_evasion"                                   "20 25 30 35 35" //OAA
+        "bonus_evasion"                                   "35 40 45 50 55"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "20 25 35 45 55"	//OAA
+        "bonus_attack_speed"                              "25 30 35 40 45"
       }
     }
   }

--- a/game/scripts/npc/items/item_diffusal_blade.txt
+++ b/game/scripts/npc/items/item_diffusal_blade.txt
@@ -72,7 +72,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 15 25 35 50"
+        "bonus_intellect"                                 "10 20 30 40 50"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_diffusal_blade_2.txt
+++ b/game/scripts/npc/items/item_diffusal_blade_2.txt
@@ -74,7 +74,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 15 25 35 50"
+        "bonus_intellect"                                 "10 20 30 40 50"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_diffusal_blade_3.txt
+++ b/game/scripts/npc/items/item_diffusal_blade_3.txt
@@ -24,7 +24,6 @@
     "ItemRequirements"
     {
       "01"                                                "item_diffusal_blade_2;item_upgrade_core_2"
-      "02"                                                "item_butterfly_2;item_upgrade_core_2"
     }
   }
 
@@ -75,7 +74,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 15 25 35 50"
+        "bonus_intellect"                                 "10 20 30 40 50"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_diffusal_blade_4.txt
+++ b/game/scripts/npc/items/item_diffusal_blade_4.txt
@@ -24,7 +24,6 @@
     "ItemRequirements"
     {
       "01"                                                "item_diffusal_blade_3;item_upgrade_core_3"
-      "02"                                                "item_butterfly_3;item_upgrade_core_3"
     }
   }
 
@@ -75,7 +74,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 15 25 35 50"
+        "bonus_intellect"                                 "10 20 30 40 50"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_diffusal_blade_5.txt
+++ b/game/scripts/npc/items/item_diffusal_blade_5.txt
@@ -24,7 +24,6 @@
     "ItemRequirements"
     {
       "01"                                                "item_diffusal_blade_4;item_upgrade_core_4"
-      "02"                                                "item_butterfly_4;item_upgrade_core_4"
     }
   }
 
@@ -75,7 +74,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 15 25 35 50"
+        "bonus_intellect"                                 "10 20 30 40 50"
       }
       "03"
       {

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -622,7 +622,6 @@
   "item_helm_of_the_dominator"    "REMOVE"
   "item_refresher"                "REMOVE"
   "item_glimmer_cape"             "REMOVE"
-  "item_butterfly"                "REMOVE"
   "item_bfury"                    "REMOVE"
   "item_abyssal_blade"            "REMOVE"
   "item_mask_of_madness"          "REMOVE"

--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -213,7 +213,7 @@
 #base "items/item_broadsword.txt"
 #base "items/item_boots.txt"
 #base "items/item_boots_of_elves.txt"
-// #base "items/item_butterfly.txt"
+#base "items/item_butterfly.txt"
 #base "items/item_butterfly_2.txt"
 #base "items/item_butterfly_3.txt"
 #base "items/item_butterfly_4.txt"

--- a/game/scripts/shops/captains_mode_shops.txt
+++ b/game/scripts/shops/captains_mode_shops.txt
@@ -201,7 +201,7 @@
     "item"                                                "item_hurricane_pike"
     "item"                                                "item_giant_form"
     "item"                                                "item_diffusal_blade"
-    "item"                                                "item_butterfly_2"
+    "item"                                                "item_butterfly"
     "item"                                                "item_skadi"
     "item"                                                "item_abyssal_blade_3"
     "item"                                                "item_trumps_fists"

--- a/game/scripts/shops/oaa_shops.txt
+++ b/game/scripts/shops/oaa_shops.txt
@@ -201,7 +201,7 @@
     "item"                                                "item_hurricane_pike"
     "item"                                                "item_giant_form"
     "item"                                                "item_diffusal_blade"
-    "item"                                                "item_butterfly_2"
+    "item"                                                "item_butterfly"
     "item"                                                "item_skadi"
     "item"                                                "item_abyssal_blade_3"
     "item"                                                "item_trumps_fists"


### PR DESCRIPTION
Butterfly is one of the worst items in the game.

Butterfly can now be purchased level 1. (The only issue with this item may be 35% evasion at level 1 but with GPM spark you can get MKB after 2 minutes.)

Butterfly is no longer a part of the diffusal blade tree. This solves the issue of level 2 butterfly being far too good because it doesnt cost 4.5k gold anymore. This also means if you buy a butterfly you have to hard commit to it. (Evasion is better now after the true strike changes.) 

All of butterflys stats have been bufffed. Same attack speed at level 5 (more agi less attack speed). Damage has been increased heavily. This makes the item better to commit to even after the evasion becomes less useful. 

Diffusal Blade Intelligence has been increased levels 2-4. 


