### PR TITLE
Bloodstone fixes

### DIFF
--- a/game/scripts/vscripts/items/bloodstone.lua
+++ b/game/scripts/vscripts/items/bloodstone.lua
@@ -296,7 +296,7 @@ end
 function modifier_item_bloodstone_non_stacking_stats:GetModifierSpellAmplify_Percentage()
   local ability = self:GetAbility()
   local parent = self:GetParent()
-  if parent:HasModifier("kaya_item_modifier_name") then
+  if not parent:HasModifier("kaya_item_modifier_name") then
     return ability:GetSpecialValueFor("spell_amp") + (ability:GetCurrentCharges() * ability:GetSpecialValueFor("amp_per_charge"))
   end
   return 0
@@ -304,7 +304,7 @@ end
 
 function modifier_item_bloodstone_non_stacking_stats:GetModifierPercentageManacostStacking()
   local parent = self:GetParent()
-  if parent:HasModifier("kaya_item_modifier_name") then
+  if not parent:HasModifier("kaya_item_modifier_name") then
     return self:GetAbility():GetSpecialValueFor("manacost_reduction")
   end
   return 0

--- a/game/scripts/vscripts/items/bloodstone.lua
+++ b/game/scripts/vscripts/items/bloodstone.lua
@@ -186,7 +186,7 @@ end
 
 function modifier_item_bloodstone_stacking_stats:GetModifierConstantHealthRegen()
   local ability = self:GetAbility()
-  return ability:GetSpecialValueFor("bonus_health_regen") + (ability:GetCurrentCharges() * ability:GetSpecialValueFor("regen_per_charge"))
+  return ability:GetSpecialValueFor("bonus_health_regen")--+ (ability:GetCurrentCharges() * ability:GetSpecialValueFor("regen_per_charge"))
 end
 
 function modifier_item_bloodstone_stacking_stats:GetModifierConstantManaRegen()
@@ -295,11 +295,19 @@ end
 
 function modifier_item_bloodstone_non_stacking_stats:GetModifierSpellAmplify_Percentage()
   local ability = self:GetAbility()
-  return ability:GetSpecialValueFor("spell_amp") + (ability:GetCurrentCharges() * ability:GetSpecialValueFor("amp_per_charge"))
+  local parent = self:GetParent()
+  if parent:HasModifier("kaya_item_modifier_name") then
+    return ability:GetSpecialValueFor("spell_amp") + (ability:GetCurrentCharges() * ability:GetSpecialValueFor("amp_per_charge"))
+  end
+  return 0
 end
 
 function modifier_item_bloodstone_non_stacking_stats:GetModifierPercentageManacostStacking()
-  return self:GetAbility():GetSpecialValueFor("manacost_reduction")
+  local parent = self:GetParent()
+  if parent:HasModifier("kaya_item_modifier_name") then
+    return self:GetAbility():GetSpecialValueFor("manacost_reduction")
+  end
+  return 0
 end
 
 --------------------------------------------------------------------------

--- a/game/scripts/vscripts/items/bloodstone.lua
+++ b/game/scripts/vscripts/items/bloodstone.lua
@@ -296,7 +296,7 @@ end
 function modifier_item_bloodstone_non_stacking_stats:GetModifierSpellAmplify_Percentage()
   local ability = self:GetAbility()
   local parent = self:GetParent()
-  if not parent:HasModifier("kaya_item_modifier_name") then
+  if not parent:HasModifier("modifier_item_kaya") and not parent:HasModifier("modifier_item_yasha_and_kaya") and not parent:HasModifier("modifier_item_kaya_and_sange") then
     return ability:GetSpecialValueFor("spell_amp") + (ability:GetCurrentCharges() * ability:GetSpecialValueFor("amp_per_charge"))
   end
   return 0
@@ -304,7 +304,7 @@ end
 
 function modifier_item_bloodstone_non_stacking_stats:GetModifierPercentageManacostStacking()
   local parent = self:GetParent()
-  if not parent:HasModifier("kaya_item_modifier_name") then
+  if not parent:HasModifier("modifier_item_kaya") and not parent:HasModifier("modifier_item_yasha_and_kaya") and not parent:HasModifier("modifier_item_kaya_and_sange") then
     return self:GetAbility():GetSpecialValueFor("manacost_reduction")
   end
   return 0


### PR DESCRIPTION
* Fixed Bloodstone giving hp regen while it shouldnt
* Fixed Bloodstone and Kaya variants stacking their spell amp and manacost/manaloss reductions.
If you have Bloodstone and a Kaya variant in your inventory, Kaya variant will have priority.