### PR TITLE
Tier 5 Twins Boss Nerf

### DIFF
--- a/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_dumb_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_dumb_tier5.txt
@@ -31,13 +31,13 @@
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_MELEE_ATTACK"
-    "AttackDamageMin"                                     "6500"    // Damage range min.
-    "AttackDamageMax"                                     "6550"    // Damage range max.
+    "AttackDamageMin"                                     "5500"    // Damage range min.
+    "AttackDamageMax"                                     "5550"    // Damage range max.
     "AttackDamageType"                                    "DAMAGE_TYPE_ArmorPhysical"
     "AttackRate"                                          "0.75"      // Speed of attack.
     "AttackAnimationPoint"                                "0.3"    // Normalized time in animation cycle to attack.
     "AttackAcquisitionRange"                              "150"    // Range within a target can be acquired.
-    "AttackRange"                                         "960"    // Range within a target can be attacked.
+    "AttackRange"                                         "600"    // Range within a target can be attacked.
     "ProjectileModel"                                     "particles/items2_fx/necronomicon_archer_projectile.vpcf"
     "ProjectileSpeed"                                     "1000"
 
@@ -61,7 +61,7 @@
 
     // Status
     //----------------------------------------------------------------
-    "StatusHealth"                                        "20000"    // Base health
+    "StatusHealth"                                        "17500"    // Base health
     "StatusHealthRegen"                                   "30.5"    // Health regeneration rate.
     "StatusMana"                                          "0"    // Base mana.
     "StatusManaRegen"                                     "0"    // Mana regeneration rate.

--- a/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/twin/npc_dota_boss_twin_tier5.txt
@@ -31,8 +31,8 @@
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_MELEE_ATTACK"
-    "AttackDamageMin"                                     "6000"    // Damage range min.
-    "AttackDamageMax"                                     "6500"    // Damage range max.
+    "AttackDamageMin"                                     "5000"    // Damage range min.
+    "AttackDamageMax"                                     "5500"    // Damage range max.
     "AttackDamageType"                                    "DAMAGE_TYPE_ArmorPhysical"
     "AttackRate"                                          "0.75"      // Speed of attack.
     "AttackAnimationPoint"                                "0.3"    // Normalized time in animation cycle to attack.
@@ -59,7 +59,7 @@
 
     // Status
     //----------------------------------------------------------------
-    "StatusHealth"                                        "20000"    // Base health
+    "StatusHealth"                                        "17500"    // Base health
     "StatusHealthRegen"                                   "30.5"    // Health regeneration rate.
     "StatusMana"                                          "0"    // Base mana.
     "StatusManaRegen"                                     "0"    // Mana regeneration rate.

--- a/game/scripts/npc/units/twin/npc_dota_boss_twin_dumb.txt
+++ b/game/scripts/npc/units/twin/npc_dota_boss_twin_dumb.txt
@@ -37,7 +37,7 @@
     "AttackRate"                                          "0.75"      // Speed of attack.
     "AttackAnimationPoint"                                "0.3"    // Normalized time in animation cycle to attack.
     "AttackAcquisitionRange"                              "150"    // Range within a target can be acquired.
-    "AttackRange"                                         "960"    // Range within a target can be attacked.
+    "AttackRange"                                         "600"    // Range within a target can be attacked.
     "ProjectileModel"                                     "particles/items2_fx/necronomicon_archer_projectile.vpcf"
     "ProjectileSpeed"                                     "1000"
 


### PR DESCRIPTION
Tier 5 Twins is still insanely powerful. This is a boss people willl actively avoid because if you don't have the right heroes for it, there is a high chance it will teamwipe you. 

The first changed affects both tier 2 and tier 5 twins. Reduced the twin dumb attack range from 960 to 600. This boss will chase you out the boss pit and can currently attack you when your next to the fountain. Meaning actually disengaging from this boss is very hard. This also leads to the boss getting alot fof player kills when aggroed by accident. 

Additionally nerfed the HP from 20000 to 17500. This boss has very high EHP compared to the other T5 bosses, and if you don't have a high AOE damage lineup this boss will take a very long time. (also going off the theme of the t2 bosses where the "easier" ones have 6k HP compared to the 3.5k HP twins.)

Finally reduced the damage on both twins by 1000. This boss still deals very high damage and it will kill you, however you probably wont die if you accidentally aggro this boss. 




