### PR TITLE
Upgraded Power Treads buffs

### DIFF
--- a/game/scripts/npc/items/farming/item_greater_power_treads.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads.txt
@@ -76,7 +76,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 15 25 40"
+        "bonus_damage"                                    "10 30 60 100"
       }
       "05"
       {
@@ -86,12 +86,12 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_magic_resistance"                          "10 12 14 16"
+        "bonus_magic_resistance"                          "12 14 16 18"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_spell_amp"                                 "9 12 15 18"
+        "bonus_spell_amp"                                 "8 12 16 20"
       }
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_power_treads_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads_2.txt
@@ -76,7 +76,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 15 25 40"
+        "bonus_damage"                                    "10 30 60 100"
       }
       "05"
       {
@@ -86,12 +86,12 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_magic_resistance"                          "10 12 14 16"
+        "bonus_magic_resistance"                          "12 14 16 18"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_spell_amp"                                 "9 12 15 18"
+        "bonus_spell_amp"                                 "8 12 16 20"
       }
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_power_treads_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads_3.txt
@@ -76,7 +76,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 15 25 40"
+        "bonus_damage"                                    "10 30 60 100"
       }
       "05"
       {
@@ -86,12 +86,12 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_magic_resistance"                          "10 12 14 16"
+        "bonus_magic_resistance"                          "12 14 16 18"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_spell_amp"                                 "9 12 15 18"
+        "bonus_spell_amp"                                 "8 12 16 20"
       }
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_power_treads_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads_4.txt
@@ -76,7 +76,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 15 25 40"
+        "bonus_damage"                                    "10 30 60 100"
       }
       "05"
       {
@@ -86,12 +86,12 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_magic_resistance"                          "10 12 14 16"
+        "bonus_magic_resistance"                          "12 14 16 18"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_spell_amp"                                 "9 12 15 18"
+        "bonus_spell_amp"                                 "8 12 16 20"
       }
     }
   }


### PR DESCRIPTION
* Increased bonus damage from 10/15/25/40 to 10/30/60/100 (when toggled to AGI)
* Increased bonus magic resistance from 10%/12%/14%/16% to 12%/14%/16%/18% (when toggled to STR)
* Rescaled bonus spell amp from 9%/12%/15%/18% to 8%/12%/16%/20% (when toggled to INT).