### PR TITLE
Charger Boss Damage Changes

### DIFF
--- a/game/scripts/npc/abilities/charger/boss_charger_charge.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_charge.txt
@@ -56,7 +56,7 @@
       "07"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "hero_pillar_damage"                              "7000 8000 9000"
+        "hero_pillar_damage"                              "8000 9000 10000"
       }
       //----------------------------------
       // Glancing blow, when the charger strikes a hero indirectly and pushes them away

--- a/game/scripts/npc/abilities/charger/boss_charger_charge.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_charge.txt
@@ -64,7 +64,7 @@
       "08"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_damage"                                  "200 300 400"
+        "glancing_damage"                                  "500 750 1000"
       }
       "09"
       {

--- a/game/scripts/npc/abilities/charger/boss_charger_charge.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_charge.txt
@@ -56,7 +56,7 @@
       "07"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "hero_pillar_damage"                              "8000 10000 12000"
+        "hero_pillar_damage"                              "7000 8000 9000"
       }
       //----------------------------------
       // Glancing blow, when the charger strikes a hero indirectly and pushes them away
@@ -64,7 +64,7 @@
       "08"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_damage"                                  "75 100 150"
+        "glancing_damage"                                  "200 300 400"
       }
       "09"
       {

--- a/game/scripts/npc/abilities/charger/boss_charger_charge_tier5.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_charge_tier5.txt
@@ -64,7 +64,7 @@
       "08"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_damage"                                  "500 1000 1500"
+        "glancing_damage"                                  "1500 2000 2500"
       }
       "09"
       {

--- a/game/scripts/npc/abilities/charger/boss_charger_charge_tier5.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_charge_tier5.txt
@@ -56,7 +56,7 @@
       "07"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "hero_pillar_damage"                              "8000 10000 12000"
+        "hero_pillar_damage"                              "18000 19000 20000"
       }
       //----------------------------------
       // Glancing blow, when the charger strikes a hero indirectly and pushes them away
@@ -64,7 +64,7 @@
       "08"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_damage"                                  "75 100 150"
+        "glancing_damage"                                  "500 1000 1500"
       }
       "09"
       {

--- a/game/scripts/npc/abilities/charger/boss_charger_charge_tier5.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_charge_tier5.txt
@@ -64,7 +64,7 @@
       "08"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_damage"                                  "1500 2000 2500"
+        "glancing_damage"                                  "2000 2500 3000"
       }
       "09"
       {

--- a/game/scripts/npc/units/boss/tier5_bosses/charger/npc_dota_boss_charger_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/charger/npc_dota_boss_charger_tier5.txt
@@ -61,7 +61,7 @@
 
     // Status
     //----------------------------------------------------------------
-    "StatusHealth"                                        "20000"     // Base health
+    "StatusHealth"                                        "15000"     // Base health
     "StatusHealthRegen"                                   "10.5"        // Health regeneration rate.
     "StatusMana"                                          "0"     // Base mana.
     "StatusManaRegen"                                     "0"     // Mana regeneration rate.


### PR DESCRIPTION
While charger is a good boss its number values aren't correct. 

Reduced tier 2 charge damage from "8000 10000 12000" to "7000 8000 9000". Getting hit by this spell is still extremely punishing but one mistake is less likely to send you to the fountain. You still only get to make one mistake versus this boss. 

Increased tier 2 glancing damage to "500 750 1000" I didn't know this spell dealt damage previously. If you execute the charger boss correctly you shouldnt get hit by this boss at all. So I increased the punishment for being hit by this boss. 

Decreased tier 5 charger boss HP from 20000 to 15000. This boss takes alot longer to do then other bosses so I decreased its HP. 

Increased tier 5 charge damage from "8000 1000 12000" to "18000 19000 20000". This was unchanged from tier 2 for some reason.

Increased Tier 5 glancing damage to "2000 2500 3000". Same idea with the tier 2 buff. 