### PR TITLE
Fix AI of simple bosses during duels

### DIFF
--- a/game/scripts/vscripts/units/ai_simple.lua
+++ b/game/scripts/vscripts/units/ai_simple.lua
@@ -18,8 +18,7 @@ function SimpleBossThink()
   end
 
   if Duels:IsActive() then
-    thisEntity:Stop()
-    return 1
+    thisEntity.aggro_target = nil
   end
 
   if not thisEntity.initialized then


### PR DESCRIPTION
Simple bosses in some edge cases completely stop acting when duel ends, because boss was aggroed before the duel.