### PR TITLE
Silver Edge buffs

### DIFF
--- a/game/scripts/npc/items/item_silver_edge.txt
+++ b/game/scripts/npc/items/item_silver_edge.txt
@@ -61,7 +61,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "30 35 40 45 50"
+        "bonus_attack_speed"                              "30 40 50 60 70"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_silver_edge.txt
+++ b/game/scripts/npc/items/item_silver_edge.txt
@@ -61,12 +61,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "30 33 36 40 45"
+        "bonus_attack_speed"                              "30 35 40 45 50"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "15 19 24 30 38"
+        "bonus_all_stats"                                 "15 20 25 30 35"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_silver_edge_2.txt
+++ b/game/scripts/npc/items/item_silver_edge_2.txt
@@ -64,7 +64,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "30 35 40 45 50"
+        "bonus_attack_speed"                              "30 40 50 60 70"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_silver_edge_2.txt
+++ b/game/scripts/npc/items/item_silver_edge_2.txt
@@ -64,12 +64,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "30 33 36 40 45"
+        "bonus_attack_speed"                              "30 35 40 45 50"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "15 19 24 30 38"
+        "bonus_all_stats"                                 "15 20 25 30 35"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_silver_edge_3.txt
+++ b/game/scripts/npc/items/item_silver_edge_3.txt
@@ -64,7 +64,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "30 35 40 45 50"
+        "bonus_attack_speed"                              "30 40 50 60 70"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_silver_edge_3.txt
+++ b/game/scripts/npc/items/item_silver_edge_3.txt
@@ -64,12 +64,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "30 33 36 40 45"
+        "bonus_attack_speed"                              "30 35 40 45 50"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "15 19 24 30 38"
+        "bonus_all_stats"                                 "15 20 25 30 35"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_silver_edge_4.txt
+++ b/game/scripts/npc/items/item_silver_edge_4.txt
@@ -64,7 +64,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "30 35 40 45 50"
+        "bonus_attack_speed"                              "30 40 50 60 70"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_silver_edge_4.txt
+++ b/game/scripts/npc/items/item_silver_edge_4.txt
@@ -64,12 +64,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "30 33 36 40 45"
+        "bonus_attack_speed"                              "30 35 40 45 50"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "15 19 24 30 38"
+        "bonus_all_stats"                                 "15 20 25 30 35"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_silver_edge_5.txt
+++ b/game/scripts/npc/items/item_silver_edge_5.txt
@@ -63,12 +63,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "30 33 36 40 45"
+        "bonus_attack_speed"                              "30 35 40 45 50"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_all_stats"                                 "15 19 24 30 38"
+        "bonus_all_stats"                                 "15 20 25 30 35"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_silver_edge_5.txt
+++ b/game/scripts/npc/items/item_silver_edge_5.txt
@@ -63,7 +63,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "30 35 40 45 50"
+        "bonus_attack_speed"                              "30 40 50 60 70"
       }
       "03"
       {


### PR DESCRIPTION
* Bonus attack speed increased from 30/33/36/40/45 to 30/40/50/60/70.
* Bonus all stats rescaled from 15/19/24/30/38 to 15/20/25/30/35.

Used same scaling rule that was used on majority of the items. This item was forgotten for some reason.