### PR TITLE
Capture Point timings tweaks and some code improvements

### DIFF
--- a/game/scripts/vscripts/components/bottlepass/server.lua
+++ b/game/scripts/vscripts/components/bottlepass/server.lua
@@ -58,7 +58,7 @@ function Bottlepass:SendWinner (winner)
   local abandonedPlayers = {}
 
   local playerBySteamid = {}
-  for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+  for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
     local steamid = PlayerResource:GetSteamAccountID(playerID)
     local player = PlayerResource:GetPlayer(playerID)
     playerBySteamid[tostring(steamid)] = playerID
@@ -122,7 +122,7 @@ function Bottlepass:SendTeams ()
   DebugPrint('Sending team data')
   local dire = {}
   local radiant = {}
-  for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+  for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
     local steamid = PlayerResource:GetSteamAccountID(playerID)
     if steamid ~= 0 then
       steamid = tostring(steamid)
@@ -144,7 +144,7 @@ end
 function Bottlepass:Ready ()
   local userList = {}
   local hostId = 0
-  for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+  for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
     local steamid = PlayerResource:GetSteamAccountID(playerID)
     if steamid ~= 0 then
       table.insert(userList, steamid)

--- a/game/scripts/vscripts/components/capturepoints/capturepoints.lua
+++ b/game/scripts/vscripts/components/capturepoints/capturepoints.lua
@@ -94,24 +94,26 @@ function CapturePoints:MinimapPing()
     Minimap:SpawnCaptureIcon(CurrentZones.right)
   end)
   Minimap:SpawnCaptureIcon(CurrentZones.left)
-  for playerId = 0,19 do
-    local player = PlayerResource:GetPlayer(playerId)
-    if player ~= nil then
-      if player:GetAssignedHero() then
-        if player:GetTeam() == DOTA_TEAM_BADGUYS then
-          MinimapEvent(DOTA_TEAM_GOODGUYS, player:GetAssignedHero(), CurrentZones.left.x,  CurrentZones.left.y, DOTA_MINIMAP_EVENT_HINT_LOCATION, 3)
-          Timers:CreateTimer(3.2, function ()
-            if player ~= nil and not player:IsNull() then
-              MinimapEvent(DOTA_TEAM_GOODGUYS, player:GetAssignedHero(), CurrentZones.right.x,  CurrentZones.right.y, DOTA_MINIMAP_EVENT_HINT_LOCATION , 3)
-            end
-          end)
-        else
-          MinimapEvent(DOTA_TEAM_GOODGUYS, player:GetAssignedHero(), CurrentZones.left.x,  CurrentZones.left.y, DOTA_MINIMAP_EVENT_HINT_LOCATION, 3)
-          Timers:CreateTimer(3.2, function ()
-            if player ~= nil and not player:IsNull() then
-              MinimapEvent(DOTA_TEAM_GOODGUYS, player:GetAssignedHero(), CurrentZones.right.x,  CurrentZones.right.y, DOTA_MINIMAP_EVENT_HINT_LOCATION , 3)
-            end
-          end)
+  for playerId = 0, DOTA_MAX_TEAM_PLAYERS-1 do
+    if PlayerResource:IsValidPlayerID(playerId) then
+      local player = PlayerResource:GetPlayer(playerId)
+      if player ~= nil and not player:IsNull() then
+        if player:GetAssignedHero() then
+          if player:GetTeam() == DOTA_TEAM_BADGUYS then
+            MinimapEvent(DOTA_TEAM_BADGUYS, player:GetAssignedHero(), CurrentZones.left.x, CurrentZones.left.y, DOTA_MINIMAP_EVENT_HINT_LOCATION, 3)
+            Timers:CreateTimer(3.2, function ()
+              if player ~= nil and not player:IsNull() then
+                MinimapEvent(DOTA_TEAM_BADGUYS, player:GetAssignedHero(), CurrentZones.right.x, CurrentZones.right.y, DOTA_MINIMAP_EVENT_HINT_LOCATION , 3)
+              end
+            end)
+          else
+            MinimapEvent(DOTA_TEAM_GOODGUYS, player:GetAssignedHero(), CurrentZones.left.x, CurrentZones.left.y, DOTA_MINIMAP_EVENT_HINT_LOCATION, 3)
+            Timers:CreateTimer(3.2, function ()
+              if player ~= nil and not player:IsNull() then
+                MinimapEvent(DOTA_TEAM_GOODGUYS, player:GetAssignedHero(), CurrentZones.right.x, CurrentZones.right.y, DOTA_MINIMAP_EVENT_HINT_LOCATION , 3)
+              end
+            end)
+          end
         end
       end
     end

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -276,47 +276,49 @@ function Duels:SplitDuelPlayers(options)
   local goodPlayers = {}
   local badPlayers = {}
 
-  for playerId = 0,19 do
-    local player = PlayerResource:GetPlayer(playerId)
-    if player ~= nil then
-      if player:GetAssignedHero() then
-        if player:GetTeam() == DOTA_TEAM_BADGUYS then
-          badPlayers[badPlayerIndex] = HeroState.SaveState(player:GetAssignedHero())
-          badPlayers[badPlayerIndex].id = playerId
-          -- used to generate keynames like badEnd1
-          -- not used in dota apis
-          badPlayers[badPlayerIndex].team = 'bad'
-          badPlayerIndex = badPlayerIndex + 1
-          validBadPlayerIndex = validBadPlayerIndex + 1
+  for playerId = 0, DOTA_MAX_TEAM_PLAYERS-1 do
+    if PlayerResource:IsValidPlayerID(playerId) then
+      local player = PlayerResource:GetPlayer(playerId)
+      if player ~= nil and not player:IsNull() then
+        if player:GetAssignedHero() then
+          if player:GetTeam() == DOTA_TEAM_BADGUYS then
+            badPlayers[badPlayerIndex] = HeroState.SaveState(player:GetAssignedHero())
+            badPlayers[badPlayerIndex].id = playerId
+            -- used to generate keynames like badEnd1
+            -- not used in dota apis
+            badPlayers[badPlayerIndex].team = 'bad'
+            badPlayerIndex = badPlayerIndex + 1
+            validBadPlayerIndex = validBadPlayerIndex + 1
 
-        elseif player:GetTeam() == DOTA_TEAM_GOODGUYS then
-          goodPlayers[goodPlayerIndex] = HeroState.SaveState(player:GetAssignedHero())
-          goodPlayers[goodPlayerIndex].id = playerId
-          goodPlayers[goodPlayerIndex].team = 'good'
-          goodPlayerIndex = goodPlayerIndex + 1
-          validGoodPlayerIndex = validGoodPlayerIndex + 1
+          elseif player:GetTeam() == DOTA_TEAM_GOODGUYS then
+            goodPlayers[goodPlayerIndex] = HeroState.SaveState(player:GetAssignedHero())
+            goodPlayers[goodPlayerIndex].id = playerId
+            goodPlayers[goodPlayerIndex].team = 'good'
+            goodPlayerIndex = goodPlayerIndex + 1
+            validGoodPlayerIndex = validGoodPlayerIndex + 1
+          end
+
+          HeroState.ResetState(player:GetAssignedHero())
         end
-
-        HeroState.ResetState(player:GetAssignedHero())
-      end
-    else
-      local hero = PlayerResource:GetSelectedHeroEntity(playerId)
-      local function CreateDisonnectedPlayer ()
-        return {
-          assignable = false
-        }
-      end
-      if hero ~= nil then
-        if PlayerResource:GetTeam(playerId) == DOTA_TEAM_BADGUYS then
-          badPlayers[badPlayerIndex] = CreateDisonnectedPlayer()
-          badPlayers[badPlayerIndex].id = playerId
-          badPlayers[badPlayerIndex].team = 'bad'
-          badPlayerIndex = badPlayerIndex + 1
-        elseif PlayerResource:GetTeam(playerId) == DOTA_TEAM_GOODGUYS then
-          goodPlayers[goodPlayerIndex] = CreateDisonnectedPlayer()
-          goodPlayers[goodPlayerIndex].id = playerId
-          goodPlayers[goodPlayerIndex].team = 'good'
-          goodPlayerIndex = goodPlayerIndex + 1
+      else
+        local hero = PlayerResource:GetSelectedHeroEntity(playerId)
+        local function CreateDisonnectedPlayer ()
+          return {
+            assignable = false
+          }
+        end
+        if hero ~= nil then
+          if PlayerResource:GetTeam(playerId) == DOTA_TEAM_BADGUYS then
+            badPlayers[badPlayerIndex] = CreateDisonnectedPlayer()
+            badPlayers[badPlayerIndex].id = playerId
+            badPlayers[badPlayerIndex].team = 'bad'
+            badPlayerIndex = badPlayerIndex + 1
+          elseif PlayerResource:GetTeam(playerId) == DOTA_TEAM_GOODGUYS then
+            goodPlayers[goodPlayerIndex] = CreateDisonnectedPlayer()
+            goodPlayers[goodPlayerIndex].id = playerId
+            goodPlayers[goodPlayerIndex].team = 'good'
+            goodPlayerIndex = goodPlayerIndex + 1
+          end
         end
       end
     end

--- a/game/scripts/vscripts/components/gold/gold.lua
+++ b/game/scripts/vscripts/components/gold/gold.lua
@@ -27,13 +27,13 @@ function Gold:Init()
 
   -- Set Bonus Passive GPM for each hero; vanilla gpm is always active (it was tied to couriers in 7.23 but not anymore)
   LinkLuaModifier("modifier_oaa_passive_gpm", "components/gold/gold.lua", LUA_MODIFIER_MOTION_NONE)
-  Gold.hasPassiveGPM = {}
+  self.hasPassiveGPM = {}
   GameEvents:OnHeroInGame(Gold.HeroSpawn)
 end
 
 function Gold:GetState ()
   local state = {}
-  for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+  for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
     local steamid = tostring(PlayerResource:GetSteamAccountID(playerID))
     state[steamid] = self:GetGold(playerID)
   end
@@ -42,7 +42,7 @@ function Gold:GetState ()
 end
 
 function Gold:LoadState (state)
-  for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+  for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
     local steamid = tostring(PlayerResource:GetSteamAccountID(playerID))
     if state[steamid] then
       self:SetGold(playerID, state[steamid])
@@ -176,7 +176,7 @@ function Gold.HeroSpawn(hero)
   if hero:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
     return
   end
-  if Gold.hasPassiveGPM[hero] then
+  if self.hasPassiveGPM[hero] then
     return
   end
   if hero:IsTempestDouble() or hero:IsClone() then

--- a/game/scripts/vscripts/components/heroselection/heroselection.lua
+++ b/game/scripts/vscripts/components/heroselection/heroselection.lua
@@ -192,7 +192,7 @@ function HeroSelection:BuildBottlePass()
   local special_arcanas = {}
   HeroSelection.SelectedBottle = {}
   HeroSelection.SelectedArcana = {}
-  for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+  for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
     local steamid = PlayerResource:GetSteamAccountID(playerID)
 
     if SPECIAL_BOTTLES[steamid] then
@@ -914,7 +914,7 @@ function HeroSelection:GetSteamAccountID(playerID)
 end
 
 function HeroSelection:ForceAssignHeroes()
-	for nPlayerID = 0, ( DOTA_MAX_TEAM_PLAYERS - 1 ) do
+	for nPlayerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
 		local hPlayer = PlayerResource:GetPlayer( nPlayerID )
 		if hPlayer and not PlayerResource:HasSelectedHero( nPlayerID ) then
 			hPlayer:MakeRandomHeroSelection()

--- a/game/scripts/vscripts/components/player/connection.lua
+++ b/game/scripts/vscripts/components/player/connection.lua
@@ -237,7 +237,7 @@ function PlayerConnection:CheckAbandons ()
   local direAbandons = 0
   local radiantAbandons = 0
 
-  for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+  for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
     local team = PlayerResource:GetTeam(playerID)
 
     if team == DOTA_TEAM_BADGUYS then

--- a/game/scripts/vscripts/components/saveload/heroes.lua
+++ b/game/scripts/vscripts/components/saveload/heroes.lua
@@ -3,7 +3,7 @@ SaveLoadStateHero = SaveLoadStateHero or class({})
 function SaveLoadStateHero:GetState ()
   local state = {}
 
-  for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+  for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
     local hero = PlayerResource:GetSelectedHeroEntity(playerID)
     local steamid = tostring(PlayerResource:GetSteamAccountID(playerID))
 
@@ -35,7 +35,7 @@ function SaveLoadStateHero:GetState ()
 end
 
 function SaveLoadStateHero:LoadState (state)
-  for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+  for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
     local hero = PlayerResource:GetSelectedHeroEntity(playerID)
     local steamid = tostring(PlayerResource:GetSteamAccountID(playerID))
 

--- a/game/scripts/vscripts/components/saveload/saveload.lua
+++ b/game/scripts/vscripts/components/saveload/saveload.lua
@@ -68,7 +68,7 @@ function SaveLoadState:GetPlayerList ()
     dire = {}
   }
 
-  for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+  for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
     local hero = PlayerResource:GetSelectedHeroName(playerID)
     local steamid = tostring(PlayerResource:GetSteamAccountID(playerID))
 

--- a/game/scripts/vscripts/components/zonecontrol/zones.lua
+++ b/game/scripts/vscripts/components/zonecontrol/zones.lua
@@ -226,8 +226,10 @@ function ZoneControl:EnforceRules (state)
     return
   end
 
-  for playerId = 0,19 do
-    ZoneControl:EnforceRulesOnPlayerId(state, playerId)
+  for playerId = 0, DOTA_MAX_TEAM_PLAYERS-1 do
+    if PlayerResource:IsValidPlayerID(playerId) then
+      ZoneControl:EnforceRulesOnPlayerId(state, playerId)
+    end
   end
 end
 

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -83,11 +83,11 @@ SPARK_LEVEL_4_TIME = 1500               -- 25 minutes
 SPARK_LEVEL_5_TIME = 2100               -- 35 minutes
 
 -- CapturePoints
-INITIAL_CAPTURE_POINT_DELAY = 600       -- how long after the clock hits 0 should the initial Capture Point start counting down
+INITIAL_CAPTURE_POINT_DELAY = 660       -- how long after the clock hits 0 should the initial Capture Point start counting down
 CAPTURE_FIRST_WARN = 60                 -- how many seconds before spawn of capture points the first ping on minimap will show
 CAPTURE_SECOND_WARN = 30                -- how many seconds before spawn of capture points the second ping on minimap will show
 CAPTURE_START_COUNTDOWN = 5             -- How many seconds to count down before each CapturePoint (added as a delay before the duel starts)
-CAPTURE_INTERVAL = 600                  -- time from CapturePoint beginning until next CapturePoint begins
+CAPTURE_INTERVAL = 480                  -- time from CapturePoint beginning until next CapturePoint begins
 CAPTURE_LENTGH = 30                     -- amount of time for 1 hero to capture the point (less with more)
 
 -- Bosses

--- a/game/scripts/vscripts/statcollection/lib/statcollection.lua
+++ b/game/scripts/vscripts/statcollection/lib/statcollection.lua
@@ -123,7 +123,7 @@ function statCollection:calcWinnersByTeam()
     local output = {}
     local winningTeam = self.winner
 
-    for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+    for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
         if PlayerResource:IsValidPlayerID(playerID) then
             output[PlayerResource:GetSteamAccountID(playerID)] = PlayerResource:GetTeam(playerID) == winningTeam and '1' or '0'
         end
@@ -245,7 +245,7 @@ function statCollection:sendStage1()
 
     -- Workout who is hosting
     local hostID = 0
-    for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+    for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
         if PlayerResource:IsValidPlayerID(playerID) then
             local player = PlayerResource:GetPlayer(playerID)
             if GameRules:PlayerHasCustomGameHostPrivileges(player) then
@@ -329,7 +329,7 @@ function statCollection:sendStage2()
 
     -- Build players array
     local players = {}
-    for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+    for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
         if PlayerResource:IsValidPlayerID(playerID) then
             table.insert(players, {
                 playerName = PlayerResource:GetPlayerName(playerID),
@@ -399,7 +399,7 @@ function statCollection:sendStage3(winners, lastRound)
 
     -- Build players array
     local players = {}
-    for playerID = 0, DOTA_MAX_TEAM_PLAYERS do
+    for playerID = 0, DOTA_MAX_TEAM_PLAYERS-1 do
         if PlayerResource:IsValidPlayerID(playerID) then
             local steamID = PlayerResource:GetSteamAccountID(playerID)
 


### PR DESCRIPTION
* First capture point now spawns at 11 minutes (after max duration duel, so there are no conflicts).
* Reduced capture points spawn interval from 10 to 8 minutes better match boss killing times.
* DOTA_MAX_TEAM_PLAYERS fixes (Added -1)
* Replaced 19 in for loops with DOTA_MAX_TEAM_PLAYERS-1. 19 is not the max playerID since forever.
* Added IsValidPlayerID(playerId) checks. I am not sure if it should be added in every loop with playerIDs.
