### PR TITLE
Ember Spirit Buffs

### DIFF
--- a/game/scripts/npc/abilities/ember_spirit_flame_guard.txt
+++ b/game/scripts/npc/abilities/ember_spirit_flame_guard.txt
@@ -56,7 +56,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage_per_second"                               "30 40 50 60 120 240"
+        "damage_per_second"                               "30 40 50 60 180 300"
         "LinkedSpecialBonus"                              "special_bonus_unique_ember_spirit_3"
       }
       "06"

--- a/game/scripts/npc/abilities/ember_spirit_flame_guard.txt
+++ b/game/scripts/npc/abilities/ember_spirit_flame_guard.txt
@@ -56,7 +56,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage_per_second"                               "30 40 50 60 180 300"
+        "damage_per_second"                               "30 40 50 60 180 360"
         "LinkedSpecialBonus"                              "special_bonus_unique_ember_spirit_3"
       }
       "06"

--- a/game/scripts/npc/abilities/ember_spirit_sleight_of_fist.txt
+++ b/game/scripts/npc/abilities/ember_spirit_sleight_of_fist.txt
@@ -38,7 +38,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_hero_damage"                               "40 80 120 160 440 720"
+        "bonus_hero_damage"                               "40 80 120 160 480 800"
         "LinkedSpecialBonus"                              "special_bonus_unique_ember_spirit_6"
         "CalculateSpellDamageTooltip"                     "0"
       }

--- a/game/scripts/npc/abilities/ember_spirit_sleight_of_fist.txt
+++ b/game/scripts/npc/abilities/ember_spirit_sleight_of_fist.txt
@@ -38,7 +38,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_hero_damage"                               "40 80 120 160 280 560"
+        "bonus_hero_damage"                               "40 80 120 160 440 720"
         "LinkedSpecialBonus"                              "special_bonus_unique_ember_spirit_6"
         "CalculateSpellDamageTooltip"                     "0"
       }

--- a/game/scripts/npc/abilities/ember_spirit_sleight_of_fist.txt
+++ b/game/scripts/npc/abilities/ember_spirit_sleight_of_fist.txt
@@ -38,7 +38,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_hero_damage"                               "40 80 120 160 480 800"
+        "bonus_hero_damage"                               "40 80 120 160 320 640"
         "LinkedSpecialBonus"                              "special_bonus_unique_ember_spirit_6"
         "CalculateSpellDamageTooltip"                     "0"
       }

--- a/game/scripts/npc/abilities/talents/ember_spirit_talents.txt
+++ b/game/scripts/npc/abilities/talents/ember_spirit_talents.txt
@@ -64,7 +64,7 @@
       "01"
       {
         "var_type"					"FIELD_INTEGER"
-        "value"				"60"
+        "value"				"120" //OAA
       }
     }
   }

--- a/game/scripts/npc/abilities/talents/ember_spirit_talents.txt
+++ b/game/scripts/npc/abilities/talents/ember_spirit_talents.txt
@@ -64,7 +64,7 @@
       "01"
       {
         "var_type"					"FIELD_INTEGER"
-        "value"				"120" //OAA
+        "value"				"200" //OAA
       }
     }
   }

--- a/game/scripts/npc/abilities/talents/ember_spirit_talents.txt
+++ b/game/scripts/npc/abilities/talents/ember_spirit_talents.txt
@@ -64,7 +64,7 @@
       "01"
       {
         "var_type"					"FIELD_INTEGER"
-        "value"				"200" //OAA
+        "value"				"120" //OAA
       }
     }
   }
@@ -133,7 +133,7 @@
       "01"
       {
         "var_type"					"FIELD_INTEGER"
-        "value"				"120" //OAA
+        "value"				"160" //OAA
       }
     }
   }

--- a/game/scripts/npc/heroes/ember_spirit.txt
+++ b/game/scripts/npc/heroes/ember_spirit.txt
@@ -5,7 +5,7 @@
   //=================================================================================================================
   "npc_dota_hero_ember_spirit"
   {
-    "Ability10"     "special_bonus_attack_damage_50" // replaces special_bonus_attack_damage_25
+    "Ability10"     "special_bonus_attack_damage_40" // replaces special_bonus_attack_damage_25
     "Ability14"     "special_bonus_spell_amplify_15" // replaces special_bonus_spell_amplify_10
   }
 }

--- a/game/scripts/npc/heroes/ember_spirit.txt
+++ b/game/scripts/npc/heroes/ember_spirit.txt
@@ -1,0 +1,11 @@
+"DOTAHeroes"
+{
+  //=================================================================================================================
+  // HERO: Ember Spirit
+  //=================================================================================================================
+  "npc_dota_hero_ember_spirit"
+  {
+    "Ability10"     "special_bonus_attack_damage_75" // replaces special_bonus_attack_damage_25
+    "Ability14"     "special_bonus_spell_amplify_15" // replaces special_bonus_spell_amplify_10
+  }
+}

--- a/game/scripts/npc/heroes/ember_spirit.txt
+++ b/game/scripts/npc/heroes/ember_spirit.txt
@@ -5,7 +5,7 @@
   //=================================================================================================================
   "npc_dota_hero_ember_spirit"
   {
-    "Ability10"     "special_bonus_attack_damage_75" // replaces special_bonus_attack_damage_25
+    "Ability10"     "special_bonus_attack_damage_50" // replaces special_bonus_attack_damage_25
     "Ability14"     "special_bonus_spell_amplify_15" // replaces special_bonus_spell_amplify_10
   }
 }

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -16,6 +16,7 @@
 #base "heroes/disruptor.txt"
 #base "heroes/dragon_knight.txt"
 #base "heroes/earth_spirit.txt"
+#base "heroes/ember_spirit.txt"
 #base "heroes/enigma.txt"
 #base "heroes/faceless_void.txt"
 #base "heroes/furion.txt"


### PR DESCRIPTION
Ember spirit is now really bad after all the gameplay changes that have happened. This hero cannot deal damage. 
Increased Flame Guard Damage at OAA levels. Also improved the talent.
Improved Ember spirits spell amp and damage talents. 
Improved Ember spirits Sleight of Fist Damage Talent. 
Improved Sleight of Fist Daamge at OAA levels. 