### PR TITLE
Abyssal Blade tweaks

### DIFF
--- a/game/scripts/npc/items/item_abyssal_blade.txt
+++ b/game/scripts/npc/items/item_abyssal_blade.txt
@@ -115,7 +115,7 @@
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bash_cooldown"                                   "2.3"
+        "bash_cooldown"                                   "2.5" //OAA
       }
       "12"
       {

--- a/game/scripts/npc/items/item_abyssal_blade.txt
+++ b/game/scripts/npc/items/item_abyssal_blade.txt
@@ -28,7 +28,7 @@
     // General
     //-------------------------------------------------------------------------------------------------------------
     "ID"                                                  "208"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_ROOT_DISABLES" //OAA
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
     "AbilityTextureName"                                  "custom/abyssal_blade"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"

--- a/game/scripts/npc/items/item_abyssal_blade_2.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_2.txt
@@ -115,7 +115,7 @@
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bash_cooldown"                                   "2.3"
+        "bash_cooldown"                                   "2.5"
       }
       "12"
       {

--- a/game/scripts/npc/items/item_abyssal_blade_2.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_2.txt
@@ -28,7 +28,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "ID"                                                  "3112"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "BaseClass"                                           "item_abyssal_blade"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_ROOT_DISABLES"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
     "AbilityTextureName"                                  "custom/abyssal_blade_2"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"

--- a/game/scripts/npc/items/item_abyssal_blade_3.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_3.txt
@@ -115,7 +115,7 @@
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bash_cooldown"                                   "2.3"
+        "bash_cooldown"                                   "2.5"
       }
       "12"
       {

--- a/game/scripts/npc/items/item_abyssal_blade_3.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_3.txt
@@ -28,7 +28,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "ID"                                                  "3113"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "BaseClass"                                           "item_abyssal_blade"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_ROOT_DISABLES"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
     "AbilityTextureName"                                  "custom/abyssal_blade_3"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"

--- a/game/scripts/npc/items/item_abyssal_blade_4.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_4.txt
@@ -29,7 +29,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "ID"                                                  "3114"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "BaseClass"                                           "item_abyssal_blade"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_ROOT_DISABLES"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
     "AbilityTextureName"                                  "custom/abyssal_blade_4"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"

--- a/game/scripts/npc/items/item_abyssal_blade_4.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_4.txt
@@ -116,7 +116,7 @@
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bash_cooldown"                                   "2.3"
+        "bash_cooldown"                                   "2.5"
       }
       "12"
       {

--- a/game/scripts/npc/items/item_abyssal_blade_5.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_5.txt
@@ -31,7 +31,7 @@
     "ID"                                                  "3115"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "BaseClass"                                           "item_abyssal_blade"
     "AbilityTextureName"                                  "custom/abyssal_blade_5"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_ROOT_DISABLES"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"

--- a/game/scripts/npc/items/item_abyssal_blade_5.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_5.txt
@@ -116,7 +116,7 @@
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bash_cooldown"                                   "2.3"
+        "bash_cooldown"                                   "2.5"
       }
       "12"
       {


### PR DESCRIPTION
* Abyssal Blade can be used while rooted (like vanilla). Cast range unchanged: 200
* Bash cooldown increased from 2.3 to 2.5 (small permabash nerf). 

Notes: Bash cooldown should be 4.3 seconds if you ask me. Why? Bash duration (1.5) + Overwhelm stun duration (2.0) + reaction time (0.8) = 4.3 -> With 4.3s it wouldn't be possible to bash -> use active -> bash in succession and stun them for **5** seconds. Luckily for us: status resistance exists and bash can proc during overwhelm stun or not proc before using the active. In other words 5 seconds is a theoretical maximum stun duration against a unit with 0% status resistance. You would say this edge case rarely happens, but what will you do when it happens to you in a game? :)