### PR TITLE
Sohei update

### DIFF
--- a/game/scripts/npc/abilities/sohei_flurry_of_blows_oaa.txt
+++ b/game/scripts/npc/abilities/sohei_flurry_of_blows_oaa.txt
@@ -71,7 +71,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "140 180 220 340 540"
+        "bonus_damage"                                    "140 220 300 540 940"
       }
       "06"
       {

--- a/game/scripts/npc/abilities/sohei_momentum_oaa.txt
+++ b/game/scripts/npc/abilities/sohei_momentum_oaa.txt
@@ -99,7 +99,7 @@
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "projectile_speed"                                "1200"
+        "projectile_speed"                                "1400"
       }
     }
   }

--- a/game/scripts/npc/herolist_cm.txt
+++ b/game/scripts/npc/herolist_cm.txt
@@ -121,7 +121,7 @@
   "npc_dota_hero_winter_wyvern"                           "1"
   "npc_dota_hero_abyssal_underlord"                       "1"
   "npc_dota_hero_arc_warden"                              "1"
-  "npc_dota_hero_sohei"                                   "0"
+  "npc_dota_hero_sohei"                                   "1"
   "npc_dota_hero_electrician"                             "1"
   "npc_dota_hero_grimstroke"                              "1"
   "npc_dota_hero_mars"                                    "1"


### PR DESCRIPTION
With nullifier buff, Sohei's W is not a big issue anymore. He can be added to Captain's mode. Buffed damage on ult and made Momentum Strike harder to dodge (same speed as Mars Spear).
* Added to Captain's mode
* Increased Flurry of Blows damage.
* Increased Momentum Strike projectile speed.