### PR TITLE
Blade of Judecca tweaks

### DIFF
--- a/game/resource/English/ability/items/tooltip_trumps_fist.txt
+++ b/game/resource/English/ability/items/tooltip_trumps_fist.txt
@@ -1,11 +1,12 @@
 //===============================================================================
 // Blade of Judecca (Covfefe)
 //===============================================================================
-
 "DOTA_Tooltip_Ability_item_trumps_fists"                                    "Blade of Judecca"
 "DOTA_Tooltip_Ability_item_recipe_trumps_fists"                             "Blade of Judecca Recipe"
-"DOTA_Tooltip_Ability_item_trumps_fists_Description"                        "<h1>Passive: Frostburn</h1> Your attacks apply a debuff that deals damage over time. Damage is equal to %heal_prevent_percent%%% of target's healing and hp regen. Debuff lasts for %heal_prevent_duration% seconds."//<br><br>The heal reduction decays linearly with the duration."
+"DOTA_Tooltip_Ability_item_trumps_fists_Description"                        "<h1>Passive: Frostburn</h1> Your attacks apply a debuff that deals damage to the affected enemy every time he gains health. Damage is equal to %heal_prevent_percent%%% of the gained health. Debuff lasts for %heal_prevent_duration% seconds."//<br><br>The heal reduction decays linearly with the duration."
 "DOTA_Tooltip_Ability_item_trumps_fists_Lore"                               "The ancient frozen hatred within this sacred blade has the power to cease bloodflow to the extremities of its victims."
+"DOTA_Tooltip_Ability_item_trumps_fists_Note0"                              "Frostburn is not converting or reducing healing, health regen and lifesteal, its just applying damage based on gained health."
+"DOTA_Tooltip_Ability_item_trumps_fists_Note1"                              "Frostburn pierces spell immunity and its not dispellable. But its duration is affected by status resistance."
 "DOTA_Tooltip_Ability_item_trumps_fists_bonus_damage"                       "+$damage"
 "DOTA_Tooltip_Ability_item_trumps_fists_bonus_all_stats"                    "+$all"
 "DOTA_Tooltip_Ability_item_trumps_fists_bonus_health"                       "+$health"
@@ -16,6 +17,8 @@
 "DOTA_Tooltip_Ability_item_recipe_trumps_fists_2"                           "#{DOTA_Tooltip_Ability_item_recipe_trumps_fists}"
 "DOTA_Tooltip_Ability_item_trumps_fists_2_Description"                      "#{DOTA_Tooltip_Ability_item_trumps_fists_Description}"
 "DOTA_Tooltip_Ability_item_trumps_fists_2_Lore"                             "#{DOTA_Tooltip_Ability_item_trumps_fists_Lore}"
+"DOTA_Tooltip_Ability_item_trumps_fists_2_Note0"                            "#{DOTA_Tooltip_Ability_item_trumps_fists_Note0}"
+"DOTA_Tooltip_Ability_item_trumps_fists_2_Note1"                            "#{DOTA_Tooltip_Ability_item_trumps_fists_Note1}"
 "DOTA_Tooltip_Ability_item_trumps_fists_2_bonus_damage"                     "#{DOTA_Tooltip_Ability_item_trumps_fists_bonus_damage}"
 "DOTA_Tooltip_Ability_item_trumps_fists_2_bonus_all_stats"                  "#{DOTA_Tooltip_Ability_item_trumps_fists_bonus_all_stats}"
 "DOTA_Tooltip_Ability_item_trumps_fists_2_bonus_health"                     "#{DOTA_Tooltip_Ability_item_trumps_fists_bonus_health}"

--- a/game/resource/English/modifier/items/modifier_trumps_fists.txt
+++ b/game/resource/English/modifier/items/modifier_trumps_fists.txt
@@ -1,5 +1,5 @@
 //=============================================================================
 // Trumps Fists UAM
 //=============================================================================
-"DOTA_Tooltip_modifier_item_trumps_fists_frostbite"                "Frostbite"
+"DOTA_Tooltip_modifier_item_trumps_fists_frostbite"                "Frostburn"
 "DOTA_Tooltip_modifier_item_trumps_fists_frostbite_Description"    "Every time you get healed you are damaged too."

--- a/game/scripts/npc/items/custom/item_trumps_fists.txt
+++ b/game/scripts/npc/items/custom/item_trumps_fists.txt
@@ -82,7 +82,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "heal_prevent_percent"                            "50 55"
+        "heal_prevent_percent"                            "50 75"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_trumps_fists_2.txt
+++ b/game/scripts/npc/items/custom/item_trumps_fists_2.txt
@@ -82,7 +82,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "heal_prevent_percent"                            "50 55"
+        "heal_prevent_percent"                            "50 75"
       }
       "06"
       {

--- a/game/scripts/vscripts/items/trumps_fists.lua
+++ b/game/scripts/vscripts/items/trumps_fists.lua
@@ -94,13 +94,17 @@ modifier_item_trumps_fists_frostbite = class(ModifierBaseClass)
 function modifier_item_trumps_fists_frostbite:OnCreated()
   if IsServer() then
     self.heal_prevent_percent = self:GetAbility():GetSpecialValueFor( "heal_prevent_percent" )
-    self.totalDuration = self:GetDuration() or self:GetAbility():GetSpecialValueFor( "heal_prevent_duration" )
-    self.health_fraction = 0
+    --self.totalDuration = self:GetDuration() or self:GetAbility():GetSpecialValueFor( "heal_prevent_duration" )
+    --self.health_fraction = 0
   end
 end
 
 function modifier_item_trumps_fists_frostbite:IsDebuff()
   return true
+end
+
+function modifier_item_trumps_fists_frostbite:IsPurgable()
+  return false
 end
 
 function modifier_item_trumps_fists_frostbite:DeclareFunctions()
@@ -127,21 +131,24 @@ function modifier_item_trumps_fists_frostbite:OnHealthGained( kv )
   end
 end
 ]]
+-- Deals damage every time a unit gains hp; damage is equal to percent of gained hp;
 function modifier_item_trumps_fists_frostbite:OnHealthGained( kv )
   if IsServer() then
     local unit = kv.unit
     local caster = self:GetCaster()
-    if unit == self:GetParent() and kv.gain > 0 and not unit:FindModifierByNameAndCaster("modifier_batrider_sticky_napalm", caster) then
-      local healPercent = self.heal_prevent_percent / 100
-      local damage = kv.gain * healPercent
-      local damage_table = {
-        victim = unit,
-        attacker = self:GetCaster(),
-        damage = damage,
-        damage_type = DAMAGE_TYPE_PURE,
-        ability = self:GetAbility()
-      }
-      ApplyDamage(damage_table)
+    if unit == self:GetParent() and kv.gain and not unit:FindModifierByNameAndCaster("modifier_batrider_sticky_napalm", caster) then
+      if kv.gain > 0 then
+        local heal_to_damage = self.heal_prevent_percent / 100
+        local damage = kv.gain * heal_to_damage
+        local damage_table = {
+          victim = unit,
+          attacker = caster,
+          damage = damage,
+          damage_type = DAMAGE_TYPE_PURE,
+          ability = self:GetAbility()
+        }
+        ApplyDamage(damage_table)
+      end
     end
   end
 end


### PR DESCRIPTION
* Reverted the heal to damage percent to the old pre-rework values: 50%/75%
* Made debuff undispellable (like Skadi debuff).
* Updated tooltips with better explanations of Blade of Judecca mechanics.
* Improved code a bit.

I am not sure if this item is powerful with these numbers or not. I still don't fully understand if the item will be overpowered if I put 100% for heal_prevent_percent because new Blade of Judecca is not reducing or blocking the heals/regen/lifesteal. New Blade of Judecca is doing dmg based on gained health every time affected unit gains health.