### PR TITLE
Tier 5 Temple Guardian Boss Nerf

### DIFF
--- a/game/scripts/npc/abilities/siltbreaker/temple_guardian_hammer_throw_tier5.txt
+++ b/game/scripts/npc/abilities/siltbreaker/temple_guardian_hammer_throw_tier5.txt
@@ -62,7 +62,7 @@
       "04"
       {
         "var_type"                  "FIELD_INTEGER"
-        "hammer_damage"             "3000"
+        "hammer_damage"             "2500"
       }
     }
 

--- a/game/scripts/npc/abilities/siltbreaker/temple_guardian_purification_tier5.txt
+++ b/game/scripts/npc/abilities/siltbreaker/temple_guardian_purification_tier5.txt
@@ -45,7 +45,7 @@
       "01"
       {
         "var_type"              "FIELD_INTEGER"
-        "heal"                  "2100" // boss resistance makes this effectively 21000 heal, every 15 seconds, 1400 hp/s... that's a lot of heal
+        "heal"                  "1500" // boss resistance makes this effectively 15000 heal, every 15 seconds, 1000 hp/s... that's a lot of heal
       }
       "02"
       {

--- a/game/scripts/npc/abilities/siltbreaker/temple_guardian_rage_hammer_smash.txt
+++ b/game/scripts/npc/abilities/siltbreaker/temple_guardian_rage_hammer_smash.txt
@@ -52,7 +52,7 @@
       "03"
       {
         "var_type"              "FIELD_INTEGER"
-        "damage"                "6400"
+        "damage"                "6000"
       }
       "04"
       {

--- a/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_temple_guardian_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_temple_guardian_tier5.txt
@@ -70,7 +70,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				  "16000"
+		"StatusHealth"				  "15000"
 		"StatusHealthRegen"			"55" // they can spam heal bombs for effective 500 hp/s heals
 		"StatusMana"				    "5000"
 		"StatusManaRegen"			  "30"


### PR DESCRIPTION
Temple Guardians are still by far the hardest boss to do. However I think tier 4 guardians are managable. Tier 5 guardians are very strong and most players actively avoid these bosses. They will often pick up multiple kills when attempted.

Reduced Tier 4 enrage hammer smash from 6400 to 6000. 

Reduced Tier 5 Health From 16000 to 15000. 
Reduced Tier 5 Hammer Throw Damage from 3000 to 2500. 
Reduced Tier 5 Purification heal/damage to 1500