### PR TITLE
Imp Claw buffs

### DIFF
--- a/game/scripts/npc/items/item_imp_claw.txt
+++ b/game/scripts/npc/items/item_imp_claw.txt
@@ -69,7 +69,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "crit_multiplier"                                 "450"
+        "crit_multiplier"                                 "400 450"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_imp_claw.txt
+++ b/game/scripts/npc/items/item_imp_claw.txt
@@ -46,18 +46,18 @@
     "MaxUpgradeLevel"                                     "2"
     "ItemBaseLevel"                                       "1"
 
-    "AbilityCooldown"                                     "8.0"
+    "AbilityCooldown"                                     "6.0"
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "17725" //OAA
+    "ItemCost"                                            "17725"
     "ItemShopTags"                                        "damage;crit"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "imp claw;crit claw"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
-    "ItemIsNeutralDrop"                                   "0" //OAA
-    "ItemPurchasable"                                     "1" //OAA
+    "ItemIsNeutralDrop"                                   "0"
+    "ItemPurchasable"                                     "1"
     "ItemShareability"                                    "ITEM_NOT_SHAREABLE"
 
     "Model"                                               "models/props_gameplay/neutral_box.vmdl"
@@ -69,12 +69,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "crit_multiplier"                                 "300" //OAA
+        "crit_multiplier"                                 "450"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "200 280" //OAA
+        "bonus_damage"                                    "200 280"
       }
     }
   }

--- a/game/scripts/npc/items/item_imp_claw_2.txt
+++ b/game/scripts/npc/items/item_imp_claw_2.txt
@@ -47,7 +47,7 @@
     "MaxUpgradeLevel"                                     "2"
     "ItemBaseLevel"                                       "2"
 
-    "AbilityCooldown"                                     "8.0"
+    "AbilityCooldown"                                     "6.0"
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
@@ -70,7 +70,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "crit_multiplier"                                 "300"
+        "crit_multiplier"                                 "450"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_imp_claw_2.txt
+++ b/game/scripts/npc/items/item_imp_claw_2.txt
@@ -70,7 +70,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "crit_multiplier"                                 "450"
+        "crit_multiplier"                                 "400 450"
       }
       "02"
       {


### PR DESCRIPTION
* Reduced cd from 8 to 6 seconds.
* Increased crit dmg from 300% to 450%.

Notes: If we want to make this item have the same average DPS as Daedalus the following formula would need to be satisfied:
**CD2 / cooldown = (AS * CC * (CD1-1))/(100 * BAT)**
where CD2 is Imp Claw crit dmg multiplier,
AS is hero's attack speed,
CC is Daedalus crit chance (0.3),
CD1 is Dadalus crit dmg multiplier (2.65/2.95),
and BAT is hero's base attack time.

Daedalus lvl 5 has 30% chance to deal 295% crit dmg. For Imp Claw to have the same DPS as Daedalus for a hero with 700 attack speed and 1.7 base attack time, Ratio CD2/cooldown needs to be around 2.4. Thats 1920% crit dmg multiplier on 8 seconds cooldown which would be ridiculous on illusion heroes. Or 720% crit dmg multiplier on 3 seconds cooldown which would be ridiculous on heroes with cooldown reduction.

**Conclusion**: I think the goal is to make Imp Claw better on heroes without too much attack speed but not to make Imp Claw brokenly overpowered on illusion heroes and heroes that have cooldown reduction.

If I made an error in calculations let me know:
Daedalus DPS = (AS * AD)/(100 * BAT) * (1+CC * CD1-CC)
Imp Claw DPS = (AS * AD)/(100 * BAT)+(AD * CD2)/cooldown
AD is attack damage