### PR TITLE
Havoc Hammer buffs

### DIFF
--- a/game/scripts/npc/items/item_havoc_hammer.txt
+++ b/game/scripts/npc/items/item_havoc_hammer.txt
@@ -45,9 +45,9 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "15550" //OAA
-    "ItemIsNeutralDrop"                                   "0" //OAA
-    "ItemPurchasable"                                     "1" //OAA
+    "ItemCost"                                            "15550"
+    "ItemIsNeutralDrop"                                   "0"
+    "ItemPurchasable"                                     "1"
     "ItemShopTags"                                        "str;damage"
     "ItemQuality"                                         "artifact"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
@@ -66,12 +66,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "65 105" //OAA
+        "bonus_damage"                                    "105 155"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "80 120" //OAA
+        "bonus_strength"                                  "80 120"
       }
       "03"
       {
@@ -106,7 +106,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "nuke_base_dmg"                                   "225 375"
+        "nuke_base_dmg"                                   "550 650"
       }
       "10"
       {

--- a/game/scripts/npc/items/item_havoc_hammer_2.txt
+++ b/game/scripts/npc/items/item_havoc_hammer_2.txt
@@ -67,7 +67,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "65 105"
+        "bonus_damage"                                    "105 155"
       }
       "02"
       {
@@ -107,7 +107,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "nuke_base_dmg"                                   "225 375"
+        "nuke_base_dmg"                                   "550 650"
       }
       "10"
       {


### PR DESCRIPTION
* Increased bonus damage from 65/105 to 105/155 (to match Echo Sabre damage).
* Increased Havoc nuke base damage from 275/375 to 550/650.

Havoc damage should now be comparable with Ethereal Blade nuke dmg.