### PR TITLE
Vampire Fang buffs and fixes

### DIFF
--- a/game/resource/English/ability/items/transformation/tooltip_vampire.txt
+++ b/game/resource/English/ability/items/transformation/tooltip_vampire.txt
@@ -8,7 +8,7 @@
 "dota_tooltip_ability_item_vampire_bonus_strength"                              "+$str"
 "dota_tooltip_ability_item_vampire_bonus_damage"                                "+$damage"
 "dota_tooltip_ability_item_vampire_bonus_attack_speed"                          "+$attack"
-"dota_tooltip_ability_item_vampire_bonus_status_resistance"                     "+$status_resist"
+"dota_tooltip_ability_item_vampire_bonus_status_resistance"                     "%+Status Resistance"
 "dota_tooltip_ability_item_vampire_Lore"                                        "A fang of fallen vampire that grants you vampire powers and weaknesses."
 
 "dota_tooltip_ability_item_vampire_2"                                           "#{dota_tooltip_ability_item_vampire}"

--- a/game/resource/English/ability/items/transformation/tooltip_vampire.txt
+++ b/game/resource/English/ability/items/transformation/tooltip_vampire.txt
@@ -9,6 +9,7 @@
 "dota_tooltip_ability_item_vampire_bonus_damage"                                "+$damage"
 "dota_tooltip_ability_item_vampire_bonus_attack_speed"                          "+$attack"
 "dota_tooltip_ability_item_vampire_bonus_status_resistance"                     "%+Status Resistance"
+"dota_tooltip_ability_item_vampire_bonus_night_vision"                          "+Night Vision"
 "dota_tooltip_ability_item_vampire_Lore"                                        "A fang of fallen vampire that grants you vampire powers and weaknesses."
 
 "dota_tooltip_ability_item_vampire_2"                                           "#{dota_tooltip_ability_item_vampire}"
@@ -19,6 +20,7 @@
 "dota_tooltip_ability_item_vampire_2_bonus_damage"                              "#{dota_tooltip_ability_item_vampire_bonus_damage}"
 "dota_tooltip_ability_item_vampire_2_bonus_attack_speed"                        "#{dota_tooltip_ability_item_vampire_bonus_attack_speed}"
 "dota_tooltip_ability_item_vampire_2_bonus_status_resistance"                   "#{dota_tooltip_ability_item_vampire_bonus_status_resistance}"
+"dota_tooltip_ability_item_vampire_2_bonus_night_vision"                        "#{dota_tooltip_ability_item_vampire_bonus_night_vision}"
 "dota_tooltip_ability_item_vampire_2_Lore"                                      "#{dota_tooltip_ability_item_vampire_Lore}"
 
 "dota_tooltip_modifier_item_vampire_active"                                     "Vampirism"

--- a/game/scripts/npc/items/custom/item_vampire.txt
+++ b/game/scripts/npc/items/custom/item_vampire.txt
@@ -74,12 +74,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "75 100"
+        "bonus_damage"                                    "100 125"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_status_resistance"                         "20 25"
+        "bonus_status_resistance"                         "25 30"
       }
       "04"
       {
@@ -89,7 +89,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "lifesteal_percent"                               "35 40"
+        "lifesteal_percent"                               "40 45"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_vampire.txt
+++ b/game/scripts/npc/items/custom/item_vampire.txt
@@ -89,24 +89,29 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "lifesteal_percent"                               "40 45"
+        "bonus_night_vision"                              "400 600"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_lifesteal_percent"                        "215 225"
+        "lifesteal_percent"                               "40 45"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage_per_second_pct"                           "8"
+        "active_lifesteal_percent"                        "215 225"
       }
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "ticks_per_second"                                "4"
+        "damage_per_second_pct"                           "8"
       }
       "09"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "ticks_per_second"                                "4"
+      }
+      "10"
       {
         "var_type"                                        "FIELD_FLOAT"
         "duration"                                        "6.0"

--- a/game/scripts/npc/items/custom/item_vampire.txt
+++ b/game/scripts/npc/items/custom/item_vampire.txt
@@ -84,7 +84,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "30 40"
+        "bonus_attack_speed"                              "40 50"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_vampire_2.txt
+++ b/game/scripts/npc/items/custom/item_vampire_2.txt
@@ -75,12 +75,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "75 100"
+        "bonus_damage"                                    "100 125"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_status_resistance"                         "20 25"
+        "bonus_status_resistance"                         "25 30"
       }
       "04"
       {
@@ -90,7 +90,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "lifesteal_percent"                               "35 40"
+        "lifesteal_percent"                               "40 45"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_vampire_2.txt
+++ b/game/scripts/npc/items/custom/item_vampire_2.txt
@@ -90,24 +90,29 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "lifesteal_percent"                               "40 45"
+        "bonus_night_vision"                              "400 600"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_lifesteal_percent"                        "215 225"
+        "lifesteal_percent"                               "40 45"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage_per_second_pct"                           "8"
+        "active_lifesteal_percent"                        "215 225"
       }
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "ticks_per_second"                                "4"
+        "damage_per_second_pct"                           "8"
       }
       "09"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "ticks_per_second"                                "4"
+      }
+      "10"
       {
         "var_type"                                        "FIELD_FLOAT"
         "duration"                                        "6.0"

--- a/game/scripts/npc/items/custom/item_vampire_2.txt
+++ b/game/scripts/npc/items/custom/item_vampire_2.txt
@@ -85,7 +85,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "30 40"
+        "bonus_attack_speed"                              "40 50"
       }
       "05"
       {

--- a/game/scripts/vscripts/items/transformation/vampire.lua
+++ b/game/scripts/vscripts/items/transformation/vampire.lua
@@ -143,7 +143,7 @@ function modifier_item_vampire_active:OnIntervalThink()
       attacker = parent,
       damage = damage,
       damage_type = DAMAGE_TYPE_PURE,
-      damage_flags = bit.bor(DOTA_DAMAGE_FLAG_HPLOSS, DOTA_DAMAGE_FLAG_NO_DAMAGE_MULTIPLIERS, DOTA_DAMAGE_FLAG_REFLECTION, DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION),
+      damage_flags = bit.bor(DOTA_DAMAGE_FLAG_HPLOSS, DOTA_DAMAGE_FLAG_NO_DAMAGE_MULTIPLIERS, DOTA_DAMAGE_FLAG_REFLECTION, DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION, DOTA_DAMAGE_FLAG_NO_SPELL_LIFESTEAL),
       ability = spell,
     }
 

--- a/game/scripts/vscripts/items/transformation/vampire.lua
+++ b/game/scripts/vscripts/items/transformation/vampire.lua
@@ -77,9 +77,7 @@ function modifier_item_vampire:OnTakeDamage( event )
     local parent = self:GetParent()
     local spell = self:GetAbility()
 
-    if not spell.mod then
-      vampire.lifesteal(self, event, spell, parent, spell:GetSpecialValueFor('lifesteal_percent'))
-    end
+    vampire.lifesteal(self, event, spell, parent, spell:GetSpecialValueFor('lifesteal_percent'))
   end
 end
 

--- a/game/scripts/vscripts/items/transformation/vampire.lua
+++ b/game/scripts/vscripts/items/transformation/vampire.lua
@@ -37,6 +37,7 @@ function modifier_item_vampire:DeclareFunctions()
     MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT,
     MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE,
     MODIFIER_PROPERTY_STATS_STRENGTH_BONUS,
+    MODIFIER_PROPERTY_BONUS_NIGHT_VISION,
     MODIFIER_EVENT_ON_TAKEDAMAGE,
     MODIFIER_EVENT_ON_ATTACK_LANDED
   }
@@ -61,6 +62,10 @@ end
 
 function modifier_item_vampire:GetModifierAttackSpeedBonus_Constant()
   return self:GetAbility():GetSpecialValueFor("bonus_attack_speed")
+end
+
+function modifier_item_vampire:GetBonusNightVision()
+  return self:GetAbility():GetSpecialValueFor("bonus_night_vision")
 end
 
 -- Have to check for process_procs flag in OnAttackLanded as the flag won't be set in OnTakeDamage

--- a/game/scripts/vscripts/items/transformation/vampire.lua
+++ b/game/scripts/vscripts/items/transformation/vampire.lua
@@ -140,7 +140,7 @@ function modifier_item_vampire_active:OnIntervalThink()
       attacker = parent,
       damage = damage,
       damage_type = DAMAGE_TYPE_PURE,
-      damage_flags = bit.bor(DOTA_DAMAGE_FLAG_HPLOSS, DOTA_DAMAGE_FLAG_NO_DAMAGE_MULTIPLIERS, DOTA_DAMAGE_FLAG_REFLECTION),
+      damage_flags = bit.bor(DOTA_DAMAGE_FLAG_HPLOSS, DOTA_DAMAGE_FLAG_NO_DAMAGE_MULTIPLIERS, DOTA_DAMAGE_FLAG_REFLECTION, DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION),
       ability = spell,
     }
 
@@ -160,9 +160,10 @@ end
 
 function modifier_item_vampire_active:GetDisableHealing( kv )
   if IsServer() then
+    -- Don't disable healing during the night
     if not GameRules:IsDaytime() then
       return 0
-	end
+    end
     -- Check that event is being called for the unit that self is attached to
     if self.isVampHeal then
       return 0
@@ -216,8 +217,8 @@ function vampire:lifesteal(event, spell, parent, amount)
     local ufResult = UnitFilter(
       target,
       DOTA_UNIT_TARGET_TEAM_ENEMY,
-      DOTA_UNIT_TARGET_BASIC + DOTA_UNIT_TARGET_HERO,
-      DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES,
+      bit.bor(DOTA_UNIT_TARGET_BASIC, DOTA_UNIT_TARGET_HERO),
+      bit.bor(DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, DOTA_UNIT_TARGET_FLAG_DEAD),
       parentTeam
     )
 


### PR DESCRIPTION
* Bonus damage increased from 75/100 to 100/125.
* Bonus status resistance increased from 20%/25% to 25%/30%.
* Passive lifesteal increased from 35%/40% to 40%/45%.
* Fixed self damage being affected by spell amp. Self damage should not be amplified by anything.
* Fixed Vampire Fang lifesteal not working on dead units.
* Bonus attack speed increased from 30/40 to 40/50.
* Fixed passive lifesteal not working at all. Lmao.
* Vampire Fang now also give 400/600 bonus night vision.
* Fixed Vampire Fang tooltips.
* Fixed spell lifesteal working on self damage. Spell Lifesteal should not work on self damage.