### PR TITLE
Dagger of Moriah buffs

### DIFF
--- a/game/resource/English/ability/items/transformation/tooltip_dagger_of_moriah.txt
+++ b/game/resource/English/ability/items/transformation/tooltip_dagger_of_moriah.txt
@@ -3,7 +3,7 @@
 //==================================================================
 "DOTA_Tooltip_Ability_item_dagger_of_moriah"                            "Dagger of Moriah"
 "DOTA_Tooltip_Ability_item_recipe_dagger_of_moriah"                     "Dagger of Moriah Recipe"
-"DOTA_Tooltip_Ability_item_dagger_of_moriah_Description"                "<h1>Active: Sangromancy</h1> Grants %sangromancy_spell_amp%%% spell amplification but reflects %sangromancy_self_damage%%% of the damage you deal with spells back to you, and increases damage you take from enemies by %sangromancy_spell_amp%%%. Lasts %duration% seconds.<br>Self-inflicted damage is not lethal."
+"DOTA_Tooltip_Ability_item_dagger_of_moriah_Description"                "<h1>Active: Sangromancy</h1> Grants %sangromancy_spell_amp%%% spell amplification but reflects %sangromancy_self_damage%%% of the damage you deal with spells back to you, and increases damage you take from enemies by %sangromancy_bonus_damage_from_others%%%. Lasts %duration% seconds.<br>Self-inflicted damage is not lethal."
 "DOTA_Tooltip_Ability_item_dagger_of_moriah_Note0"                      "Self-inflicted damage is not amplified, it can be reduced and it is of the same type as the spell that caused it."
 //"DOTA_Tooltip_Ability_item_dagger_of_moriah_Note1"                      "#{transformation_note0}"
 "DOTA_Tooltip_Ability_item_dagger_of_moriah_bonus_health_regen"         "+$hp_regen"

--- a/game/scripts/npc/items/custom/item_dagger_of_moriah.txt
+++ b/game/scripts/npc/items/custom/item_dagger_of_moriah.txt
@@ -73,7 +73,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sangromancy_spell_amp"                           "50 75"
+        "sangromancy_spell_amp"                           "75 100"
       }
       "02"
       {
@@ -83,19 +83,24 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "25 40"
+        "sangromancy_bonus_damage_from_others"            "50"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "25 40"
+        "bonus_health_regen"                              "25 40"
       }
       "05"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_all_stats"                                 "40 60"
+      }
+      "06"
       {
         "var_type"                                        "FIELD_FLOAT"
         "bonus_mana_regen"                                "6.0 7.5"
       }
-      "06"
+      "07"
       {
         "var_type"                                        "FIELD_FLOAT"
         "duration"                                        "6.0"

--- a/game/scripts/npc/items/custom/item_dagger_of_moriah_2.txt
+++ b/game/scripts/npc/items/custom/item_dagger_of_moriah_2.txt
@@ -69,7 +69,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sangromancy_spell_amp"                           "50 75"
+        "sangromancy_spell_amp"                           "75 100"
       }
       "02"
       {
@@ -79,19 +79,24 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "25 40"
+        "sangromancy_bonus_damage_from_others"            "50"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "25 40"
+        "bonus_health_regen"                              "25 40"
       }
       "05"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_all_stats"                                 "40 60"
+      }
+      "06"
       {
         "var_type"                                        "FIELD_FLOAT"
         "bonus_mana_regen"                                "6.0 7.5"
       }
-      "06"
+      "07"
       {
         "var_type"                                        "FIELD_FLOAT"
         "duration"                                        "6.0"

--- a/game/scripts/vscripts/items/transformation/dagger_of_moriah.lua
+++ b/game/scripts/vscripts/items/transformation/dagger_of_moriah.lua
@@ -42,6 +42,7 @@ function modifier_item_dagger_of_moriah_sangromancy:OnCreated( event )
 
   self.spellamp = spell:GetSpecialValueFor( "sangromancy_spell_amp" )
   self.selfDamage = spell:GetSpecialValueFor( "sangromancy_self_damage" )
+  self.bonusDamagefromOthers = spell:GetSpecialValueFor( "sangromancy_bonus_damage_from_others" )
 
   if IsServer() and self.nPreviewFX == nil then
     self.nPreviewFX = ParticleManager:CreateParticle( "particles/items/dagger_of_moriah/dagger_of_moriah_ambient_smoke.vpcf", PATTACH_ABSORIGIN_FOLLOW, self:GetParent() )
@@ -64,6 +65,7 @@ function modifier_item_dagger_of_moriah_sangromancy:OnRefresh( event )
 
   self.spellamp = spell:GetSpecialValueFor( "sangromancy_spell_amp" )
   self.selfDamage = spell:GetSpecialValueFor( "sangromancy_self_damage" )
+  self.bonusDamagefromOthers = spell:GetSpecialValueFor( "sangromancy_bonus_damage_from_others" )
 end
 
 function modifier_item_dagger_of_moriah_sangromancy:OnRemoved()
@@ -95,7 +97,7 @@ function modifier_item_dagger_of_moriah_sangromancy:GetModifierIncomingDamage_Pe
   if event.attacker == self:GetParent() then
     return 0
   else
-    return self.spellamp or spell:GetSpecialValueFor( "sangromancy_spell_amp" )
+    return self.bonusDamagefromOthers or spell:GetSpecialValueFor( "sangromancy_bonus_damage_from_others" )
   end
 end
 


### PR DESCRIPTION
* Sangromancy spell Amp increased from 50%/75% to 75%/100%
* Sangromancy bonus damage taken from others reduced from 50%/75% to 50%.
* Bonus all stats increased from 25/40 to 40/60.