### PR TITLE
Disables leaving penalties temporarily

### DIFF
--- a/game/addoninfo.txt
+++ b/game/addoninfo.txt
@@ -3,7 +3,7 @@
 	"TeamCount" 	      "3"
 	"maps"	            "oaa oaa_winter captains_mode 10v10"
 	"IsPlayable"	      "1"
-  "PenaltiesEnabled"  "1"
+  "PenaltiesEnabled"  "0"
   "EnablePickRules"   "1"
   "oaa"
   {


### PR DESCRIPTION
Until we are sure crashes are gone with Void Spirit.