### PR TITLE
Ward Stack changes

### DIFF
--- a/game/scripts/npc/items/custom/item_ward_stack.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack.txt
@@ -90,15 +90,15 @@
         "var_type"                                        "FIELD_FLOAT"
         "aura_mana_regen"                                 "1.25 2.0 3.0 4.0 5.0"
       }
-      "06"
+      "06" // dota observer ward: 360
       {
         "var_type"                                        "FIELD_INTEGER"
         "observer_duration"                               "180"
       }
-      "07"
+      "07" // dota sentry ward: 480
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_duration"                                 "180"
+        "sentry_duration"                                 "240"
       }
       "08"
       {
@@ -128,7 +128,7 @@
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_recharge"                                 "80 60 50 40 30"
+        "sentry_recharge"                                 "90 65 50 40 30"
       }
       "14"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack.txt
@@ -88,7 +88,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.25 2.0 3.0 4.0 5.0"
+        "aura_mana_regen"                                 "1.4 2.0 3.0 4.0 5.0"
       }
       "06" // dota observer ward: 360
       {

--- a/game/scripts/npc/items/custom/item_ward_stack.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack.txt
@@ -108,7 +108,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_vision_radius"                            "150"
+        "sentry_radius"                                   "150"
       }
       "10"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_2.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_2.txt
@@ -98,7 +98,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_duration"                                 "180"
+        "sentry_duration"                                 "240"
       }
       "08"
       {
@@ -128,7 +128,7 @@
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_recharge"                                 "80 60 50 40 30"
+        "sentry_recharge"                                 "90 65 50 40 30"
       }
       "14"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_2.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_2.txt
@@ -108,7 +108,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_vision_radius"                            "150"
+        "sentry_radius"                                   "150"
       }
       "10"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_2.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_2.txt
@@ -88,7 +88,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.25 2.0 3.0 4.0 5.0"
+        "aura_mana_regen"                                 "1.4 2.0 3.0 4.0 5.0"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_3.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_3.txt
@@ -92,7 +92,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.25 2.0 3.0 4.0 5.0"
+        "aura_mana_regen"                                 "1.4 2.0 3.0 4.0 5.0"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_3.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_3.txt
@@ -102,7 +102,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_duration"                                 "180"
+        "sentry_duration"                                 "240"
       }
       "08"
       {
@@ -132,7 +132,7 @@
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_recharge"                                 "80 60 50 40 30"
+        "sentry_recharge"                                 "90 65 50 40 30"
       }
       "14"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_3.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_3.txt
@@ -112,7 +112,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_vision_radius"                            "150"
+        "sentry_radius"                                   "150"
       }
       "10"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_4.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_4.txt
@@ -111,7 +111,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_vision_radius"                            "150"
+        "sentry_radius"                                   "150"
       }
       "10"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_4.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_4.txt
@@ -101,7 +101,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_duration"                                 "180"
+        "sentry_duration"                                 "240"
       }
       "08"
       {
@@ -131,7 +131,7 @@
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_recharge"                                 "80 60 50 40 30"
+        "sentry_recharge"                                 "90 65 50 40 30"
       }
       "14"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_4.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_4.txt
@@ -91,7 +91,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.25 2.0 3.0 4.0 5.0"
+        "aura_mana_regen"                                 "1.4 2.0 3.0 4.0 5.0"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_5.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_5.txt
@@ -111,7 +111,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_vision_radius"                            "150"
+        "sentry_radius"                                   "150"
       }
       "10"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_5.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_5.txt
@@ -101,7 +101,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_duration"                                 "180"
+        "sentry_duration"                                 "240"
       }
       "08"
       {
@@ -131,7 +131,7 @@
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sentry_recharge"                                 "80 60 50 40 30"
+        "sentry_recharge"                                 "90 65 50 40 30"
       }
       "14"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_5.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_5.txt
@@ -91,7 +91,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.25 2.0 3.0 4.0 5.0"
+        "aura_mana_regen"                                 "1.4 2.0 3.0 4.0 5.0"
       }
       "06"
       {

--- a/game/scripts/vscripts/items/ward_stack.lua
+++ b/game/scripts/vscripts/items/ward_stack.lua
@@ -134,6 +134,22 @@ if not IsServer() then
       return "item_branches"
     end
   end
+
+  function item_ward_stack:GetAOERadius()
+    local wardType = self.lastType or WARD_TYPE_OBSERVER
+    if self.mod and not self.mod:IsNull() then
+      wardType = self.mod:GetStackCount()
+    end
+    if wardType == WARD_TYPE_OBSERVER or wardType == WARD_TYPE_OBSERVER_ONLY then
+      -- observer radius
+      return self:GetSpecialValueFor("observer_radius")
+    elseif wardType == WARD_TYPE_SENTRY or wardType == WARD_TYPE_SENTRY_ONLY then
+      -- sentry radius
+      return self:GetSpecialValueFor("sentry_reveal_radius")
+    else
+      return 0
+    end
+  end
 end
 
 function item_ward_stack:CastFilterResultTarget (unit)

--- a/game/scripts/vscripts/items/ward_stack.lua
+++ b/game/scripts/vscripts/items/ward_stack.lua
@@ -74,6 +74,9 @@ if IsServer() then
       duration = self:GetSpecialValueFor(wardType .. '_duration')
     })
 
+    ward:SetDayTimeVisionRange(self:GetSpecialValueFor(wardType .. '_radius'))
+    ward:SetNightTimeVisionRange(self:GetSpecialValueFor(wardType .. '_radius'))
+
     caster[wardType .. 'Count'] = caster[wardType .. 'Count'] - 1
     if caster[wardType .. 'Count'] == 0 then
       self:ToggleType()


### PR DESCRIPTION
* Aura mana regeneration increased at level 1 from 1.25 to 1.4 (to match Ring of Basilius)
* Sentry duration increased from 180 to 240 seconds.
* Sentry recharge (restock) time increased at levels 1-2 from 80/60 to 90/65 seconds.
* Sentry Wards now give 150 radius ground vision (like before patch 6.79).
* Fixed Ward Stack AoE particle not showing when using it. Its still not the same as in normal dota (in normal dota it shows obstructions that block vision) but its still better than nothing.
* Observer Wards now correctly give 1400 vision instead of 1600 (like it was stated in patch 7.25).