### PR TITLE
Antimage Mana Void Nerf

### DIFF
--- a/game/scripts/npc/abilities/antimage_mana_void.txt
+++ b/game/scripts/npc/abilities/antimage_mana_void.txt
@@ -47,7 +47,7 @@
       "01"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "mana_void_damage_per_mana"                       "0.8 1.1 1.4 1.85 2.3" //OAA
+        "mana_void_damage_per_mana"                       "0.8 0.95 1.1 1.25 1.4"
       }
       "02"
       {
@@ -57,7 +57,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "mana_void_aoe_radius"                            "300 350 400 450 500" //OAA
+        "mana_void_aoe_radius"                            "500"
       }
       "04"
       {


### PR DESCRIPTION
Reverted Antimage mana void back to default dota values. This includes the spell AOE. This nerf was unessecary and you should get punished by anti mage if you group up to close. 

This ultimate damage multiplier was not balanced around antimage being able to completely drain the targets mana. Due to the mana break changes he now can drain peoples mana, making this ultimates damage multiplier too strong. Additionally everybody has 25% magic resistance for the whole game. 

After these nerfs this spell should still be extremely strong, due to how it scales. This should put anti-mage into a niche role, allowing him to destroy mage heavy lineups without him being the kind of hero that just can OHKO anybody who buys a mana item. 