### PR TITLE
Satanic Core buffs

### DIFF
--- a/game/resource/English/ability/items/tooltip_satanic_core.txt
+++ b/game/resource/English/ability/items/tooltip_satanic_core.txt
@@ -11,6 +11,7 @@
 "DOTA_Tooltip_Ability_item_satanic_core_bonus_intelligence"                 "+$int"
 "DOTA_Tooltip_Ability_item_satanic_core_bonus_health"                       "+$health"
 "DOTA_Tooltip_Ability_item_satanic_core_bonus_mana"                         "+$mana"
+"DOTA_Tooltip_Ability_item_satanic_core_bonus_status_resist"                "%+Status Resistance"
 
 "DOTA_Tooltip_Ability_item_satanic_core_2"                                  "#{DOTA_Tooltip_Ability_item_satanic_core}"
 "DOTA_Tooltip_Ability_item_recipe_satanic_core_2"                           "#{DOTA_Tooltip_Ability_item_recipe_satanic_core}"
@@ -22,6 +23,7 @@
 "DOTA_Tooltip_Ability_item_satanic_core_2_bonus_intelligence"               "#{DOTA_Tooltip_Ability_item_satanic_core_bonus_intelligence}"
 "DOTA_Tooltip_Ability_item_satanic_core_2_bonus_health"                     "#{DOTA_Tooltip_Ability_item_satanic_core_bonus_health}"
 "DOTA_Tooltip_Ability_item_satanic_core_2_bonus_mana"                       "#{DOTA_Tooltip_Ability_item_satanic_core_bonus_mana}"
+"DOTA_Tooltip_Ability_item_satanic_core_2_bonus_status_resist"              "#{DOTA_Tooltip_Ability_item_satanic_core_bonus_status_resist}"
 
 "DOTA_Tooltip_Ability_item_satanic_core_3"                                  "#{DOTA_Tooltip_Ability_item_satanic_core}"
 "DOTA_Tooltip_Ability_item_recipe_satanic_core_3"                           "#{DOTA_Tooltip_Ability_item_recipe_satanic_core}"
@@ -33,3 +35,4 @@
 "DOTA_Tooltip_Ability_item_satanic_core_3_bonus_intelligence"               "#{DOTA_Tooltip_Ability_item_satanic_core_bonus_intelligence}"
 "DOTA_Tooltip_Ability_item_satanic_core_3_bonus_health"                     "#{DOTA_Tooltip_Ability_item_satanic_core_bonus_health}"
 "DOTA_Tooltip_Ability_item_satanic_core_3_bonus_mana"                       "#{DOTA_Tooltip_Ability_item_satanic_core_bonus_mana}"
+"DOTA_Tooltip_Ability_item_satanic_core_3_bonus_status_resist"              "#{DOTA_Tooltip_Ability_item_satanic_core_bonus_status_resist}"

--- a/game/scripts/npc/items/custom/item_satanic_core.txt
+++ b/game/scripts/npc/items/custom/item_satanic_core.txt
@@ -64,15 +64,15 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilitySpecial"
     {
-      "01"
+      "01" // like bonus_intelligence
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "40 55 75"
+        "bonus_strength"                                  "40 60 85"
       }
-      "02"
+      "02" // like Octarine Core intelligence at levels 2-4
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intelligence"                              "40 55 75"
+        "bonus_intelligence"                              "40 60 85"
       }
       "03"
       {
@@ -92,12 +92,12 @@
       "06" // name needs to be the same as in octarine core
       {
         "var_type"                                        "FIELD_FLOAT"
-        "creep_lifesteal"                                 "13 14 15"
+        "creep_lifesteal"                                 "15 20 25"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_hero_spell_lifesteal"                     "150"
+        "unholy_hero_spell_lifesteal"                     "200"
       }
       "08"
       {
@@ -108,6 +108,11 @@
       {
         "var_type"                                        "FIELD_FLOAT"
         "duration"                                        "5.0"
+      }
+      "10"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_status_resist"                             "10 15 20"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_satanic_core_2.txt
+++ b/game/scripts/npc/items/custom/item_satanic_core_2.txt
@@ -68,12 +68,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "40 55 75"
+        "bonus_strength"                                  "40 60 85"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intelligence"                              "40 55 75"
+        "bonus_intelligence"                              "40 60 85"
       }
       "03"
       {
@@ -93,12 +93,12 @@
       "06"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "creep_lifesteal"                                 "13 14 15"
+        "creep_lifesteal"                                 "15 20 25"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_hero_spell_lifesteal"                     "150"
+        "unholy_hero_spell_lifesteal"                     "200"
       }
       "08"
       {
@@ -109,6 +109,11 @@
       {
         "var_type"                                        "FIELD_FLOAT"
         "duration"                                        "5.0"
+      }
+      "10"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_status_resist"                             "10 15 20"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_satanic_core_3.txt
+++ b/game/scripts/npc/items/custom/item_satanic_core_3.txt
@@ -68,12 +68,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "40 55 75"
+        "bonus_strength"                                  "40 60 85"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intelligence"                              "40 55 75"
+        "bonus_intelligence"                              "40 60 85"
       }
       "03"
       {
@@ -93,12 +93,12 @@
       "06"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "creep_lifesteal"                                 "13 14 15"
+        "creep_lifesteal"                                 "15 20 25"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "unholy_hero_spell_lifesteal"                     "150"
+        "unholy_hero_spell_lifesteal"                     "200"
       }
       "08"
       {
@@ -109,6 +109,11 @@
       {
         "var_type"                                        "FIELD_FLOAT"
         "duration"                                        "5.0"
+      }
+      "10"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_status_resist"                             "10 15 20"
       }
     }
   }

--- a/game/scripts/vscripts/items/satanic_core.lua
+++ b/game/scripts/vscripts/items/satanic_core.lua
@@ -62,6 +62,7 @@ function modifier_item_satanic_core:DeclareFunctions()
     MODIFIER_PROPERTY_STATS_INTELLECT_BONUS,
     MODIFIER_PROPERTY_HEALTH_BONUS,
     MODIFIER_PROPERTY_MANA_BONUS,
+    MODIFIER_PROPERTY_STATUS_RESISTANCE_STACKING
     --MODIFIER_EVENT_ON_TAKEDAMAGE,
   }
   return funcs
@@ -81,6 +82,10 @@ end
 
 function modifier_item_satanic_core:GetModifierManaBonus()
   return self:GetAbility():GetSpecialValueFor("bonus_mana")
+end
+
+function modifier_item_satanic_core:GetModifierStatusResistanceStacking()
+  return self:GetAbility():GetSpecialValueFor("bonus_status_resist")
 end
 
 --[[


### PR DESCRIPTION
Because Valve is adding more healing and lifesteal reduction to the game. Satanic Core can be buffed.
* Buffed bonus intelligence to match Octarine Core levels 2-4
* Buffed bonus strength to match bonus intelligence numbers.
* Buffed Unholy Wrath spell lifesteal against heroes from 150% to 200%.
* Buffed passive spell lifesteal against creeps to match most lifesteal items.
* Added bonus status resistance to Satanic Core: 10%/15%/20%.