### PR TITLE
Giant Form buffs

### DIFF
--- a/game/scripts/npc/items/custom/item_giant_form.txt
+++ b/game/scripts/npc/items/custom/item_giant_form.txt
@@ -65,17 +65,17 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "35 50"
+        "bonus_agility"                                   "50 70"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "27 42"
+        "bonus_strength"                                  "42 62"
       }
-      "03"
+      "03" // ranged only
       {
         "var_type"                                        "FIELD_INTEGER"
-        "base_attack_range"                               "160 170"
+        "base_attack_range"                               "170 180"
       }
       "04"
       {
@@ -105,12 +105,12 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "giant_splash"                                    "100"
+        "giant_splash"                                    "150"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "giant_move_speed"                                "250"
+        "giant_move_speed"                                "290"
       }
       "11"
       {

--- a/game/scripts/npc/items/custom/item_giant_form_2.txt
+++ b/game/scripts/npc/items/custom/item_giant_form_2.txt
@@ -64,17 +64,17 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "35 50"
+        "bonus_agility"                                   "50 70"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "27 42"
+        "bonus_strength"                                  "42 62"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "base_attack_range"                               "160 170"
+        "base_attack_range"                               "170 180"
       }
       "04"
       {
@@ -104,12 +104,12 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "giant_splash"                                    "100"
+        "giant_splash"                                    "150"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "giant_move_speed"                                "250"
+        "giant_move_speed"                                "290"
       }
       "11"
       {


### PR DESCRIPTION
* Buffed bonus agility, strength and attack range to match Hurricane Pike stats.
* Buffed Giant Form splash damage from 100% to 150% (damage is reduced by armor so its not gamebreaking).
* Buffed Giant Form fixed movement speed from 250 to 290.