### PR TITLE
Rescaling mana and INT items

### DIFF
--- a/game/scripts/npc/items/custom/item_allied_cyclone.txt
+++ b/game/scripts/npc/items/custom/item_allied_cyclone.txt
@@ -76,12 +76,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "25 50 95 140"
+        "bonus_intellect"                                 "25 45 70 100"
       }
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "6.0 7.5 9.25 11.5"
+        "bonus_mana_regen"                                "5.25 5.75 9.0 10.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/custom/item_allied_cyclone_2.txt
+++ b/game/scripts/npc/items/custom/item_allied_cyclone_2.txt
@@ -70,12 +70,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "25 50 95 140"
+        "bonus_intellect"                                 "25 45 70 100"
       }
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "6.0 7.5 9.25 11.5"
+        "bonus_mana_regen"                                "5.25 5.75 9.0 10.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/custom/item_allied_cyclone_3.txt
+++ b/game/scripts/npc/items/custom/item_allied_cyclone_3.txt
@@ -70,12 +70,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "25 50 95 140"
+        "bonus_intellect"                                 "25 45 70 100"
       }
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "6.0 7.5 9.25 11.5"
+        "bonus_mana_regen"                                "5.25 5.75 9.0 10.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/custom/item_allied_cyclone_4.txt
+++ b/game/scripts/npc/items/custom/item_allied_cyclone_4.txt
@@ -73,12 +73,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "25 50 95 140"
+        "bonus_intellect"                                 "25 45 70 100"
       }
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "6.0 7.5 9.25 11.5"
+        "bonus_mana_regen"                                "5.25 5.75 9.0 10.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/custom/item_bubble_orb_1.txt
+++ b/game/scripts/npc/items/custom/item_bubble_orb_1.txt
@@ -79,12 +79,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "7.25 9.75"
+        "bonus_mana_regen"                                "7.0 9.0"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "700 1000"
+        "bonus_mana"                                      "610 850"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_bubble_orb_1.txt
+++ b/game/scripts/npc/items/custom/item_bubble_orb_1.txt
@@ -84,7 +84,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "610 850"
+        "bonus_mana"                                      "700 950"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_bubble_orb_2.txt
+++ b/game/scripts/npc/items/custom/item_bubble_orb_2.txt
@@ -80,12 +80,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "7.25 9.75"
+        "bonus_mana_regen"                                "7.0 9.0"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-	      "bonus_mana"                                      "700 1000"
+	      "bonus_mana"                                      "610 850"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_bubble_orb_2.txt
+++ b/game/scripts/npc/items/custom/item_bubble_orb_2.txt
@@ -85,7 +85,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-	      "bonus_mana"                                      "610 850"
+	      "bonus_mana"                                      "700 950"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_dagger_of_moriah.txt
+++ b/game/scripts/npc/items/custom/item_dagger_of_moriah.txt
@@ -98,7 +98,7 @@
       "06"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "6.0 7.5"
+        "bonus_mana_regen"                                "3.0 4.0"
       }
       "07"
       {

--- a/game/scripts/npc/items/custom/item_dagger_of_moriah_2.txt
+++ b/game/scripts/npc/items/custom/item_dagger_of_moriah_2.txt
@@ -94,7 +94,7 @@
       "06"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "6.0 7.5"
+        "bonus_mana_regen"                                "3.0 4.0"
       }
       "07"
       {

--- a/game/scripts/npc/items/custom/item_dispel_orb_1.txt
+++ b/game/scripts/npc/items/custom/item_dispel_orb_1.txt
@@ -91,7 +91,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "430 610 850"
+        "bonus_mana"                                      "500 700 950"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_dispel_orb_1.txt
+++ b/game/scripts/npc/items/custom/item_dispel_orb_1.txt
@@ -86,12 +86,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.75 7.25 9.75"
+        "bonus_mana_regen"                                "4.75 5.5 6.5"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "500 700 1000"
+        "bonus_mana"                                      "430 610 850"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_dispel_orb_2.txt
+++ b/game/scripts/npc/items/custom/item_dispel_orb_2.txt
@@ -79,12 +79,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.75 7.25 9.75"
+        "bonus_mana_regen"                                "4.75 5.5 6.5"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "500 700 1000"
+        "bonus_mana"                                      "430 610 850"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_dispel_orb_2.txt
+++ b/game/scripts/npc/items/custom/item_dispel_orb_2.txt
@@ -84,7 +84,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "430 610 850"
+        "bonus_mana"                                      "500 700 950"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_dispel_orb_3.txt
+++ b/game/scripts/npc/items/custom/item_dispel_orb_3.txt
@@ -85,7 +85,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "430 610 850"
+        "bonus_mana"                                      "500 700 950"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_dispel_orb_3.txt
+++ b/game/scripts/npc/items/custom/item_dispel_orb_3.txt
@@ -80,12 +80,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.75 7.25 9.75"
+        "bonus_mana_regen"                                "4.75 5.5 6.5"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "500 700 1000"
+        "bonus_mana"                                      "430 610 850"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_pull_staff.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff.txt
@@ -100,7 +100,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 30 45 60"
+        "bonus_intellect"                                 "25 45 70 100"
       }
       "02"
       {

--- a/game/scripts/npc/items/custom/item_pull_staff_2.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_2.txt
@@ -101,7 +101,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 30 45 60"
+        "bonus_intellect"                                 "25 45 70 100"
       }
       "02"
       {

--- a/game/scripts/npc/items/custom/item_pull_staff_3.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_3.txt
@@ -101,7 +101,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 30 45 60"
+        "bonus_intellect"                                 "25 45 70 100"
       }
       "02"
       {

--- a/game/scripts/npc/items/custom/item_pull_staff_4.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_4.txt
@@ -101,7 +101,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "15 30 45 60"
+        "bonus_intellect"                                 "25 45 70 100"
       }
       "02"
       {

--- a/game/scripts/npc/items/custom/item_reflection_shard_1.txt
+++ b/game/scripts/npc/items/custom/item_reflection_shard_1.txt
@@ -96,7 +96,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "9 11 13"
+        "bonus_mana_regen"                                "6.5 7.5 8.5"
       }
       "04"
       {

--- a/game/scripts/npc/items/custom/item_reflection_shard_2.txt
+++ b/game/scripts/npc/items/custom/item_reflection_shard_2.txt
@@ -84,7 +84,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "9 11 13"
+        "bonus_mana_regen"                                "6.5 7.5 8.5"
       }
       "04"
       {

--- a/game/scripts/npc/items/custom/item_reflection_shard_3.txt
+++ b/game/scripts/npc/items/custom/item_reflection_shard_3.txt
@@ -85,7 +85,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "9 11 13"
+        "bonus_mana_regen"                                "6.5 7.5 8.5"
       }
       "04"
       {

--- a/game/scripts/npc/items/custom/item_satanic_core.txt
+++ b/game/scripts/npc/items/custom/item_satanic_core.txt
@@ -82,7 +82,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "485 605 785"
+        "bonus_mana"                                      "675 875 1125"
       }
       "05" // name needs to be the same as in octarine core
       {

--- a/game/scripts/npc/items/custom/item_satanic_core.txt
+++ b/game/scripts/npc/items/custom/item_satanic_core.txt
@@ -82,7 +82,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "650 1000 1500"
+        "bonus_mana"                                      "485 605 785"
       }
       "05" // name needs to be the same as in octarine core
       {

--- a/game/scripts/npc/items/custom/item_satanic_core_2.txt
+++ b/game/scripts/npc/items/custom/item_satanic_core_2.txt
@@ -83,7 +83,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "650 1000 1500"
+        "bonus_mana"                                      "485 605 785"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_satanic_core_2.txt
+++ b/game/scripts/npc/items/custom/item_satanic_core_2.txt
@@ -83,7 +83,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "485 605 785"
+        "bonus_mana"                                      "675 875 1125"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_satanic_core_3.txt
+++ b/game/scripts/npc/items/custom/item_satanic_core_3.txt
@@ -83,7 +83,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "650 1000 1500"
+        "bonus_mana"                                      "485 605 785"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_satanic_core_3.txt
+++ b/game/scripts/npc/items/custom/item_satanic_core_3.txt
@@ -83,7 +83,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "485 605 785"
+        "bonus_mana"                                      "675 875 1125"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_trumps_fists.txt
+++ b/game/scripts/npc/items/custom/item_trumps_fists.txt
@@ -77,7 +77,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "1000 1250"
+        "bonus_mana"                                      "610 850"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_trumps_fists.txt
+++ b/game/scripts/npc/items/custom/item_trumps_fists.txt
@@ -77,7 +77,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "610 850"
+        "bonus_mana"                                      "700 950"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_trumps_fists_2.txt
+++ b/game/scripts/npc/items/custom/item_trumps_fists_2.txt
@@ -77,7 +77,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "1000 1250"
+        "bonus_mana"                                      "610 850"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_trumps_fists_2.txt
+++ b/game/scripts/npc/items/custom/item_trumps_fists_2.txt
@@ -77,7 +77,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "610 850"
+        "bonus_mana"                                      "700 950"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack.txt
@@ -88,7 +88,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.4 2.0 3.0 4.0 5.0"
+        "aura_mana_regen"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "06" // dota observer ward: 360
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_2.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_2.txt
@@ -88,7 +88,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.4 2.0 3.0 4.0 5.0"
+        "aura_mana_regen"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_3.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_3.txt
@@ -92,7 +92,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.4 2.0 3.0 4.0 5.0"
+        "aura_mana_regen"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_4.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_4.txt
@@ -91,7 +91,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.4 2.0 3.0 4.0 5.0"
+        "aura_mana_regen"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_ward_stack_5.txt
+++ b/game/scripts/npc/items/custom/item_ward_stack_5.txt
@@ -91,7 +91,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.4 2.0 3.0 4.0 5.0"
+        "aura_mana_regen"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "06"
       {

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves.txt
@@ -75,7 +75,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "350 550 850 1250"
+        "bonus_mana"                                      "310 430 610 850"
       }
       "03"
       {

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves.txt
@@ -75,7 +75,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "310 430 610 850"
+        "bonus_mana"                                      "350 500 700 950"
       }
       "03"
       {

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves_2.txt
@@ -77,7 +77,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "310 430 610 850"
+        "bonus_mana"                                      "350 500 700 950"
       }
       "03"
       {

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves_2.txt
@@ -77,7 +77,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "350 550 850 1250"
+        "bonus_mana"                                      "310 430 610 850"
       }
       "03"
       {

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves_3.txt
@@ -77,7 +77,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "310 430 610 850"
+        "bonus_mana"                                      "350 500 700 950"
       }
       "03"
       {

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves_3.txt
@@ -77,7 +77,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "350 550 850 1250"
+        "bonus_mana"                                      "310 430 610 850"
       }
       "03"
       {

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves_4.txt
@@ -77,7 +77,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "310 430 610 850"
+        "bonus_mana"                                      "350 500 700 950"
       }
       "03"
       {

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves_4.txt
@@ -77,7 +77,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "350 550 850 1250"
+        "bonus_mana"                                      "310 430 610 850"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk.txt
+++ b/game/scripts/npc/items/item_aeon_disk.txt
@@ -53,7 +53,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 360 480 660 900"
+        "bonus_mana"                                      "300 400 550 750 1000"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk.txt
+++ b/game/scripts/npc/items/item_aeon_disk.txt
@@ -53,7 +53,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 600 900 1200 1500"
+        "bonus_mana"                                      "300 360 480 660 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk_2.txt
+++ b/game/scripts/npc/items/item_aeon_disk_2.txt
@@ -54,7 +54,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 600 900 1200 1500"
+        "bonus_mana"                                      "300 360 480 660 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk_2.txt
+++ b/game/scripts/npc/items/item_aeon_disk_2.txt
@@ -54,7 +54,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 360 480 660 900"
+        "bonus_mana"                                      "300 400 550 750 1000"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk_3.txt
+++ b/game/scripts/npc/items/item_aeon_disk_3.txt
@@ -54,7 +54,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 600 900 1200 1500"
+        "bonus_mana"                                      "300 360 480 660 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk_3.txt
+++ b/game/scripts/npc/items/item_aeon_disk_3.txt
@@ -54,7 +54,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 360 480 660 900"
+        "bonus_mana"                                      "300 400 550 750 1000"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk_4.txt
+++ b/game/scripts/npc/items/item_aeon_disk_4.txt
@@ -55,7 +55,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 600 900 1200 1500"
+        "bonus_mana"                                      "300 360 480 660 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk_4.txt
+++ b/game/scripts/npc/items/item_aeon_disk_4.txt
@@ -55,7 +55,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 360 480 660 900"
+        "bonus_mana"                                      "300 400 550 750 1000"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk_5.txt
+++ b/game/scripts/npc/items/item_aeon_disk_5.txt
@@ -56,7 +56,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 360 480 660 900"
+        "bonus_mana"                                      "300 400 550 750 1000"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk_5.txt
+++ b/game/scripts/npc/items/item_aeon_disk_5.txt
@@ -56,7 +56,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 600 900 1200 1500"
+        "bonus_mana"                                      "300 360 480 660 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aether_lens.txt
+++ b/game/scripts/npc/items/item_aether_lens.txt
@@ -51,7 +51,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "450 510 630 810 1050"
+        "bonus_mana"                                      "450 550 700 900 1150"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_aether_lens.txt
+++ b/game/scripts/npc/items/item_aether_lens.txt
@@ -51,12 +51,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "450 900 1450 2000 2650"
+        "bonus_mana"                                      "450 510 630 810 1050"
       }
       "02"
       {
-        "var_type"        "FIELD_FLOAT"
-        "bonus_mana_regen"    "3.0 6.0 12.0 18.0 24.0"
+        "var_type"                                        "FIELD_FLOAT"
+        "bonus_mana_regen"                                "3.0 3.25 3.75 4.5 5.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aether_lens_2.txt
+++ b/game/scripts/npc/items/item_aether_lens_2.txt
@@ -53,7 +53,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "450 510 630 810 1050"
+        "bonus_mana"                                      "450 550 700 900 1150"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_aether_lens_2.txt
+++ b/game/scripts/npc/items/item_aether_lens_2.txt
@@ -53,12 +53,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "450 900 1450 2000 2650"
+        "bonus_mana"                                      "450 510 630 810 1050"
       }
       "02"
       {
-        "var_type"        "FIELD_FLOAT"
-        "bonus_mana_regen"    "3.0 6.0 12.0 18.0 24.0"
+        "var_type"                                        "FIELD_FLOAT"
+        "bonus_mana_regen"                                "3.0 3.25 3.75 4.5 5.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aether_lens_3.txt
+++ b/game/scripts/npc/items/item_aether_lens_3.txt
@@ -53,7 +53,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "450 510 630 810 1050"
+        "bonus_mana"                                      "450 550 700 900 1150"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_aether_lens_3.txt
+++ b/game/scripts/npc/items/item_aether_lens_3.txt
@@ -53,12 +53,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "450 900 1450 2000 2650"
+        "bonus_mana"                                      "450 510 630 810 1050"
       }
       "02"
       {
-        "var_type"        "FIELD_FLOAT"
-        "bonus_mana_regen"    "3.0 6.0 12.0 18.0 24.0"
+        "var_type"                                        "FIELD_FLOAT"
+        "bonus_mana_regen"                                "3.0 3.25 3.75 4.5 5.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aether_lens_4.txt
+++ b/game/scripts/npc/items/item_aether_lens_4.txt
@@ -53,7 +53,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "450 510 630 810 1050"
+        "bonus_mana"                                      "450 550 700 900 1150"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_aether_lens_4.txt
+++ b/game/scripts/npc/items/item_aether_lens_4.txt
@@ -53,12 +53,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "450 900 1450 2000 2650"
+        "bonus_mana"                                      "450 510 630 810 1050"
       }
       "02"
       {
-        "var_type"        "FIELD_FLOAT"
-        "bonus_mana_regen"    "3.0 6.0 12.0 18.0 24.0"
+        "var_type"                                        "FIELD_FLOAT"
+        "bonus_mana_regen"                                "3.0 3.25 3.75 4.5 5.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aether_lens_5.txt
+++ b/game/scripts/npc/items/item_aether_lens_5.txt
@@ -53,7 +53,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "450 510 630 810 1050"
+        "bonus_mana"                                      "450 550 700 900 1150"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_aether_lens_5.txt
+++ b/game/scripts/npc/items/item_aether_lens_5.txt
@@ -53,12 +53,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "450 900 1450 2000 2650"
+        "bonus_mana"                                      "450 510 630 810 1050"
       }
       "02"
       {
-        "var_type"        "FIELD_FLOAT"
-        "bonus_mana_regen"    "3.0 6.0 12.0 18.0 24.0"
+        "var_type"                                        "FIELD_FLOAT"
+        "bonus_mana_regen"                                "3.0 3.25 3.75 4.5 5.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_bfury.txt
+++ b/game/scripts/npc/items/item_bfury.txt
@@ -63,7 +63,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "3.75 4.5 6.25 8.0 10.5"
+        "bonus_mana_regen"                                "3.75 4.0 4.5 5.25 6.25"
       }
       "04" // Cleave against heroes
       {

--- a/game/scripts/npc/items/item_bfury_2.txt
+++ b/game/scripts/npc/items/item_bfury_2.txt
@@ -66,7 +66,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "3.75 4.5 6.25 8.0 10.5"
+        "bonus_mana_regen"                                "3.75 4.0 4.5 5.25 6.25"
       }
       "04" // Cleave against heroes
       {

--- a/game/scripts/npc/items/item_bfury_3.txt
+++ b/game/scripts/npc/items/item_bfury_3.txt
@@ -67,7 +67,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "3.75 4.5 6.25 8.0 10.5"
+        "bonus_mana_regen"                                "3.75 4.0 4.5 5.25 6.25"
       }
       "04" // Cleave against heroes
       {

--- a/game/scripts/npc/items/item_bfury_4.txt
+++ b/game/scripts/npc/items/item_bfury_4.txt
@@ -68,7 +68,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "3.75 4.5 6.25 8.0 10.5"
+        "bonus_mana_regen"                                "3.75 4.0 4.5 5.25 6.25"
       }
       "04" // Cleave against heroes
       {

--- a/game/scripts/npc/items/item_bfury_5.txt
+++ b/game/scripts/npc/items/item_bfury_5.txt
@@ -67,7 +67,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "3.75 4.5 6.25 8.0 10.5"
+        "bonus_mana_regen"                                "3.75 4.0 4.5 5.25 6.25"
       }
       "04" // Cleave against heroes
       {

--- a/game/scripts/npc/items/item_bloodstone.txt
+++ b/game/scripts/npc/items/item_bloodstone.txt
@@ -70,7 +70,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 650 1175 1875 2750"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_bloodstone.txt
+++ b/game/scripts/npc/items/item_bloodstone.txt
@@ -70,7 +70,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_bloodstone_2.txt
+++ b/game/scripts/npc/items/item_bloodstone_2.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 650 1175 1875 2750"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_bloodstone_2.txt
+++ b/game/scripts/npc/items/item_bloodstone_2.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_bloodstone_3.txt
+++ b/game/scripts/npc/items/item_bloodstone_3.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 650 1175 1875 2750"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_bloodstone_3.txt
+++ b/game/scripts/npc/items/item_bloodstone_3.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_bloodstone_4.txt
+++ b/game/scripts/npc/items/item_bloodstone_4.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 650 1175 1875 2750"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_bloodstone_4.txt
+++ b/game/scripts/npc/items/item_bloodstone_4.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_bloodstone_5.txt
+++ b/game/scripts/npc/items/item_bloodstone_5.txt
@@ -68,7 +68,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 650 1175 1875 2750"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_bloodstone_5.txt
+++ b/game/scripts/npc/items/item_bloodstone_5.txt
@@ -68,7 +68,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_bloodthorn.txt
+++ b/game/scripts/npc/items/item_bloodthorn.txt
@@ -68,7 +68,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "25 35 45 55 65"
+        "bonus_intellect"                                 "25 40 60 85 115"
       }
       "02"
       {
@@ -83,7 +83,7 @@
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.5 6.0 6.5 7.0 7.5"
+        "bonus_mana_regen"                                "5.5 5.75 6.25 7.0 8.0"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_bloodthorn_2.txt
+++ b/game/scripts/npc/items/item_bloodthorn_2.txt
@@ -72,7 +72,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "25 35 45 55 65"
+        "bonus_intellect"                                 "25 40 60 85 115"
       }
       "02"
       {
@@ -87,7 +87,7 @@
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.5 6.0 6.5 7.0 7.5"
+        "bonus_mana_regen"                                "5.5 5.75 6.25 7.0 8.0"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_bloodthorn_3.txt
+++ b/game/scripts/npc/items/item_bloodthorn_3.txt
@@ -72,7 +72,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "25 35 45 55 65"
+        "bonus_intellect"                                 "25 40 60 85 115"
       }
       "02"
       {
@@ -87,7 +87,7 @@
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.5 6.0 6.5 7.0 7.5"
+        "bonus_mana_regen"                                "5.5 5.75 6.25 7.0 8.0"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_bloodthorn_4.txt
+++ b/game/scripts/npc/items/item_bloodthorn_4.txt
@@ -72,7 +72,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "25 35 45 55 65"
+        "bonus_intellect"                                 "25 40 60 85 115"
       }
       "02"
       {
@@ -87,7 +87,7 @@
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.5 6.0 6.5 7.0 7.5"
+        "bonus_mana_regen"                                "5.5 5.75 6.25 7.0 8.0"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_bloodthorn_5.txt
+++ b/game/scripts/npc/items/item_bloodthorn_5.txt
@@ -72,7 +72,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "25 35 45 55 65"
+        "bonus_intellect"                                 "25 40 60 85 115"
       }
       "02"
       {
@@ -87,7 +87,7 @@
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.5 6.0 6.5 7.0 7.5"
+        "bonus_mana_regen"                                "5.5 5.75 6.25 7.0 8.0"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_cyclone.txt
+++ b/game/scripts/npc/items/item_cyclone.txt
@@ -68,12 +68,12 @@
       "01"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_intellect"       "10 25 50 95 140"
+        "bonus_intellect"       "10 25 45 70 100"
       }
       "02"
       {
         "var_type"              "FIELD_FLOAT"
-        "bonus_mana_regen"      "5.0 6.0 7.5 9.25 11.5"
+        "bonus_mana_regen"      "5.0 5.25 5.75 6.5 7.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_cyclone_2.txt
+++ b/game/scripts/npc/items/item_cyclone_2.txt
@@ -71,12 +71,12 @@
       "01"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_intellect"       "10 25 50 95 140"
+        "bonus_intellect"       "10 25 45 70 100"
       }
       "02"
       {
         "var_type"              "FIELD_FLOAT"
-        "bonus_mana_regen"      "5.0 6.0 7.5 9.25 11.5"
+        "bonus_mana_regen"      "5.0 5.25 5.75 6.5 7.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_cyclone_3.txt
+++ b/game/scripts/npc/items/item_cyclone_3.txt
@@ -72,12 +72,12 @@
       "01"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_intellect"       "10 25 50 95 140"
+        "bonus_intellect"       "10 25 45 70 100"
       }
       "02"
       {
         "var_type"              "FIELD_FLOAT"
-        "bonus_mana_regen"      "5.0 6.0 7.5 9.25 11.5"
+        "bonus_mana_regen"      "5.0 5.25 5.75 6.5 7.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_cyclone_4.txt
+++ b/game/scripts/npc/items/item_cyclone_4.txt
@@ -72,12 +72,12 @@
       "01"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_intellect"       "10 25 50 95 140"
+        "bonus_intellect"       "10 25 45 70 100"
       }
       "02"
       {
         "var_type"              "FIELD_FLOAT"
-        "bonus_mana_regen"      "5.0 6.0 7.5 9.25 11.5"
+        "bonus_mana_regen"      "5.0 5.25 5.75 6.5 7.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_cyclone_5.txt
+++ b/game/scripts/npc/items/item_cyclone_5.txt
@@ -73,12 +73,12 @@
       "01"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_intellect"       "10 25 50 95 140"
+        "bonus_intellect"       "10 25 45 70 100"
       }
       "02"
       {
         "var_type"              "FIELD_FLOAT"
-        "bonus_mana_regen"      "5.0 6.0 7.5 9.25 11.5"
+        "bonus_mana_regen"      "5.0 5.25 5.75 6.5 7.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_echo_sabre.txt
+++ b/game/scripts/npc/items/item_echo_sabre.txt
@@ -82,7 +82,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "1.25 1.75 2.25 3.0 4.0"
+        "bonus_mana_regen"                                "1.25 1.5 2.0 2.75 3.75"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_echo_sabre_2.txt
+++ b/game/scripts/npc/items/item_echo_sabre_2.txt
@@ -85,7 +85,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "1.25 1.75 2.25 3.0 4.0"
+        "bonus_mana_regen"                                "1.25 1.5 2.0 2.75 3.75"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_echo_sabre_3.txt
+++ b/game/scripts/npc/items/item_echo_sabre_3.txt
@@ -85,7 +85,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "1.25 1.75 2.25 3.0 4.0"
+        "bonus_mana_regen"                                "1.25 1.5 2.0 2.75 3.75"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_echo_sabre_4.txt
+++ b/game/scripts/npc/items/item_echo_sabre_4.txt
@@ -85,7 +85,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "1.25 1.75 2.25 3.0 4.0"
+        "bonus_mana_regen"                                "1.25 1.5 2.0 2.75 3.75"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_echo_sabre_5.txt
+++ b/game/scripts/npc/items/item_echo_sabre_5.txt
@@ -85,7 +85,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "1.25 1.75 2.25 3.0 4.0"
+        "bonus_mana_regen"                                "1.25 1.5 2.0 2.75 3.75"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_force_staff.txt
+++ b/game/scripts/npc/items/item_force_staff.txt
@@ -66,7 +66,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 25 40 55 70"
+        "bonus_intellect"                                 "10 25 45 70 100"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_force_staff_2.txt
+++ b/game/scripts/npc/items/item_force_staff_2.txt
@@ -67,7 +67,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 25 40 55 70"
+        "bonus_intellect"                                 "10 25 45 70 100"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_force_staff_3.txt
+++ b/game/scripts/npc/items/item_force_staff_3.txt
@@ -68,7 +68,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 25 40 55 70"
+        "bonus_intellect"                                 "10 25 45 70 100"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_force_staff_4.txt
+++ b/game/scripts/npc/items/item_force_staff_4.txt
@@ -68,7 +68,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 25 40 55 70"
+        "bonus_intellect"                                 "10 25 45 70 100"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_force_staff_5.txt
+++ b/game/scripts/npc/items/item_force_staff_5.txt
@@ -68,7 +68,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "10 25 40 55 70"
+        "bonus_intellect"                                 "10 25 45 70 100"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_holy_locket.txt
+++ b/game/scripts/npc/items/item_holy_locket.txt
@@ -63,7 +63,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "325 385 505 685 925"
+        "bonus_mana"                                      "325 425 575 775 1025"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_holy_locket.txt
+++ b/game/scripts/npc/items/item_holy_locket.txt
@@ -63,7 +63,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "325 650 975 1300 1625"
+        "bonus_mana"                                      "325 385 505 685 925"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_holy_locket_2.txt
+++ b/game/scripts/npc/items/item_holy_locket_2.txt
@@ -67,7 +67,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "325 650 975 1300 1625"
+        "bonus_mana"                                      "325 385 505 685 925"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_holy_locket_2.txt
+++ b/game/scripts/npc/items/item_holy_locket_2.txt
@@ -67,7 +67,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "325 385 505 685 925"
+        "bonus_mana"                                      "325 425 575 775 1025"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_holy_locket_3.txt
+++ b/game/scripts/npc/items/item_holy_locket_3.txt
@@ -67,7 +67,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "325 650 975 1300 1625"
+        "bonus_mana"                                      "325 385 505 685 925"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_holy_locket_3.txt
+++ b/game/scripts/npc/items/item_holy_locket_3.txt
@@ -67,7 +67,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "325 385 505 685 925"
+        "bonus_mana"                                      "325 425 575 775 1025"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_holy_locket_4.txt
+++ b/game/scripts/npc/items/item_holy_locket_4.txt
@@ -67,7 +67,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "325 650 975 1300 1625"
+        "bonus_mana"                                      "325 385 505 685 925"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_holy_locket_4.txt
+++ b/game/scripts/npc/items/item_holy_locket_4.txt
@@ -67,7 +67,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "325 385 505 685 925"
+        "bonus_mana"                                      "325 425 575 775 1025"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_holy_locket_5.txt
+++ b/game/scripts/npc/items/item_holy_locket_5.txt
@@ -67,7 +67,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "325 650 975 1300 1625"
+        "bonus_mana"                                      "325 385 505 685 925"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_holy_locket_5.txt
+++ b/game/scripts/npc/items/item_holy_locket_5.txt
@@ -67,7 +67,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "325 385 505 685 925"
+        "bonus_mana"                                      "325 425 575 775 1025"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_lotus_orb.txt
+++ b/game/scripts/npc/items/item_lotus_orb.txt
@@ -77,7 +77,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 310 430 610 850"
+        "bonus_mana"                                      "250 350 500 700 950"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_lotus_orb.txt
+++ b/game/scripts/npc/items/item_lotus_orb.txt
@@ -72,12 +72,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "4.0 4.75 5.75 7.25 9.75"
+        "bonus_mana_regen"                                "4.0 4.25 4.75 5.5 6.5"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 350 500 700 1000"
+        "bonus_mana"                                      "250 310 430 610 850"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_lotus_orb_2.txt
+++ b/game/scripts/npc/items/item_lotus_orb_2.txt
@@ -76,12 +76,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "4.0 4.75 5.75 7.25 9.75"
+        "bonus_mana_regen"                                "4.0 4.25 4.75 5.5 6.5"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 350 500 700 1000"
+        "bonus_mana"                                      "250 310 430 610 850"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_lotus_orb_2.txt
+++ b/game/scripts/npc/items/item_lotus_orb_2.txt
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 310 430 610 850"
+        "bonus_mana"                                      "250 350 500 700 950"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_lotus_orb_3.txt
+++ b/game/scripts/npc/items/item_lotus_orb_3.txt
@@ -76,12 +76,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "4.0 4.75 5.75 7.25 9.75"
+        "bonus_mana_regen"                                "4.0 4.25 4.75 5.5 6.5"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 350 500 700 1000"
+        "bonus_mana"                                      "250 310 430 610 850"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_lotus_orb_3.txt
+++ b/game/scripts/npc/items/item_lotus_orb_3.txt
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 310 430 610 850"
+        "bonus_mana"                                      "250 350 500 700 950"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_lotus_orb_4.txt
+++ b/game/scripts/npc/items/item_lotus_orb_4.txt
@@ -77,12 +77,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "4.0 4.75 5.75 7.25 9.75"
+        "bonus_mana_regen"                                "4.0 4.25 4.75 5.5 6.5"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 350 500 700 1000"
+        "bonus_mana"                                      "250 310 430 610 850"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_lotus_orb_4.txt
+++ b/game/scripts/npc/items/item_lotus_orb_4.txt
@@ -82,7 +82,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 310 430 610 850"
+        "bonus_mana"                                      "250 350 500 700 950"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_lotus_orb_5.txt
+++ b/game/scripts/npc/items/item_lotus_orb_5.txt
@@ -77,12 +77,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "4.0 4.75 5.75 7.25 9.75"
+        "bonus_mana_regen"                                "4.0 4.25 4.75 5.5 6.5"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 350 500 700 1000"
+        "bonus_mana"                                      "250 310 430 610 850"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_lotus_orb_5.txt
+++ b/game/scripts/npc/items/item_lotus_orb_5.txt
@@ -82,7 +82,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 310 430 610 850"
+        "bonus_mana"                                      "250 350 500 700 950"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_meteor_hammer.txt
+++ b/game/scripts/npc/items/item_meteor_hammer.txt
@@ -90,7 +90,7 @@
       "04"
       {
         "var_type"              "FIELD_FLOAT"
-        "bonus_mana_regen"      "3.0 4.5 6.0 7.5 9.0"
+        "bonus_mana_regen"      "3.0 3.25 3.75 4.5 5.5"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_meteor_hammer.txt
+++ b/game/scripts/npc/items/item_meteor_hammer.txt
@@ -75,12 +75,12 @@
       "01"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_strength"        "12 24 36 48 60"
+        "bonus_strength"        "20 30 45 65 90"
       }
       "02"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_intellect"       "12 24 36 48 60"
+        "bonus_intellect"       "20 30 45 65 90"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_meteor_hammer_2.txt
+++ b/game/scripts/npc/items/item_meteor_hammer_2.txt
@@ -74,12 +74,12 @@
       "01"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_strength"        "12 24 36 48 60"
+        "bonus_strength"        "20 30 45 65 90"
       }
       "02"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_intellect"       "12 24 36 48 60"
+        "bonus_intellect"       "20 30 45 65 90"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_meteor_hammer_2.txt
+++ b/game/scripts/npc/items/item_meteor_hammer_2.txt
@@ -89,7 +89,7 @@
       "04"
       {
         "var_type"              "FIELD_FLOAT"
-        "bonus_mana_regen"      "3.0 4.5 6.0 7.5 9.0"
+        "bonus_mana_regen"      "3.0 3.25 3.75 4.5 5.5"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_meteor_hammer_3.txt
+++ b/game/scripts/npc/items/item_meteor_hammer_3.txt
@@ -90,7 +90,7 @@
       "04"
       {
         "var_type"              "FIELD_FLOAT"
-        "bonus_mana_regen"      "3.0 4.5 6.0 7.5 9.0"
+        "bonus_mana_regen"      "3.0 3.25 3.75 4.5 5.5"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_meteor_hammer_3.txt
+++ b/game/scripts/npc/items/item_meteor_hammer_3.txt
@@ -75,12 +75,12 @@
       "01"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_strength"        "12 24 36 48 60"
+        "bonus_strength"        "20 30 45 65 90"
       }
       "02"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_intellect"       "12 24 36 48 60"
+        "bonus_intellect"       "20 30 45 65 90"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_meteor_hammer_4.txt
+++ b/game/scripts/npc/items/item_meteor_hammer_4.txt
@@ -90,7 +90,7 @@
       "04"
       {
         "var_type"              "FIELD_FLOAT"
-        "bonus_mana_regen"      "3.0 4.5 6.0 7.5 9.0"
+        "bonus_mana_regen"      "3.0 3.25 3.75 4.5 5.5"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_meteor_hammer_4.txt
+++ b/game/scripts/npc/items/item_meteor_hammer_4.txt
@@ -75,12 +75,12 @@
       "01"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_strength"        "12 24 36 48 60"
+        "bonus_strength"        "20 30 45 65 90"
       }
       "02"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_intellect"       "12 24 36 48 60"
+        "bonus_intellect"       "20 30 45 65 90"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_meteor_hammer_5.txt
+++ b/game/scripts/npc/items/item_meteor_hammer_5.txt
@@ -91,7 +91,7 @@
       "04"
       {
         "var_type"              "FIELD_FLOAT"
-        "bonus_mana_regen"      "3.0 4.5 6.0 7.5 9.0"
+        "bonus_mana_regen"      "3.0 3.25 3.75 4.5 5.5"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_meteor_hammer_5.txt
+++ b/game/scripts/npc/items/item_meteor_hammer_5.txt
@@ -76,12 +76,12 @@
       "01"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_strength"        "12 24 36 48 60"
+        "bonus_strength"        "20 30 45 65 90"
       }
       "02"
       {
         "var_type"              "FIELD_INTEGER"
-        "bonus_intellect"       "12 24 36 48 60"
+        "bonus_intellect"       "20 30 45 65 90"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_necronomicon.txt
+++ b/game/scripts/npc/items/item_necronomicon.txt
@@ -60,7 +60,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "3 3.5 4.0 4.5 5.5 7.5 10.0"
+        "bonus_mana_regen"                                "2.0 2.5 3.0 3.25 3.75 4.5 5.5" //OAA
       }
       "03"
       {

--- a/game/scripts/npc/items/item_necronomicon_2.txt
+++ b/game/scripts/npc/items/item_necronomicon_2.txt
@@ -60,7 +60,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "3 3.5 4.0 4.5 5.5 7.5 10.0"
+        "bonus_mana_regen"                                "2.0 2.5 3.0 3.25 3.75 4.5 5.5" //OAA
       }
       "03"
       {

--- a/game/scripts/npc/items/item_necronomicon_3.txt
+++ b/game/scripts/npc/items/item_necronomicon_3.txt
@@ -60,7 +60,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "3 3.5 4.0 4.5 5.5 7.5 10.0"
+        "bonus_mana_regen"                                "2.0 2.5 3.0 3.25 3.75 4.5 5.5" //OAA
       }
       "03"
       {

--- a/game/scripts/npc/items/item_necronomicon_4.txt
+++ b/game/scripts/npc/items/item_necronomicon_4.txt
@@ -63,7 +63,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "3 3.5 4.0 4.5 5.5 7.5 10.0"
+        "bonus_mana_regen"                                "2.0 2.5 3.0 3.25 3.75 4.5 5.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_necronomicon_5.txt
+++ b/game/scripts/npc/items/item_necronomicon_5.txt
@@ -62,7 +62,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "3 3.5 4.0 4.5 5.5 7.5 10.0"
+        "bonus_mana_regen"                                "2.0 2.5 3.0 3.25 3.75 4.5 5.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_necronomicon_6.txt
+++ b/game/scripts/npc/items/item_necronomicon_6.txt
@@ -61,7 +61,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "3 3.5 4.0 4.5 5.5 7.5 10.0"
+        "bonus_mana_regen"                                "2.0 2.5 3.0 3.25 3.75 4.5 5.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_necronomicon_7.txt
+++ b/game/scripts/npc/items/item_necronomicon_7.txt
@@ -61,7 +61,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "3 3.5 4.0 4.5 5.5 7.5 10.0"
+        "bonus_mana_regen"                                "2.0 2.5 3.0 3.25 3.75 4.5 5.5"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_octarine_core.txt
+++ b/game/scripts/npc/items/item_octarine_core.txt
@@ -57,7 +57,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_octarine_core.txt
+++ b/game/scripts/npc/items/item_octarine_core.txt
@@ -57,7 +57,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 650 1000 1500 2000"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_octarine_core_2.txt
+++ b/game/scripts/npc/items/item_octarine_core_2.txt
@@ -60,7 +60,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 650 1000 1500 2000"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_octarine_core_2.txt
+++ b/game/scripts/npc/items/item_octarine_core_2.txt
@@ -60,7 +60,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_octarine_core_3.txt
+++ b/game/scripts/npc/items/item_octarine_core_3.txt
@@ -60,7 +60,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 650 1000 1500 2000"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_octarine_core_3.txt
+++ b/game/scripts/npc/items/item_octarine_core_3.txt
@@ -60,7 +60,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_octarine_core_4.txt
+++ b/game/scripts/npc/items/item_octarine_core_4.txt
@@ -61,7 +61,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 650 1000 1500 2000"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_octarine_core_4.txt
+++ b/game/scripts/npc/items/item_octarine_core_4.txt
@@ -61,7 +61,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_octarine_core_5.txt
+++ b/game/scripts/npc/items/item_octarine_core_5.txt
@@ -62,7 +62,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_octarine_core_5.txt
+++ b/game/scripts/npc/items/item_octarine_core_5.txt
@@ -62,7 +62,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 650 1000 1500 2000"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_refresher.txt
+++ b/game/scripts/npc/items/item_refresher.txt
@@ -77,7 +77,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
     }
   }

--- a/game/scripts/npc/items/item_refresher.txt
+++ b/game/scripts/npc/items/item_refresher.txt
@@ -77,7 +77,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 500 750 1000 1500"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
     }
   }

--- a/game/scripts/npc/items/item_refresher_2.txt
+++ b/game/scripts/npc/items/item_refresher_2.txt
@@ -77,7 +77,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
     }
   }

--- a/game/scripts/npc/items/item_refresher_2.txt
+++ b/game/scripts/npc/items/item_refresher_2.txt
@@ -77,7 +77,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 500 750 1000 1500"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
     }
   }

--- a/game/scripts/npc/items/item_refresher_3.txt
+++ b/game/scripts/npc/items/item_refresher_3.txt
@@ -77,7 +77,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
     }
   }

--- a/game/scripts/npc/items/item_refresher_3.txt
+++ b/game/scripts/npc/items/item_refresher_3.txt
@@ -77,7 +77,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 500 750 1000 1500"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
     }
   }

--- a/game/scripts/npc/items/item_refresher_4.txt
+++ b/game/scripts/npc/items/item_refresher_4.txt
@@ -78,7 +78,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 500 750 1000 1500"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
     }
   }

--- a/game/scripts/npc/items/item_refresher_4.txt
+++ b/game/scripts/npc/items/item_refresher_4.txt
@@ -78,7 +78,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
     }
   }

--- a/game/scripts/npc/items/item_refresher_5.txt
+++ b/game/scripts/npc/items/item_refresher_5.txt
@@ -79,7 +79,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "425 485 605 785 1025"
+        "bonus_mana"                                      "425 525 675 875 1125"
       }
     }
   }

--- a/game/scripts/npc/items/item_refresher_5.txt
+++ b/game/scripts/npc/items/item_refresher_5.txt
@@ -79,7 +79,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 500 750 1000 1500"
+        "bonus_mana"                                      "425 485 605 785 1025"
       }
     }
   }

--- a/game/scripts/npc/items/item_rod_of_atos.txt
+++ b/game/scripts/npc/items/item_rod_of_atos.txt
@@ -65,7 +65,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "20 40 60 80 105"
+        "bonus_intellect"                                 "20 30 45 65 90"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_rod_of_atos_2.txt
+++ b/game/scripts/npc/items/item_rod_of_atos_2.txt
@@ -68,7 +68,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "20 40 60 80 105"
+        "bonus_intellect"                                 "20 30 45 65 90"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_rod_of_atos_3.txt
+++ b/game/scripts/npc/items/item_rod_of_atos_3.txt
@@ -70,7 +70,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "20 40 60 80 105"
+        "bonus_intellect"                                 "20 30 45 65 90"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_rod_of_atos_4.txt
+++ b/game/scripts/npc/items/item_rod_of_atos_4.txt
@@ -70,7 +70,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "20 40 60 80 105"
+        "bonus_intellect"                                 "20 30 45 65 90"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_rod_of_atos_5.txt
+++ b/game/scripts/npc/items/item_rod_of_atos_5.txt
@@ -71,7 +71,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "20 40 60 80 105"
+        "bonus_intellect"                                 "20 30 45 65 90"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_sheepstick.txt
+++ b/game/scripts/npc/items/item_sheepstick.txt
@@ -60,15 +60,15 @@
         "var_type"                                        "FIELD_INTEGER"
         "bonus_agility"                                   "10 15 20 30 40"
       }
-      "03"
+      "03" // first 3 values must be the same as Eul's Scepter or Rod of Atos
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "35 50 70 105 140"
+        "bonus_intellect"                                 "10 25 45 70 100" //OAA
       }
-      "04"
+      "04" // first 3 values must be the same as Eul's Scepter
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "9.0 9.75 11.25 13.5 16.0"
+        "bonus_mana_regen"                                "5.0 5.25 5.75 9.0 10.0" //OAA
       }
       "05"
       {

--- a/game/scripts/npc/items/item_sheepstick_2.txt
+++ b/game/scripts/npc/items/item_sheepstick_2.txt
@@ -65,12 +65,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "35 50 70 105 140"
+        "bonus_intellect"                                 "10 25 45 70 100"
       }
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "9.0 9.75 11.25 13.5 16.0"
+        "bonus_mana_regen"                                "5.0 5.25 5.75 9.0 10.0"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_sheepstick_3.txt
+++ b/game/scripts/npc/items/item_sheepstick_3.txt
@@ -65,12 +65,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "35 50 70 105 140"
+        "bonus_intellect"                                 "10 25 45 70 100"
       }
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "9.0 9.75 11.25 13.5 16.0"
+        "bonus_mana_regen"                                "5.0 5.25 5.75 9.0 10.0"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_sheepstick_4.txt
+++ b/game/scripts/npc/items/item_sheepstick_4.txt
@@ -67,12 +67,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "35 50 70 105 140"
+        "bonus_intellect"                                 "10 25 45 70 100"
       }
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "9.0 9.75 11.25 13.5 16.0"
+        "bonus_mana_regen"                                "5.0 5.25 5.75 9.0 10.0"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_sheepstick_5.txt
+++ b/game/scripts/npc/items/item_sheepstick_5.txt
@@ -67,12 +67,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "35 50 70 105 140"
+        "bonus_intellect"                                 "10 25 45 70 100"
       }
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "9.0 9.75 11.25 13.5 16.0"
+        "bonus_mana_regen"                                "5.0 5.25 5.75 9.0 10.0"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_shivas_guard.txt
+++ b/game/scripts/npc/items/item_shivas_guard.txt
@@ -63,7 +63,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "30 45 70 100 150"
+        "bonus_intellect"                                 "30 45 65 90 120"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_shivas_guard_2.txt
+++ b/game/scripts/npc/items/item_shivas_guard_2.txt
@@ -65,7 +65,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "30 45 70 100 150"
+        "bonus_intellect"                                 "30 45 65 90 120"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_shivas_guard_3.txt
+++ b/game/scripts/npc/items/item_shivas_guard_3.txt
@@ -63,7 +63,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "30 45 70 100 150"
+        "bonus_intellect"                                 "30 45 65 90 120"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_shivas_guard_4.txt
+++ b/game/scripts/npc/items/item_shivas_guard_4.txt
@@ -63,7 +63,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "30 45 70 100 150"
+        "bonus_intellect"                                 "30 45 65 90 120"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_shivas_guard_5.txt
+++ b/game/scripts/npc/items/item_shivas_guard_5.txt
@@ -64,7 +64,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "30 45 70 100 150"
+        "bonus_intellect"                                 "30 45 65 90 120"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_skadi.txt
+++ b/game/scripts/npc/items/item_skadi.txt
@@ -65,7 +65,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 310 430 610 850"
+        "bonus_mana"                                      "250 350 500 700 950"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_skadi.txt
+++ b/game/scripts/npc/items/item_skadi.txt
@@ -65,7 +65,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 500 750 1000 1250"
+        "bonus_mana"                                      "250 310 430 610 850"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_skadi_2.txt
+++ b/game/scripts/npc/items/item_skadi_2.txt
@@ -67,7 +67,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 310 430 610 850"
+        "bonus_mana"                                      "250 350 500 700 950"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_skadi_2.txt
+++ b/game/scripts/npc/items/item_skadi_2.txt
@@ -67,7 +67,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 500 750 1000 1250"
+        "bonus_mana"                                      "250 310 430 610 850"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_skadi_3.txt
+++ b/game/scripts/npc/items/item_skadi_3.txt
@@ -68,7 +68,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 500 750 1000 1250"
+        "bonus_mana"                                      "250 310 430 610 850"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_skadi_3.txt
+++ b/game/scripts/npc/items/item_skadi_3.txt
@@ -68,7 +68,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 310 430 610 850"
+        "bonus_mana"                                      "250 350 500 700 950"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_skadi_4.txt
+++ b/game/scripts/npc/items/item_skadi_4.txt
@@ -69,7 +69,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 310 430 610 850"
+        "bonus_mana"                                      "250 350 500 700 950"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_skadi_4.txt
+++ b/game/scripts/npc/items/item_skadi_4.txt
@@ -69,7 +69,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 500 750 1000 1250"
+        "bonus_mana"                                      "250 310 430 610 850"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_skadi_5.txt
+++ b/game/scripts/npc/items/item_skadi_5.txt
@@ -68,7 +68,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 500 750 1000 1250"
+        "bonus_mana"                                      "250 310 430 610 850"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_skadi_5.txt
+++ b/game/scripts/npc/items/item_skadi_5.txt
@@ -68,7 +68,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "250 310 430 610 850"
+        "bonus_mana"                                      "250 350 500 700 950"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_solar_crest.txt
+++ b/game/scripts/npc/items/item_solar_crest.txt
@@ -79,7 +79,7 @@
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen_pct"                            "1.75 2.75 3.75 4.75 5.75"
+        "bonus_mana_regen_pct"                            "1.75 2.0 2.5 3.25 4.25"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_solar_crest_2.txt
+++ b/game/scripts/npc/items/item_solar_crest_2.txt
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen_pct"                            "1.75 2.75 3.75 4.75 5.75"
+        "bonus_mana_regen_pct"                            "1.75 2.0 2.5 3.25 4.25"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_solar_crest_3.txt
+++ b/game/scripts/npc/items/item_solar_crest_3.txt
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen_pct"                            "1.75 2.75 3.75 4.75 5.75"
+        "bonus_mana_regen_pct"                            "1.75 2.0 2.5 3.25 4.25"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_solar_crest_4.txt
+++ b/game/scripts/npc/items/item_solar_crest_4.txt
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen_pct"                            "1.75 2.75 3.75 4.75 5.75"
+        "bonus_mana_regen_pct"                            "1.75 2.0 2.5 3.25 4.25"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_solar_crest_5.txt
+++ b/game/scripts/npc/items/item_solar_crest_5.txt
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen_pct"                            "1.75 2.75 3.75 4.75 5.75"
+        "bonus_mana_regen_pct"                            "1.75 2.0 2.5 3.25 4.25"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_sphere.txt
+++ b/game/scripts/npc/items/item_sphere.txt
@@ -74,7 +74,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.0 6.0 7.5 9.0 11.0"
+        "bonus_mana_regen"                                "5.0 5.25 5.75 6.5 7.5"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_sphere_2.txt
+++ b/game/scripts/npc/items/item_sphere_2.txt
@@ -76,7 +76,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.0 6.0 7.5 9.0 11.0"
+        "bonus_mana_regen"                                "5.0 5.25 5.75 6.5 7.5"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_sphere_3.txt
+++ b/game/scripts/npc/items/item_sphere_3.txt
@@ -76,7 +76,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.0 6.0 7.5 9.0 11.0"
+        "bonus_mana_regen"                                "5.0 5.25 5.75 6.5 7.5"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_sphere_4.txt
+++ b/game/scripts/npc/items/item_sphere_4.txt
@@ -77,7 +77,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.0 6.0 7.5 9.0 11.0"
+        "bonus_mana_regen"                                "5.0 5.25 5.75 6.5 7.5"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_sphere_5.txt
+++ b/game/scripts/npc/items/item_sphere_5.txt
@@ -78,7 +78,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "5.0 6.0 7.5 9.0 11.0"
+        "bonus_mana_regen"                                "5.0 5.25 5.75 6.5 7.5"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_spirit_vessel.txt
+++ b/game/scripts/npc/items/item_spirit_vessel.txt
@@ -64,7 +64,7 @@
       "02"
       {
         "var_type"                    "FIELD_FLOAT"
-        "bonus_mana_regen"            "1.5 2.0 2.5 4.0 6.0"
+        "bonus_mana_regen"            "1.5 1.75 2.25 3.0 4.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_spirit_vessel_2.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_2.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                    "FIELD_FLOAT"
-        "bonus_mana_regen"            "1.5 2.0 2.5 4.0 6.0"
+        "bonus_mana_regen"            "1.5 1.75 2.25 3.0 4.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_spirit_vessel_3.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_3.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                    "FIELD_FLOAT"
-        "bonus_mana_regen"            "1.5 2.0 2.5 4.0 6.0"
+        "bonus_mana_regen"            "1.5 1.75 2.25 3.0 4.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_spirit_vessel_4.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_4.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                    "FIELD_FLOAT"
-        "bonus_mana_regen"            "1.5 2.0 2.5 4.0 6.0"
+        "bonus_mana_regen"            "1.5 1.75 2.25 3.0 4.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_spirit_vessel_5.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_5.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                    "FIELD_FLOAT"
-        "bonus_mana_regen"            "1.5 2.0 2.5 4.0 6.0"
+        "bonus_mana_regen"            "1.5 1.75 2.25 3.0 4.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_ultimate_scepter.txt
+++ b/game/scripts/npc/items/item_ultimate_scepter.txt
@@ -52,7 +52,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "175 250 400 600 800"
+        "bonus_mana"                                      "175 235 355 535 775"
       }
       "04" // OAA
       {

--- a/game/scripts/npc/items/item_ultimate_scepter.txt
+++ b/game/scripts/npc/items/item_ultimate_scepter.txt
@@ -47,12 +47,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "175 250 400 600 800"
+        "bonus_health"                                    "175 275 425 625 875"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "175 235 355 535 775"
+        "bonus_mana"                                      "175 275 425 625 875"
       }
       "04" // OAA
       {

--- a/game/scripts/npc/items/item_ultimate_scepter_2.txt
+++ b/game/scripts/npc/items/item_ultimate_scepter_2.txt
@@ -69,7 +69,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "175 250 400 600 800"
+        "bonus_mana"                                      "175 235 355 535 775"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_ultimate_scepter_2.txt
+++ b/game/scripts/npc/items/item_ultimate_scepter_2.txt
@@ -64,12 +64,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "175 250 400 600 800"
+        "bonus_health"                                    "175 275 425 625 875"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "175 235 355 535 775"
+        "bonus_mana"                                      "175 275 425 625 875"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_ultimate_scepter_3.txt
+++ b/game/scripts/npc/items/item_ultimate_scepter_3.txt
@@ -69,7 +69,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "175 250 400 600 800"
+        "bonus_mana"                                      "175 235 355 535 775"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_ultimate_scepter_3.txt
+++ b/game/scripts/npc/items/item_ultimate_scepter_3.txt
@@ -64,12 +64,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "175 250 400 600 800"
+        "bonus_health"                                    "175 275 425 625 875"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "175 235 355 535 775"
+        "bonus_mana"                                      "175 275 425 625 875"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_ultimate_scepter_4.txt
+++ b/game/scripts/npc/items/item_ultimate_scepter_4.txt
@@ -69,7 +69,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "175 250 400 600 800"
+        "bonus_mana"                                      "175 235 355 535 775"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_ultimate_scepter_4.txt
+++ b/game/scripts/npc/items/item_ultimate_scepter_4.txt
@@ -64,12 +64,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "175 250 400 600 800"
+        "bonus_health"                                    "175 275 425 625 875"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "175 235 355 535 775"
+        "bonus_mana"                                      "175 275 425 625 875"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_ultimate_scepter_5.txt
+++ b/game/scripts/npc/items/item_ultimate_scepter_5.txt
@@ -63,12 +63,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "175 250 400 600 800"
+        "bonus_health"                                    "175 275 425 625 875"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "175 235 355 535 775"
+        "bonus_mana"                                      "175 275 425 625 875"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_ultimate_scepter_5.txt
+++ b/game/scripts/npc/items/item_ultimate_scepter_5.txt
@@ -68,7 +68,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "175 250 400 600 800"
+        "bonus_mana"                                      "175 235 355 535 775"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_veil_of_discord.txt
+++ b/game/scripts/npc/items/item_veil_of_discord.txt
@@ -68,7 +68,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.5 3.0 4.5 6.0 7.5"
+        "aura_mana_regen"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_veil_of_discord_2.txt
+++ b/game/scripts/npc/items/item_veil_of_discord_2.txt
@@ -70,7 +70,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.5 3.0 4.5 6.0 7.5"
+        "aura_mana_regen"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_veil_of_discord_3.txt
+++ b/game/scripts/npc/items/item_veil_of_discord_3.txt
@@ -70,7 +70,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.5 3.0 4.5 6.0 7.5"
+        "aura_mana_regen"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_veil_of_discord_4.txt
+++ b/game/scripts/npc/items/item_veil_of_discord_4.txt
@@ -70,7 +70,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.5 3.0 4.5 6.0 7.5"
+        "aura_mana_regen"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_veil_of_discord_5.txt
+++ b/game/scripts/npc/items/item_veil_of_discord_5.txt
@@ -70,7 +70,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "aura_mana_regen"                                 "1.5 3.0 4.5 6.0 7.5"
+        "aura_mana_regen"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_vladmir.txt
+++ b/game/scripts/npc/items/item_vladmir.txt
@@ -56,7 +56,7 @@
       "01"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "mana_regen_aura"                                 "1.5 2.5 4.0 6.0 7.5"
+        "mana_regen_aura"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_vladmir_2.txt
+++ b/game/scripts/npc/items/item_vladmir_2.txt
@@ -58,7 +58,7 @@
       "01"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "mana_regen_aura"                                 "1.5 2.5 4.0 6.0 7.5"
+        "mana_regen_aura"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_vladmir_3.txt
+++ b/game/scripts/npc/items/item_vladmir_3.txt
@@ -59,7 +59,7 @@
       "01"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "mana_regen_aura"                                 "1.5 2.5 4.0 6.0 7.5"
+        "mana_regen_aura"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_vladmir_4.txt
+++ b/game/scripts/npc/items/item_vladmir_4.txt
@@ -59,7 +59,7 @@
       "01"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "mana_regen_aura"                                 "1.5 2.5 4.0 6.0 7.5"
+        "mana_regen_aura"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "02"
       {

--- a/game/scripts/npc/items/item_vladmir_5.txt
+++ b/game/scripts/npc/items/item_vladmir_5.txt
@@ -59,7 +59,7 @@
       "01"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "mana_regen_aura"                                 "1.5 2.5 4.0 6.0 7.5"
+        "mana_regen_aura"                                 "1.5 1.75 2.25 3.0 4.0"
       }
       "02"
       {


### PR DESCRIPTION
Scaling of mana and INT is all over the place. The goal is to normalize mana items and reduce total mana in the game. There will be another PR with hero mana cost changes as well.
* Reducing bonus intelligence on Eul's Scepter, Rod of Atos, Scythe of Vyse and Shiva's Guard.
* Increasing bonus intelligence on Bloodthorne, Force Staff, Pull Staff and Meteor Hammer.
* Every item that gives flat mana now has the same bonus mana scaling: **x/x+100/x+250/x+450/x+700**
* Every item that gives flat mana regen now has the same bonus mana regen scaling: **y/y+0.25/y+0.75/y+1.5/y+2.5** except Scythe of Vyse, Bloodstone, Allied Eul's Scepter and some other custom items.