### PR TITLE
Manta Style Buffs (Updated to 7.26a)

### DIFF
--- a/game/scripts/npc/items/item_manta.txt
+++ b/game/scripts/npc/items/item_manta.txt
@@ -78,12 +78,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-65 -60 -55 -50 -45" //OAA
+        "images_do_damage_percent_melee"                  "-65 -55 -45 -35 -25" //OAA
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "35 40 45 50 55" //OAA
+        "tooltip_damage_outgoing_melee"                   "35 45 55 65 75" //OAA
       }
       "10"
       {
@@ -98,12 +98,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-70 -65 -60 -55 -50" //OAA
+        "images_do_damage_percent_ranged"                 "-70 -60 -50 -40 -30" //OAA
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "30 35 40 45 50" //OAA
+        "tooltip_damage_outgoing_ranged"                  "30 40 50 60 70" //OAA
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta.txt
+++ b/game/scripts/npc/items/item_manta.txt
@@ -63,7 +63,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_movement_speed"                            "20 25 30 35 40"
+        "bonus_movement_speed"                            "8 10 12 14 16"
       }
       "06"
       {
@@ -78,12 +78,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-65 -55 -45 -35 -25" //OAA
+        "images_do_damage_percent_melee"                  "-67 -62 -57 -52 -47"
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "35 45 55 65 75" //OAA
+        "tooltip_damage_outgoing_melee"                   "33 38 43 48 53"
       }
       "10"
       {
@@ -98,12 +98,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-70 -60 -50 -40 -30" //OAA
+        "images_do_damage_percent_ranged"                 "-72 -67 -62 -57 -52"
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "30 40 50 60 70" //OAA
+        "tooltip_damage_outgoing_ranged"                  "28 33 38 43 48"
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta.txt
+++ b/game/scripts/npc/items/item_manta.txt
@@ -78,12 +78,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-67"
+        "images_do_damage_percent_melee"                  "-65 -60 -55 -50 -45" //OAA
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "33"
+        "tooltip_damage_outgoing_melee"                   "35 40 45 50 55" //OAA
       }
       "10"
       {
@@ -98,12 +98,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-72"
+        "images_do_damage_percent_ranged"                 "-70 -65 -60 -55 -50" //OAA
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "28"
+        "tooltip_damage_outgoing_ranged"                  "30 35 40 45 50" //OAA
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta_2.txt
+++ b/game/scripts/npc/items/item_manta_2.txt
@@ -93,12 +93,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-65 -60 -55 -50 -45" //OAA
+        "images_do_damage_percent_melee"                  "-65 -55 -45 -35 -25" //OAA
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "35 40 45 50 55" //OAA
+        "tooltip_damage_outgoing_melee"                   "35 45 55 65 75" //OAA
       }
       "10"
       {
@@ -113,12 +113,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-70 -65 -60 -55 -50" //OAA
+        "images_do_damage_percent_ranged"                 "-70 -60 -50 -40 -30" //OAA
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "30 35 40 45 50" //OAA
+        "tooltip_damage_outgoing_ranged"                  "30 40 50 60 70" //OAA
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta_2.txt
+++ b/game/scripts/npc/items/item_manta_2.txt
@@ -93,12 +93,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-67"
+        "images_do_damage_percent_melee"                  "-65 -60 -55 -50 -45" //OAA
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "33"
+        "tooltip_damage_outgoing_melee"                   "35 40 45 50 55" //OAA
       }
       "10"
       {
@@ -113,12 +113,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-72"
+        "images_do_damage_percent_ranged"                 "-70 -65 -60 -55 -50" //OAA
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "28"
+        "tooltip_damage_outgoing_ranged"                  "30 35 40 45 50" //OAA
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta_2.txt
+++ b/game/scripts/npc/items/item_manta_2.txt
@@ -78,7 +78,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_movement_speed"                            "20 25 30 35 40"
+        "bonus_movement_speed"                            "8 10 12 14 16"
       }
       "06"
       {
@@ -93,12 +93,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-65 -55 -45 -35 -25" //OAA
+        "images_do_damage_percent_melee"                  "-67 -62 -57 -52 -47"
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "35 45 55 65 75" //OAA
+        "tooltip_damage_outgoing_melee"                   "33 38 43 48 53"
       }
       "10"
       {
@@ -113,12 +113,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-70 -60 -50 -40 -30" //OAA
+        "images_do_damage_percent_ranged"                 "-72 -67 -62 -57 -52"
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "30 40 50 60 70" //OAA
+        "tooltip_damage_outgoing_ranged"                  "28 33 38 43 48"
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta_3.txt
+++ b/game/scripts/npc/items/item_manta_3.txt
@@ -93,12 +93,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-65 -60 -55 -50 -45" //OAA
+        "images_do_damage_percent_melee"                  "-65 -55 -45 -35 -25" //OAA
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "35 40 45 50 55" //OAA
+        "tooltip_damage_outgoing_melee"                   "35 45 55 65 75" //OAA
       }
       "10"
       {
@@ -113,12 +113,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-70 -65 -60 -55 -50" //OAA
+        "images_do_damage_percent_ranged"                 "-70 -60 -50 -40 -30" //OAA
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "30 35 40 45 50" //OAA
+        "tooltip_damage_outgoing_ranged"                  "30 40 50 60 70" //OAA
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta_3.txt
+++ b/game/scripts/npc/items/item_manta_3.txt
@@ -93,12 +93,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-67"
+        "images_do_damage_percent_melee"                  "-65 -60 -55 -50 -45" //OAA
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "33"
+        "tooltip_damage_outgoing_melee"                   "35 40 45 50 55" //OAA
       }
       "10"
       {
@@ -113,12 +113,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-72"
+        "images_do_damage_percent_ranged"                 "-70 -65 -60 -55 -50" //OAA
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "28"
+        "tooltip_damage_outgoing_ranged"                  "30 35 40 45 50" //OAA
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta_3.txt
+++ b/game/scripts/npc/items/item_manta_3.txt
@@ -78,7 +78,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_movement_speed"                            "20 25 30 35 40"
+        "bonus_movement_speed"                            "8 10 12 14 16"
       }
       "06"
       {
@@ -93,12 +93,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-65 -55 -45 -35 -25" //OAA
+        "images_do_damage_percent_melee"                  "-67 -62 -57 -52 -47"
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "35 45 55 65 75" //OAA
+        "tooltip_damage_outgoing_melee"                   "33 38 43 48 53"
       }
       "10"
       {
@@ -113,12 +113,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-70 -60 -50 -40 -30" //OAA
+        "images_do_damage_percent_ranged"                 "-72 -67 -62 -57 -52"
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "30 40 50 60 70" //OAA
+        "tooltip_damage_outgoing_ranged"                  "28 33 38 43 48"
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta_4.txt
+++ b/game/scripts/npc/items/item_manta_4.txt
@@ -93,12 +93,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-65 -60 -55 -50 -45" //OAA
+        "images_do_damage_percent_melee"                  "-65 -55 -45 -35 -25" //OAA
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "35 40 45 50 55" //OAA
+        "tooltip_damage_outgoing_melee"                   "35 45 55 65 75" //OAA
       }
       "10"
       {
@@ -113,12 +113,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-70 -65 -60 -55 -50" //OAA
+        "images_do_damage_percent_ranged"                 "-70 -60 -50 -40 -30" //OAA
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "30 35 40 45 50" //OAA
+        "tooltip_damage_outgoing_ranged"                  "30 40 50 60 70" //OAA
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta_4.txt
+++ b/game/scripts/npc/items/item_manta_4.txt
@@ -93,12 +93,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-67"
+        "images_do_damage_percent_melee"                  "-65 -60 -55 -50 -45" //OAA
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "33"
+        "tooltip_damage_outgoing_melee"                   "35 40 45 50 55" //OAA
       }
       "10"
       {
@@ -113,12 +113,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-72"
+        "images_do_damage_percent_ranged"                 "-70 -65 -60 -55 -50" //OAA
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "28"
+        "tooltip_damage_outgoing_ranged"                  "30 35 40 45 50" //OAA
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta_4.txt
+++ b/game/scripts/npc/items/item_manta_4.txt
@@ -78,7 +78,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_movement_speed"                            "20 25 30 35 40"
+        "bonus_movement_speed"                            "8 10 12 14 16"
       }
       "06"
       {
@@ -93,12 +93,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-65 -55 -45 -35 -25" //OAA
+        "images_do_damage_percent_melee"                  "-67 -62 -57 -52 -47"
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "35 45 55 65 75" //OAA
+        "tooltip_damage_outgoing_melee"                   "33 38 43 48 53"
       }
       "10"
       {
@@ -113,12 +113,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-70 -60 -50 -40 -30" //OAA
+        "images_do_damage_percent_ranged"                 "-72 -67 -62 -57 -52"
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "30 40 50 60 70" //OAA
+        "tooltip_damage_outgoing_ranged"                  "28 33 38 43 48"
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta_5.txt
+++ b/game/scripts/npc/items/item_manta_5.txt
@@ -79,7 +79,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_movement_speed"                            "20 25 30 35 40"
+        "bonus_movement_speed"                            "8 10 12 14 16"
       }
       "06"
       {
@@ -94,12 +94,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-65 -55 -45 -35 -25" //OAA
+        "images_do_damage_percent_melee"                  "-67 -62 -57 -52 -47"
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "35 45 55 65 75" //OAA
+        "tooltip_damage_outgoing_melee"                   "33 38 43 48 53"
       }
       "10"
       {
@@ -114,12 +114,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-70 -60 -50 -40 -30" //OAA
+        "images_do_damage_percent_ranged"                 "-72 -67 -62 -57 -52"
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "30 40 50 60 70" //OAA
+        "tooltip_damage_outgoing_ranged"                  "28 33 38 43 48"
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta_5.txt
+++ b/game/scripts/npc/items/item_manta_5.txt
@@ -94,12 +94,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-65 -60 -55 -50 -45" //OAA
+        "images_do_damage_percent_melee"                  "-65 -55 -45 -35 -25" //OAA
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "35 40 45 50 55" //OAA
+        "tooltip_damage_outgoing_melee"                   "35 45 55 65 75" //OAA
       }
       "10"
       {
@@ -114,12 +114,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-70 -65 -60 -55 -50" //OAA
+        "images_do_damage_percent_ranged"                 "-70 -60 -50 -40 -30" //OAA
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "30 35 40 45 50" //OAA
+        "tooltip_damage_outgoing_ranged"                  "30 40 50 60 70" //OAA
       }
       "14"
       {

--- a/game/scripts/npc/items/item_manta_5.txt
+++ b/game/scripts/npc/items/item_manta_5.txt
@@ -94,12 +94,12 @@
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_melee"                  "-67"
+        "images_do_damage_percent_melee"                  "-65 -60 -55 -50 -45" //OAA
       }
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_melee"                   "33"
+        "tooltip_damage_outgoing_melee"                   "35 40 45 50 55" //OAA
       }
       "10"
       {
@@ -114,12 +114,12 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "images_do_damage_percent_ranged"                 "-72"
+        "images_do_damage_percent_ranged"                 "-70 -65 -60 -55 -50" //OAA
       }
       "13"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_damage_outgoing_ranged"                  "28"
+        "tooltip_damage_outgoing_ranged"                  "30 35 40 45 50" //OAA
       }
       "14"
       {


### PR DESCRIPTION
Increased the damage manta style illusions do. Manta style is a very weak item at the moment, with the illusions dealing no damage. 

Damage now scales on melee "33 38 43 48 53"
Damage now scales on ranged "28 33 38 43 48" 