### PR TITLE
Swiper Boss Damage Type Change

### DIFF
--- a/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
@@ -16,7 +16,7 @@
         "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
         "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
         "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
-        "AbilityUnitDamageType"         "DAMAGE_TYPE_PURE"
+        "AbilityUnitDamageType"         "DAMAGE_TYPE_PHYSICAL"
         "AnimationIgnoresModelScale"     "1"
 
         // Casting
@@ -40,7 +40,7 @@
             "01"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "3150"
+                "damage"                    "5000"
             }
         }
 

--- a/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
@@ -40,7 +40,7 @@
             "01"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "6000"
+                "damage"                    "6500"
             }
         }
 

--- a/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
@@ -40,7 +40,7 @@
             "01"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "6000"
+                "damage"                    "5000"
             }
         }
 

--- a/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
@@ -40,7 +40,7 @@
             "01"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "6500"
+                "damage"                    "6000"
             }
         }
 

--- a/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
@@ -40,7 +40,7 @@
             "01"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "5000"
+                "damage"                    "6000"
             }
         }
 

--- a/game/scripts/npc/abilities/swiper/boss_swiper_frontswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_frontswipe.txt
@@ -40,7 +40,7 @@
             "01"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "5000"
+                "damage"                    "6000"
             }
             "02"
             {

--- a/game/scripts/npc/abilities/swiper/boss_swiper_frontswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_frontswipe.txt
@@ -40,7 +40,7 @@
             "01"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "6000"
+                "damage"                    "6500"
             }
             "02"
             {

--- a/game/scripts/npc/abilities/swiper/boss_swiper_frontswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_frontswipe.txt
@@ -16,7 +16,7 @@
         "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
         "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
         "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
-        "AbilityUnitDamageType"         "DAMAGE_TYPE_PURE"
+        "AbilityUnitDamageType"         "DAMAGE_TYPE_PHYSICAL"
         "AnimationIgnoresModelScale"     "1"
 
         // Casting
@@ -40,7 +40,7 @@
             "01"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "3150"
+                "damage"                    "5000"
             }
             "02"
             {

--- a/game/scripts/npc/abilities/swiper/boss_swiper_reapers_rush.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_reapers_rush.txt
@@ -74,7 +74,7 @@
             "08"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "max_damage"                "6000"
+                "max_damage"                "7000"
             }
             "09"
             {

--- a/game/scripts/npc/abilities/swiper/boss_swiper_reapers_rush.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_reapers_rush.txt
@@ -79,7 +79,7 @@
             "09"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "min_damage"                "1000"
+                "min_damage"                "2000"
             }
             "10"
             {

--- a/game/scripts/npc/abilities/swiper/boss_swiper_reapers_rush.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_reapers_rush.txt
@@ -16,7 +16,7 @@
         "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
         "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
         "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
-        "AbilityUnitDamageType"         "DAMAGE_TYPE_PURE"
+        "AbilityUnitDamageType"         "DAMAGE_TYPE_PHYSICAL"
         "AnimationIgnoresModelScale"     "1"
 
         // Casting
@@ -74,12 +74,12 @@
             "08"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "max_damage"                "4500"
+                "max_damage"                "6000"
             }
             "09"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "min_damage"                "100"
+                "min_damage"                "1000"
             }
             "10"
             {

--- a/game/scripts/npc/abilities/swiper/boss_swiper_thrust.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_thrust.txt
@@ -16,7 +16,7 @@
         "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
         "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
         "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
-        "AbilityUnitDamageType"         "DAMAGE_TYPE_PURE"
+        "AbilityUnitDamageType"         "DAMAGE_TYPE_PHYSICAL"
         "AnimationIgnoresModelScale"     "1"
 
         // Casting
@@ -54,7 +54,7 @@
             "04"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "3150"
+                "damage"                    "5000"
             }
         }
 

--- a/game/scripts/npc/abilities/swiper/boss_swiper_thrust.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_thrust.txt
@@ -54,7 +54,7 @@
             "04"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "5000"
+                "damage"                    "6000"
             }
         }
 

--- a/game/scripts/npc/abilities/swiper/boss_swiper_thrust.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_thrust.txt
@@ -54,7 +54,7 @@
             "04"
             {
                 "var_type"                  "FIELD_INTEGER"
-                "damage"                    "6000"
+                "damage"                    "6500"
             }
         }
 


### PR DESCRIPTION
Changed the damage type on the Swiper boss from pure to physical. I increased the damage this boss does to compensate for this change. Additionally I buffed the minimum damage for reapers rush. 

The reason for this change is that most heroes apart from high HP strength heroes with heart get punished hard by Swiper. Swiper gets player kills. Additionally, during boss contests swiper is one of the most dangerous bosses, with his ranged abilities one shotting most heroes. 

Another reason for this change is so the boss falls off in powerlevel more reasonably like all the other bosses in the game when you get higher tier items etc. (Just for reference some of sven bosses attacks hit harder then temple guardians.)

The boss still hits very hard, dealing more damage then tier 3 bosses however everyone has slightly more EHP vs this boss, allowing for a slightly higher marign for error. Swiper is also alot easier to kite then tier 3 bosses, so its high damage is acceptable. 