### PR TITLE
Mask of Madness rebalance

### DIFF
--- a/game/scripts/npc/items/item_mask_of_madness.txt
+++ b/game/scripts/npc/items/item_mask_of_madness.txt
@@ -67,12 +67,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "lifesteal_percent"                               "20"
+        "lifesteal_percent"                               "25 30 35 40 45" //OAA
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 130 150 170 190"
+        "berserk_bonus_attack_speed"                      "110 120 130 140 150"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness.txt
+++ b/game/scripts/npc/items/item_mask_of_madness.txt
@@ -72,7 +72,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 120 130 140 150"
+        "berserk_bonus_attack_speed"                      "110 120 140 170 210"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness_2.txt
+++ b/game/scripts/npc/items/item_mask_of_madness_2.txt
@@ -15,7 +15,7 @@
     "ItemResult"                                          "item_mask_of_madness_2"
     "ItemRequirements"
     {
-      "01"                                                "item_mask_of_madness;item_upgrade_core"
+      "01"                                                "item_satanic;item_upgrade_core"
     }
   }
 
@@ -46,7 +46,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "25"
-    "ItemCost"                                            "3275"
+    "ItemCost"                                            "6800"
     "ItemShopTags"                                        "unique;hard_to_tag"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "mom 2;mask of madness 2"
@@ -70,12 +70,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "lifesteal_percent"                               "20"
+        "lifesteal_percent"                               "25 30 35 40 45"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 130 150 170 190"
+        "berserk_bonus_attack_speed"                      "110 120 130 140 150"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness_2.txt
+++ b/game/scripts/npc/items/item_mask_of_madness_2.txt
@@ -75,7 +75,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 120 130 140 150"
+        "berserk_bonus_attack_speed"                      "110 120 140 170 210"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness_3.txt
+++ b/game/scripts/npc/items/item_mask_of_madness_3.txt
@@ -15,7 +15,8 @@
     "AbilityTextureName"                                  "custom/recipe/recipe_3"
     "ItemRequirements"
     {
-      "01"                                                "item_satanic_2;item_upgrade_core_2"
+      "01"                                                "item_mask_of_madness_2;item_upgrade_core_2"
+      "02"                                                "item_satanic_2;item_upgrade_core_2"
     }
   }
 
@@ -68,12 +69,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "lifesteal_percent"                               "20"
+        "lifesteal_percent"                               "25 30 35 40 45"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 130 150 170 190"
+        "berserk_bonus_attack_speed"                      "110 120 130 140 150"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness_3.txt
+++ b/game/scripts/npc/items/item_mask_of_madness_3.txt
@@ -74,7 +74,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 120 130 140 150"
+        "berserk_bonus_attack_speed"                      "110 120 140 170 210"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness_4.txt
+++ b/game/scripts/npc/items/item_mask_of_madness_4.txt
@@ -69,12 +69,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "lifesteal_percent"                               "20"
+        "lifesteal_percent"                               "25 30 35 40 45"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 130 150 170 190"
+        "berserk_bonus_attack_speed"                      "110 120 130 140 150"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness_4.txt
+++ b/game/scripts/npc/items/item_mask_of_madness_4.txt
@@ -74,7 +74,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 120 130 140 150"
+        "berserk_bonus_attack_speed"                      "110 120 140 170 210"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness_5.txt
+++ b/game/scripts/npc/items/item_mask_of_madness_5.txt
@@ -75,7 +75,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 120 130 140 150"
+        "berserk_bonus_attack_speed"                      "110 120 140 170 210"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness_5.txt
+++ b/game/scripts/npc/items/item_mask_of_madness_5.txt
@@ -70,12 +70,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "lifesteal_percent"                               "20"
+        "lifesteal_percent"                               "25 30 35 40 45"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 130 150 170 190"
+        "berserk_bonus_attack_speed"                      "110 120 130 140 150"
       }
       "05"
       {

--- a/game/scripts/shops/10v10_shops.txt
+++ b/game/scripts/shops/10v10_shops.txt
@@ -206,7 +206,7 @@
     "item"                                                "item_abyssal_blade_3"
     "item"                                                "item_trumps_fists"
     "item"                                                "item_satanic"
-    "item"                                                "item_mask_of_madness_3"
+    "item"                                                "item_mask_of_madness_2"
     "item"                                                "item_vampire"
     "item"                                                "item_mjollnir"
     "item"                                                "item_monkey_king_bar"

--- a/game/scripts/shops/ardm_shops.txt
+++ b/game/scripts/shops/ardm_shops.txt
@@ -206,7 +206,7 @@
     "item"                                                "item_abyssal_blade_3"
     "item"                                                "item_trumps_fists"
     "item"                                                "item_satanic"
-    "item"                                                "item_mask_of_madness_3"
+    "item"                                                "item_mask_of_madness_2"
     "item"                                                "item_vampire"
     "item"                                                "item_mjollnir"
     "item"                                                "item_monkey_king_bar"

--- a/game/scripts/shops/captains_mode_shops.txt
+++ b/game/scripts/shops/captains_mode_shops.txt
@@ -206,7 +206,7 @@
     "item"                                                "item_abyssal_blade_3"
     "item"                                                "item_trumps_fists"
     "item"                                                "item_satanic"
-    "item"                                                "item_mask_of_madness_3"
+    "item"                                                "item_mask_of_madness_2"
     "item"                                                "item_vampire"
     "item"                                                "item_mjollnir"
     "item"                                                "item_monkey_king_bar"

--- a/game/scripts/shops/oaa_shops.txt
+++ b/game/scripts/shops/oaa_shops.txt
@@ -206,7 +206,7 @@
     "item"                                                "item_abyssal_blade_3"
     "item"                                                "item_trumps_fists"
     "item"                                                "item_satanic"
-    "item"                                                "item_mask_of_madness_3"
+    "item"                                                "item_mask_of_madness_2"
     "item"                                                "item_vampire"
     "item"                                                "item_mjollnir"
     "item"                                                "item_monkey_king_bar"

--- a/game/scripts/shops/oaa_test_shops.txt
+++ b/game/scripts/shops/oaa_test_shops.txt
@@ -206,7 +206,7 @@
     "item"                                                "item_abyssal_blade_3"
     "item"                                                "item_trumps_fists"
     "item"                                                "item_satanic"
-    "item"                                                "item_mask_of_madness_3"
+    "item"                                                "item_mask_of_madness_2"
     "item"                                                "item_vampire"
     "item"                                                "item_mjollnir"
     "item"                                                "item_monkey_king_bar"

--- a/game/scripts/shops/oaa_winter_shops.txt
+++ b/game/scripts/shops/oaa_winter_shops.txt
@@ -206,7 +206,7 @@
     "item"                                                "item_abyssal_blade_3"
     "item"                                                "item_trumps_fists"
     "item"                                                "item_satanic"
-    "item"                                                "item_mask_of_madness_3"
+    "item"                                                "item_mask_of_madness_2"
     "item"                                                "item_vampire"
     "item"                                                "item_mjollnir"
     "item"                                                "item_monkey_king_bar"


### PR DESCRIPTION
Forgotten item that is bought only on Lone Druid and sometimes on Juggernaut or Sniper.
* Mask of Madness tier 2 is now buyable. Recipe: Satanic 1 + Upgrade Core 1 - this change should make the item more viable in the early game on heroes that desperately need attack speed. ~~Also it will serve as a farming item for noobs that don't know about Cleave Spark.~~
* Buffed passive lifesteal from 20% to 30%/35%/40%/45%. (same scaling as passive lifesteal on Satanic and Vampire Fang) - There is no reason not to scale this.
* Rescaled berserk active bonus attack speed from 150/170/190 to 120/140/170/210. - Mask of Madness has 4 buyable tiers now. Buffed level 5 will maybe make this item worth buying on heroes that don't want status resistance or strength.