### PR TITLE
Ogre Boss: Ogre Seer Buffs

### DIFF
--- a/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite.txt
+++ b/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite.txt
@@ -43,7 +43,7 @@
             "02"
             {
                 "var_type"          "FIELD_INTEGER"
-                "burn_damage"       "400"
+                "burn_damage"       "600"
             }
 
             "03"

--- a/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite.txt
+++ b/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite.txt
@@ -43,7 +43,7 @@
             "02"
             {
                 "var_type"          "FIELD_INTEGER"
-                "burn_damage"       "500"
+                "burn_damage"       "600"
             }
 
             "03"

--- a/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite.txt
+++ b/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite.txt
@@ -43,7 +43,7 @@
             "02"
             {
                 "var_type"          "FIELD_INTEGER"
-                "burn_damage"       "600"
+                "burn_damage"       "500"
             }
 
             "03"

--- a/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite_tier5.txt
+++ b/game/scripts/npc/abilities/siltbreaker/ogre_seer_area_ignite_tier5.txt
@@ -37,13 +37,13 @@
             "01"
             {
                 "var_type"          "FIELD_FLOAT"
-                "duration"          "5"
+                "duration"          "2"
             }
 
             "02"
             {
                 "var_type"          "FIELD_INTEGER"
-                "burn_damage"       "800"
+                "burn_damage"       "900"
             }
 
             "03"

--- a/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_ogre_seer_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_ogre_seer_tier5.txt
@@ -64,7 +64,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				"3000"
+		"StatusHealth"				"2000"
 		"StatusHealthRegen"			"50"
 		"StatusMana"				"1200"
 		"StatusManaRegen"			"10"

--- a/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_ogre_seer_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_ogre_seer_tier5.txt
@@ -64,7 +64,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				"2000"
+		"StatusHealth"				"3000"
 		"StatusHealthRegen"			"50"
 		"StatusMana"				"1200"
 		"StatusManaRegen"			"10"

--- a/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_ogre_seer_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/siltbreaker/npc_dota_creature_ogre_seer_tier5.txt
@@ -27,12 +27,12 @@
 		"Ability1"					"ogre_magi_channelled_bloodlust_tier5"
 		"Ability2"					"ogre_seer_area_ignite_tier5"
 		"Ability3"					"boss_regen"
-		"Ability4"					""
+		"Ability3"          "boss_resistance"
 
 		// Armor
 		//----------------------------------------------------------------
-		"ArmorPhysical"				"25"
-		"MagicalResistance"                                   "-25"            // Magical protection.
+		"ArmorPhysical"				"40"
+		"MagicalResistance"                                   "-50"            // Magical protection.
 
 		// Attack
 		//----------------------------------------------------------------
@@ -64,7 +64,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				"10000"
+		"StatusHealth"				"2000"
 		"StatusHealthRegen"			"50"
 		"StatusMana"				"1200"
 		"StatusManaRegen"			"10"

--- a/game/scripts/npc/units/siltbreaker/npc_dota_creature_ogre_seer.txt
+++ b/game/scripts/npc/units/siltbreaker/npc_dota_creature_ogre_seer.txt
@@ -64,7 +64,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				"1500"
+		"StatusHealth"				"2000"
 		"StatusHealthRegen"			"5"
 		"StatusMana"				"1200"
 		"StatusManaRegen"			"10"

--- a/game/scripts/npc/units/siltbreaker/npc_dota_creature_ogre_seer.txt
+++ b/game/scripts/npc/units/siltbreaker/npc_dota_creature_ogre_seer.txt
@@ -64,7 +64,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				"2000"
+		"StatusHealth"				"1500"
 		"StatusHealthRegen"			"5"
 		"StatusMana"				"1200"
 		"StatusManaRegen"			"10"

--- a/game/scripts/npc/units/siltbreaker/npc_dota_creature_ogre_seer.txt
+++ b/game/scripts/npc/units/siltbreaker/npc_dota_creature_ogre_seer.txt
@@ -27,11 +27,12 @@
 		"Ability1"					"ogre_magi_channelled_bloodlust"
 		"Ability2"					"ogre_seer_area_ignite"
 		"Ability3"					"boss_regen"
-		"Ability4"					""
+		"Ability4"          "boss_resistance"
 
 		// Armor
 		//----------------------------------------------------------------
-		"ArmorPhysical"				"15"
+		"ArmorPhysical"				"33"
+    "MagicalResistance"   "-50"
 
 		// Attack
 		//----------------------------------------------------------------
@@ -63,7 +64,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				"7500"
+		"StatusHealth"				"1500"
 		"StatusHealthRegen"			"5"
 		"StatusMana"				"1200"
 		"StatusManaRegen"			"10"


### PR DESCRIPTION
Ogre Seers Die far too fast when doing the ogre boss. This basically removed a part of the boss because the ogre seers are dead within the first 10 seconds of the fight. Ogre seers can also be countered by silences, stuns and hexes which are quite common when doing tier 3+ bosses.

Gave Ogre Seers the boss resistance ability. I reduced their HP to compensate for this buff. Now the Ogre Seers are more durable. I also changed their armour and magic resistance to match the ogre boss. I gave their new HP by multiplying their old HP by [1-0.8 (the damage reduction)] = 0.2

Increased Ignite DPS on both tier 3 and tier 5 bosses. The damage currently isn't noticable and you can stand in the fire with no consequence. I reduced the duration on the tier 5 ignite damage duration to match the tier 3 boss. When you walk out of the fire the buff isn't supposed to linger for long. 



