### PR TITLE
AI improvements of simple bosses

### DIFF
--- a/game/scripts/vscripts/units/ai_simple.lua
+++ b/game/scripts/vscripts/units/ai_simple.lua
@@ -39,17 +39,7 @@ function SimpleBossThink()
       --thisEntity:SetAcquisitionRange(128) -- It seems this is not helping
       local nearby_enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, bit.bor(DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE), FIND_CLOSEST, false)
       if #nearby_enemies == 0 then
-        nearby_enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, 3*SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, bit.bor(DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE), FIND_CLOSEST, false)
-      end
-      -- Filter out couriers and invisible units
-      if #nearby_enemies ~= 0 then
-        for i=1,#nearby_enemies do
-          if nearby_enemies[i] then
-            if nearby_enemies[i]:IsCourier() or nearby_enemies[i]:IsInvisible() then
-              table.remove(nearby_enemies,i)
-            end
-          end
-        end
+        nearby_enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, 3*SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_CLOSEST, false)
       end
       -- Find nearest enemy that a boss can attack and assign it as aggro_target
       local nearest_enemy
@@ -64,7 +54,7 @@ function SimpleBossThink()
           Queue = 0,
         })
       end
-      thisEntity.aggro_target = nearest_enemy
+      --thisEntity.aggro_target = nearest_enemy
       thisEntity.state = SIMPLE_AI_STATE_AGGRO
     else
       -- Check if the boss was messed around with displacing abilities (Force Staff for example)
@@ -78,23 +68,35 @@ function SimpleBossThink()
     -- Check how far did the boss go from the spawn position
     if (thisEntity:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > SIMPLE_BOSS_LEASH_SIZE then
       -- Remove aggro_target if boss goes outside of leash range
-      if thisEntity.aggro_target then
-        thisEntity.aggro_target = nil
+      --if thisEntity.aggro_target then
+        --thisEntity.aggro_target = nil
+      --end
+      thisEntity.aggro_target = thisEntity:GetAggroTarget()
+      print(thisEntity:GetAggroTarget())
+      if thisEntity.aggro_target and not thisEntity.aggro_target:IsNull() then
+        print(thisEntity.aggro_target:GetUnitName())
+        if (thisEntity.aggro_target:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > SIMPLE_BOSS_LEASH_SIZE then
+          if thisEntity.aggro_target:GetAttackRange() <= SIMPLE_BOSS_LEASH_SIZE then
+            thisEntity.aggro_target = nil
+          end
+        end
       end
       -- Find units that attacked the boss outside of leash range (Sniper and other high attack range units)
-      local enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, 3*SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, bit.bor(DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE), FIND_CLOSEST, false)
-      if #enemies ~=0 then
-        for i=1,#enemies do
+      --[[
+      local enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, 3*SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_CLOSEST, false)
+      if #enemies ~= 0 then
+        for i = 1, #enemies do
           local enemy = enemies[i]
-          if enemy:IsAttackingEntity(thisEntity) and enemy:GetAttackRange() > SIMPLE_BOSS_LEASH_SIZE then
+          if enemy:IsAttackingEntity(thisEntity) and enemy:GetAttackRange() >= SIMPLE_BOSS_LEASH_SIZE then
             thisEntity.aggro_target = enemy
             break
           end
         end
       else
         -- No enemies so no need for aggro_target
-        thisEntity.aggro_target = nil
+        --thisEntity.aggro_target = nil
       end
+      ]]
     end
 
     -- Check if aggro_target exists
@@ -105,12 +107,12 @@ function SimpleBossThink()
         return 1
       end
       -- Check if aggro_target is dead or attack immune (ethereal) or a courier or invisible
-      if thisEntity.aggro_target:IsAlive() and not thisEntity.aggro_target:IsAttackImmune() and not thisEntity.aggro_target:IsCourier() and not thisEntity.aggro_target:IsInvisible() then
-        thisEntity:MoveToTargetToAttack(thisEntity.aggro_target)
-      else
+      --if thisEntity.aggro_target:IsAlive() and not thisEntity.aggro_target:IsAttackImmune() and not thisEntity.aggro_target:IsCourier() and not thisEntity.aggro_target:IsInvisible() then
+        --thisEntity:MoveToTargetToAttack(thisEntity.aggro_target)
+      --else
         -- Don't try to attack dead units, attack-immune units, invisible units or couriers
-        thisEntity.aggro_target = nil
-      end
+        --thisEntity.aggro_target = nil
+      --end
     else
       -- Boss goes back angry (attack-moving to the spawn position) because he can't attack
       ExecuteOrderFromTable({

--- a/game/scripts/vscripts/units/ai_simple.lua
+++ b/game/scripts/vscripts/units/ai_simple.lua
@@ -43,7 +43,6 @@ function SimpleBossThink()
         end
       end
     end
-
     nearby_enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, 3*SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_CLOSEST, false)
     if #nearby_enemies ~= 0 then
       for i = 1, #nearby_enemies do
@@ -55,10 +54,9 @@ function SimpleBossThink()
         end
       end
     end
-
     return nil
   end
-  
+
   local function AttackNearestTarget(thisEntity)
     local nearest_enemy = FindNearestAttackableUnit(thisEntity)
     if nearest_enemy then
@@ -71,7 +69,7 @@ function SimpleBossThink()
     end
     thisEntity.aggro_target = nearest_enemy
   end
-  
+
   local function StartLeashing(thisEntity)
     thisEntity.aggro_target = nil
     thisEntity.state = SIMPLE_AI_STATE_LEASH
@@ -82,11 +80,8 @@ function SimpleBossThink()
     local current_hp_pct = thisEntity:GetHealth()/thisEntity:GetMaxHealth()
     local aggro_hp_pct = SIMPLE_BOSS_AGGRO_HP_PERCENT/100
     if current_hp_pct < aggro_hp_pct then
-      --thisEntity:SetIdleAcquire(true)     -- It seems this is not helping
-      --thisEntity:SetAcquisitionRange(128) -- It seems this is not helping
-
       -- Issue an attack-move command towards the nearast unit that is attackable and assign it as aggro_target.
-      -- Because of attack priorities (wards have the lowest attack priority) aggro_target will not always be 
+      -- Because of attack priorities (wards have the lowest attack priority) aggro_target will not always be
       -- the same as true aggro target (unit that is boss actually attacking at the moment)
       AttackNearestTarget(thisEntity)
       thisEntity.state = SIMPLE_AI_STATE_AGGRO
@@ -121,23 +116,23 @@ function SimpleBossThink()
     -- Check if aggro_target exists
     if thisEntity.aggro_target then
       --print(thisEntity.aggro_target:GetUnitName())
-	  -- Check if aggro_target is getting deleted soon from c++
+      -- Check if aggro_target is getting deleted soon from c++
       if thisEntity.aggro_target:IsNull() then
         thisEntity.aggro_target = nil
       end
       -- Check if state of aggro_target changed (died, became attack immune (ethereal), became invulnerable or banished)
-	  local aggro_target = thisEntity.aggro_target
+      local aggro_target = thisEntity.aggro_target
       if not aggro_target:IsAlive() or aggro_target:IsAttackImmune() or aggro_target:IsInvulnerable() or aggro_target:IsOutOfGame() then
-	    thisEntity.aggro_target = nil
-	  end
+        thisEntity.aggro_target = nil
+      end
       -- Check if aggro_target is out of aggro/leash range
       if (aggro_target:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > 2*SIMPLE_BOSS_LEASH_SIZE then
         thisEntity.aggro_target = nil
       elseif (aggro_target:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > SIMPLE_BOSS_LEASH_SIZE then
         -- Check aggro_target attack range, if its less than leash/aggro range
-		if aggro_target:GetAttackRange() <= SIMPLE_BOSS_LEASH_SIZE then
+        if aggro_target:GetAttackRange() <= SIMPLE_BOSS_LEASH_SIZE then
           thisEntity.aggro_target = nil
-		end
+        end
       end
       -- Check HP of the boss
       local current_hp_pct = thisEntity:GetHealth()/thisEntity:GetMaxHealth()
@@ -159,7 +154,7 @@ function SimpleBossThink()
         AttackNearestTarget(thisEntity)
       end
 
-	  if not thisEntity.aggro_target then
+      if not thisEntity.aggro_target then
         thisEntity.state = SIMPLE_AI_STATE_LEASH
       end
     end

--- a/game/scripts/vscripts/units/ai_simple.lua
+++ b/game/scripts/vscripts/units/ai_simple.lua
@@ -31,30 +31,64 @@ function SimpleBossThink()
     thisEntity.initialized = true
   end
 
+  local function FindNearestAttackableUnit(thisEntity)
+    local nearby_enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, bit.bor(DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE), FIND_CLOSEST, false)
+    if #nearby_enemies ~= 0 then
+      for i = 1, #nearby_enemies do
+        local enemy = nearby_enemies[i]
+        if enemy and not enemy:IsNull() then
+          if enemy:IsAlive() and not enemy:IsAttackImmune() and not enemy:IsInvulnerable() and not enemy:IsOutOfGame() and not enemy:HasModifier("modifier_item_buff_ward") and not enemy:IsCourier() then
+            return enemy
+          end
+        end
+      end
+    end
+
+    nearby_enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, 3*SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_CLOSEST, false)
+    if #nearby_enemies ~= 0 then
+      for i = 1, #nearby_enemies do
+        local enemy = nearby_enemies[i]
+        if enemy and not enemy:IsNull() then
+          if enemy:IsAlive() and not enemy:IsAttackImmune() and not enemy:IsInvulnerable() and not enemy:IsOutOfGame() and not enemy:HasModifier("modifier_item_buff_ward") and not enemy:IsCourier() and enemy:GetAttackRange() > SIMPLE_BOSS_LEASH_SIZE and (enemy:GetAbsOrigin() - thisEntity.spawn_position):Length2D() < 2*SIMPLE_BOSS_LEASH_SIZE then
+            return enemy
+          end
+        end
+      end
+    end
+
+    return nil
+  end
+  
+  local function AttackNearestTarget(thisEntity)
+    local nearest_enemy = FindNearestAttackableUnit(thisEntity)
+    if nearest_enemy then
+      ExecuteOrderFromTable({
+        UnitIndex = thisEntity:entindex(),
+        OrderType = DOTA_UNIT_ORDER_ATTACK_MOVE,
+        Position = nearest_enemy:GetAbsOrigin(),
+        Queue = 0,
+      })
+    end
+    thisEntity.aggro_target = nearest_enemy
+  end
+  
+  local function StartLeashing(thisEntity)
+    thisEntity.aggro_target = nil
+    thisEntity.state = SIMPLE_AI_STATE_LEASH
+    return 1
+  end
+
   if thisEntity.state == SIMPLE_AI_STATE_IDLE then
     local current_hp_pct = thisEntity:GetHealth()/thisEntity:GetMaxHealth()
     local aggro_hp_pct = SIMPLE_BOSS_AGGRO_HP_PERCENT/100
     if current_hp_pct < aggro_hp_pct then
       --thisEntity:SetIdleAcquire(true)     -- It seems this is not helping
       --thisEntity:SetAcquisitionRange(128) -- It seems this is not helping
-      local nearby_enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, bit.bor(DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE), FIND_CLOSEST, false)
-      if #nearby_enemies == 0 then
-        nearby_enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, 3*SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_CLOSEST, false)
-      end
-      -- Find nearest enemy that a boss can attack and assign it as aggro_target
-      local nearest_enemy
-      if #nearby_enemies ~= 0 then
-        nearest_enemy = nearby_enemies[1]
-      end
-      if nearest_enemy then
-        ExecuteOrderFromTable({
-          UnitIndex = thisEntity:entindex(),
-          OrderType = DOTA_UNIT_ORDER_ATTACK_MOVE,
-          Position = nearest_enemy:GetAbsOrigin(),
-          Queue = 0,
-        })
-      end
-      --thisEntity.aggro_target = nearest_enemy
+
+      -- Issue an attack-move command towards the nearast unit that is attackable and assign it as aggro_target.
+      -- Because of attack priorities (wards have the lowest attack priority) aggro_target will not always be 
+      -- the same as true aggro target (unit that is boss actually attacking at the moment)
+      AttackNearestTarget(thisEntity)
       thisEntity.state = SIMPLE_AI_STATE_AGGRO
     else
       -- Check if the boss was messed around with displacing abilities (Force Staff for example)
@@ -64,68 +98,72 @@ function SimpleBossThink()
       end
     end
   elseif thisEntity.state == SIMPLE_AI_STATE_AGGRO then
-    --print("AGGRO STATE")
     -- Check how far did the boss go from the spawn position
     if (thisEntity:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > SIMPLE_BOSS_LEASH_SIZE then
-      -- Remove aggro_target if boss goes outside of leash range
-      --if thisEntity.aggro_target then
-        --thisEntity.aggro_target = nil
-      --end
-      thisEntity.aggro_target = thisEntity:GetAggroTarget()
-      print(thisEntity:GetAggroTarget())
-      if thisEntity.aggro_target and not thisEntity.aggro_target:IsNull() then
-        print(thisEntity.aggro_target:GetUnitName())
-        if (thisEntity.aggro_target:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > SIMPLE_BOSS_LEASH_SIZE then
-          if thisEntity.aggro_target:GetAttackRange() <= SIMPLE_BOSS_LEASH_SIZE then
-            thisEntity.aggro_target = nil
-          end
-        end
-      end
-      -- Find units that attacked the boss outside of leash range (Sniper and other high attack range units)
-      --[[
-      local enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, 3*SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_CLOSEST, false)
-      if #enemies ~= 0 then
-        for i = 1, #enemies do
-          local enemy = enemies[i]
-          if enemy:IsAttackingEntity(thisEntity) and enemy:GetAttackRange() >= SIMPLE_BOSS_LEASH_SIZE then
-            thisEntity.aggro_target = enemy
-            break
+      -- Check for actual aggro target
+      if thisEntity:GetAggroTarget() and not thisEntity:GetAggroTarget():IsNull() then
+        local true_aggro_target = thisEntity:GetAggroTarget()
+        -- Prevent bosses chasing Snipers all over the map (its funny though)
+        if (true_aggro_target:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > 2*SIMPLE_BOSS_LEASH_SIZE then
+          return StartLeashing(thisEntity)
+        elseif (true_aggro_target:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > SIMPLE_BOSS_LEASH_SIZE then
+          -- Check attack range of true aggro target, if its less than leash/aggro range, start leashing
+          if true_aggro_target:GetAttackRange() <= SIMPLE_BOSS_LEASH_SIZE then
+            return StartLeashing(thisEntity)
           end
         end
       else
-        -- No enemies so no need for aggro_target
-        --thisEntity.aggro_target = nil
+        -- Boss is outside of leash range and the unit he was attacking doesnt exist, start leashing
+        return StartLeashing(thisEntity)
       end
-      ]]
     end
 
     -- Check if aggro_target exists
     if thisEntity.aggro_target then
-      -- Check if aggro_target is getting deleted soon from c++
+      --print(thisEntity.aggro_target:GetUnitName())
+	  -- Check if aggro_target is getting deleted soon from c++
       if thisEntity.aggro_target:IsNull() then
         thisEntity.aggro_target = nil
-        return 1
       end
-      -- Check if aggro_target is dead or attack immune (ethereal) or a courier or invisible
-      --if thisEntity.aggro_target:IsAlive() and not thisEntity.aggro_target:IsAttackImmune() and not thisEntity.aggro_target:IsCourier() and not thisEntity.aggro_target:IsInvisible() then
-        --thisEntity:MoveToTargetToAttack(thisEntity.aggro_target)
-      --else
-        -- Don't try to attack dead units, attack-immune units, invisible units or couriers
-        --thisEntity.aggro_target = nil
-      --end
+      -- Check if state of aggro_target changed (died, became attack immune (ethereal), became invulnerable or banished)
+	  local aggro_target = thisEntity.aggro_target
+      if not aggro_target:IsAlive() or aggro_target:IsAttackImmune() or aggro_target:IsInvulnerable() or aggro_target:IsOutOfGame() then
+	    thisEntity.aggro_target = nil
+	  end
+      -- Check if aggro_target is out of aggro/leash range
+      if (aggro_target:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > 2*SIMPLE_BOSS_LEASH_SIZE then
+        thisEntity.aggro_target = nil
+      elseif (aggro_target:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > SIMPLE_BOSS_LEASH_SIZE then
+        -- Check aggro_target attack range, if its less than leash/aggro range
+		if aggro_target:GetAttackRange() <= SIMPLE_BOSS_LEASH_SIZE then
+          thisEntity.aggro_target = nil
+		end
+      end
+      -- Check HP of the boss
+      local current_hp_pct = thisEntity:GetHealth()/thisEntity:GetMaxHealth()
+      local aggro_hp_pct = SIMPLE_BOSS_AGGRO_HP_PERCENT/100
+      if current_hp_pct > aggro_hp_pct then
+        thisEntity.aggro_target = nil
+      end
+      -- Check if boss is stuck or idle because actual aggro target doesn't exist.
+      if not thisEntity:GetAggroTarget() or thisEntity:IsIdle() then
+        thisEntity.aggro_target = nil
+      end
+      -- OLD: if not thisEntity.aggro_target:IsAttackingEntity(thisEntity) then
+      -- OLD: thisEntity:MoveToTargetToAttack(thisEntity.aggro_target)
     else
-      -- Boss goes back angry (attack-moving to the spawn position) because he can't attack
-      ExecuteOrderFromTable({
-        UnitIndex = thisEntity:entindex(),
-        OrderType = DOTA_UNIT_ORDER_ATTACK_MOVE,
-        Position = thisEntity.spawn_position,
-        Queue = 0,
-      })
+      -- Check HP of the boss and if its able to attack
+      local current_hp_pct = thisEntity:GetHealth()/thisEntity:GetMaxHealth()
+      local aggro_hp_pct = SIMPLE_BOSS_AGGRO_HP_PERCENT/100
+      if current_hp_pct < aggro_hp_pct and not thisEntity:IsOutOfGame() and not thisEntity:IsDisarmed() then
+        AttackNearestTarget(thisEntity)
+      end
 
-      thisEntity.state = SIMPLE_AI_STATE_LEASH
+	  if not thisEntity.aggro_target then
+        thisEntity.state = SIMPLE_AI_STATE_LEASH
+      end
     end
   elseif thisEntity.state == SIMPLE_AI_STATE_LEASH then
-    --print("LEASHING STATE")
     -- Actual leashing
     thisEntity:MoveToPosition(thisEntity.spawn_position)
     -- Check if boss reached the spawn_position


### PR DESCRIPTION
* You can now switch aggro.
* Bosses now ignore ward units if there are other units around.
* Bosses will not go to the spawn point anymore when they kill something, they will search for the new target to attack (unless killed unit was more than 1200 units away from the spawn point)
* Bosses will not try to attack banished and invulnerable units.
* Bosses will not try to attack when disarmed or ethereal. (its still buggy behavior)
* Bosses will now ignore sentry and observer wards.