### PR TITLE
Neutral Creeps Fixes and Updates

### DIFF
--- a/game/scripts/npc/abilities/neutrals/ghost_frostburn_oaa.txt
+++ b/game/scripts/npc/abilities/neutrals/ghost_frostburn_oaa.txt
@@ -24,7 +24,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "heal_prevent_percent"                            "-40"
+        "heal_prevent_percent"                            "-35"
       }
       "02"
       {

--- a/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_black_dragon.txt
+++ b/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_black_dragon.txt
@@ -60,7 +60,7 @@
     //----------------------------------------------------------------
     "StatusHealth"                                        "2000"    // Base health.
     "StatusHealthRegen"                                   "1"       // Health regeneration rate.
-    "StatusMana"                                          "500"     // Base mana.
+    "StatusMana"                                          "300"     // Base mana.
     "StatusManaRegen"                                     "1"       // Mana regeneration rate.
 
     // Vision

--- a/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_centaur_khan.txt
+++ b/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_centaur_khan.txt
@@ -60,7 +60,7 @@
     //----------------------------------------------------------------
     "StatusHealth"                                        "1100"  // Base health.
     "StatusHealthRegen"                                   "1"     // Health regeneration rate.
-    "StatusMana"                                          "200"   // Base mana.
+    "StatusMana"                                          "300"   // Base mana.
     "StatusManaRegen"                                     "1.0"   // Mana regeneration rate.
 
     // Vision

--- a/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_ghost.txt
+++ b/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_ghost.txt
@@ -60,7 +60,7 @@
     //----------------------------------------------------------------
     "StatusHealth"                                        "500"   // Base health.
     "StatusHealthRegen"                                   "0.5"   // Health regeneration rate.
-    "StatusMana"                                          "400"   // Base mana.
+    "StatusMana"                                          "0"   // Base mana.
     "StatusManaRegen"                                     "1.0"   // Mana regeneration rate.
 
     // Vision

--- a/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_ghost.txt
+++ b/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_ghost.txt
@@ -19,14 +19,14 @@
     // Abilities
     //----------------------------------------------------------------
     "Ability1"                                            "ghost_frostburn_oaa"
-    "Ability2"                                            "ghost_vortex_oaa"
+    "Ability2"                                            "mudgolem_cloak_aura"
     "Ability3"                                            ""
     "Ability4"                                            ""
 
     // Armor
     //----------------------------------------------------------------
     "ArmorPhysical"                                       "1"     // Physical protection.
-    "MagicalResistance"                                   "25"    // Magical protection.
+    "MagicalResistance"                                   "5"    // Magical protection.
 
     // Attack
     //----------------------------------------------------------------

--- a/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_harpy_scout.txt
+++ b/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_harpy_scout.txt
@@ -60,7 +60,7 @@
     "StatusHealth"                                        "400"    // Base health.
     "StatusHealthRegen"                                   "0.5"    // Health regeneration rate.
     "StatusMana"                                          "0"    // Base mana.
-    "StatusManaRegen"                                     "1"    // Mana regeneration rate.
+    "StatusManaRegen"                                     "0.0"    // Mana regeneration rate.
 
     // Vision
     //----------------------------------------------------------------

--- a/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_harpy_storm.txt
+++ b/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_harpy_storm.txt
@@ -60,7 +60,7 @@
     //----------------------------------------------------------------
     "StatusHealth"                                        "550"   // Base health.
     "StatusHealthRegen"                                   "0.5"   // Health regeneration rate.
-    "StatusMana"                                          "400"   // Base mana.
+    "StatusMana"                                          "300"   // Base mana.
     "StatusManaRegen"                                     "1"     // Mana regeneration rate.
 
     // Vision

--- a/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_kobold_foreman.txt
+++ b/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_kobold_foreman.txt
@@ -60,7 +60,7 @@
     //----------------------------------------------------------------
     "StatusHealth"                                        "400"   // Base health.
     "StatusHealthRegen"                                   "0.5"   // Health regeneration rate.
-    "StatusMana"                                          "400"   // Base mana.
+    "StatusMana"                                          "150"   // Base mana.
     "StatusManaRegen"                                     "1.0"   // Mana regeneration rate.
 
     // Vision

--- a/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_mud_golem.txt
+++ b/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_mud_golem.txt
@@ -60,8 +60,8 @@
     //----------------------------------------------------------------
     "StatusHealth"                                        "800"   // Base health.
     "StatusHealthRegen"                                   "0.5"   // Health regeneration rate.
-    "StatusMana"                                          "400"   // Base mana.
-    "StatusManaRegen"                                     "1.0"   // Mana regeneration rate.
+    "StatusMana"                                          "0"   // Base mana.
+    "StatusManaRegen"                                     "0.0"   // Mana regeneration rate.
 
     // Vision
     //----------------------------------------------------------------

--- a/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_mud_golem_split.txt
+++ b/game/scripts/npc/units/neutrals/npc_dota_neutral_custom_mud_golem_split.txt
@@ -60,8 +60,8 @@
     //----------------------------------------------------------------
     "StatusHealth"                                        "400"   // Base health.
     "StatusHealthRegen"                                   "0.5"   // Health regeneration rate.
-    "StatusMana"                                          "400"   // Base mana.
-    "StatusManaRegen"                                     "1.0"   // Mana regeneration rate.
+    "StatusMana"                                          "0"   // Base mana.
+    "StatusManaRegen"                                     "0.0"   // Mana regeneration rate.
 
     // Vision
     //----------------------------------------------------------------

--- a/game/scripts/vscripts/abilities/neutrals/oaa_alpha_wolf_critical_strike_aura.lua
+++ b/game/scripts/vscripts/abilities/neutrals/oaa_alpha_wolf_critical_strike_aura.lua
@@ -54,7 +54,7 @@ end
 function modifier_alpha_critical_strike_aura_oaa_applier:GetAuraEntityReject(hEntity)
   local caster = self:GetCaster()
   -- Dont provide the aura effect to hero creeps when caster (owner of this aura) cannot be controlled
-  if hEntity ~= caster and hEntity:IsConsideredHero() and not caster:IsControllableByAnyPlayer() then
+  if hEntity ~= caster and hEntity:GetUnitName() ~= "npc_dota_neutral_custom_small_wolf" and not caster:IsControllableByAnyPlayer() then
     return true
   end
   return false

--- a/game/scripts/vscripts/abilities/neutrals/oaa_ghost_frostburn.lua
+++ b/game/scripts/vscripts/abilities/neutrals/oaa_ghost_frostburn.lua
@@ -50,8 +50,7 @@ function modifier_frostburn_oaa_applier:OnAttackLanded(event)
       return
     end
     if attacker == self:GetParent() and not attacker:IsIllusion() and not attacker:PassivesDisabled() and not target:IsMagicImmune() then
-      local debuff_duration = target:GetValueChangedByStatusResistance(self.heal_prevent_duration)
-      target:AddNewModifier(attacker, self:GetAbility(), "modifier_frostburn_oaa_effect", {duration = debuff_duration})
+      target:AddNewModifier(attacker, self:GetAbility(), "modifier_frostburn_oaa_effect", {duration = self.heal_prevent_duration})
     end
   end
 end
@@ -78,7 +77,7 @@ function modifier_frostburn_oaa_effect:OnCreated()
     if ability then
       self.heal_prevent_percent = ability:GetSpecialValueFor("heal_prevent_percent")
     else
-      self.heal_prevent_percent = 40
+      self.heal_prevent_percent = 35
     end
     self.duration = self:GetDuration()
     self.health_fraction = 0

--- a/game/scripts/vscripts/abilities/neutrals/oaa_harpy_storm_null_field.lua
+++ b/game/scripts/vscripts/abilities/neutrals/oaa_harpy_storm_null_field.lua
@@ -28,6 +28,9 @@ function modifier_harpy_null_field_oaa_applier:IsAura()
   if parent:PassivesDisabled() then
     return false
   end
+  if not parent:IsControllableByAnyPlayer() then
+    return false
+  end
   return true
 end
 

--- a/game/scripts/vscripts/components/creeps/creep_power.lua
+++ b/game/scripts/vscripts/components/creeps/creep_power.lua
@@ -50,6 +50,10 @@ function CreepPower:GetBaseCavePowerForMinute (minute)
 end
 
 function CreepPower:Init ()
+  if self.initialized then
+    print("CreepPower is already initialized and there was an attempt to initialize it again -> preventing")
+    return nil
+  end
   local maxTeamPlayerCount = 10 -- TODO: Make maxTeamPlayerCount based on values set in settings.lua (?)
   if HeroSelection.is10v10 then
     maxTeamPlayerCount = 20
@@ -62,4 +66,5 @@ function CreepPower:Init ()
   end
 
   self.BootGoldFactor = _G.BOOT_GOLD_FACTOR
+  self.initialized = true
 end

--- a/game/scripts/vscripts/components/creeps/creep_types.lua
+++ b/game/scripts/vscripts/components/creeps/creep_types.lua
@@ -4,45 +4,45 @@ CreepTypes = {
   -- 1 "easy camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_custom_big_wolf",          600,  480,  35,   1.5,   40,  40}, -- expected gold is 100 and XP is 90
+      {"npc_dota_neutral_custom_big_wolf",          600,  150,  35,   1.5,   40,  40}, -- expected gold is 100 and XP is 90
       {"npc_dota_neutral_custom_small_wolf",        400,    0,  15,   0.5,   30,  25},
       {"npc_dota_neutral_custom_small_wolf",        400,    0,  15,   0.5,   30,  25}
     },
     {
-      {"npc_dota_neutral_custom_kobold_foreman",    560,  480,  16,    1,    40,  35},
-      {"npc_dota_neutral_custom_kobold_soldier",    480,    0,  12,    1,    35,  30},
+      {"npc_dota_neutral_custom_kobold_foreman",    560,  150,  30,    1,    40,  35},
+      {"npc_dota_neutral_custom_kobold_soldier",    480,    0,  20,    1,    35,  30},
       {"npc_dota_neutral_custom_kobold",            280,    0,  10,   0.5,   25,  25}
     },
   },
     -- 2 "medium camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_custom_harpy_storm",       560,  400,  35,   1.2,   45,  82}, -- expected gold is 80 and XP is 143
+      {"npc_dota_neutral_custom_harpy_storm",       560,  300,  40,   1.2,   45,  82}, -- expected gold is 80 and XP is 143
       {"npc_dota_neutral_custom_harpy_scout",       480,    0,  40,   0.7,   40,  61}
     },
     {
       {"npc_dota_neutral_custom_mud_golem",         800,    0,  35,    1,    35,  57} -- multiply gold value by 2 and xp value by 2.5 because they split
     },
     {
-      {"npc_dota_neutral_custom_blue_tomato",       800,  400,  35,   1.3,   45,  82},
-      {"npc_dota_neutral_custom_blue_potato",       480,    0,  30,   1.3,   40,  61}
+      {"npc_dota_neutral_custom_blue_tomato",       800,  300,  40,   1.3,   45,  82},
+      {"npc_dota_neutral_custom_blue_potato",       480,    0,  35,   1.3,   40,  61}
     }
   },
     -- 3 "hard camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_custom_ghost",             800,  400,  40,   1.5,   75,  60}, -- expected gold is 147 and XP 120
-      {"npc_dota_neutral_custom_ghost",             800,  400,  40,   1.5,   75,  60}
+      {"npc_dota_neutral_custom_ghost",             850,    0,  40,   1.5,   75,  60}, -- expected gold is 147 and XP 120
+      {"npc_dota_neutral_custom_ghost",             850,    0,  40,   1.5,   75,  60}
     },
     {
-      {"npc_dota_neutral_custom_centaur_khan",      900,  400,  50,   1.5,   76,  60},
+      {"npc_dota_neutral_custom_centaur_khan",      900,  300,  50,   1.5,   76,  60},
       {"npc_dota_neutral_custom_small_centaur",     500,    0,  30,    1,    37,  30},
       {"npc_dota_neutral_custom_small_centaur",     500,    0,  30,    1,    37,  30}
     },
     {
-      {"npc_dota_neutral_satyr_hellcaller",         900,  480,  50,   1.5,   76,  53},
-      {"npc_dota_neutral_satyr_soulstealer",        600,  480,  30,    1,    38,  40},
-      {"npc_dota_neutral_satyr_trickster",          350,  480,  10,    1,    28,  27}
+      {"npc_dota_neutral_satyr_hellcaller",         900,  400,  50,   1.5,   76,  53},
+      {"npc_dota_neutral_satyr_soulstealer",        600,  600,  30,    1,    38,  40},
+      {"npc_dota_neutral_satyr_trickster",          350,  500,  10,    1,    28,  27}
     }
   },
    -- 4 "ancient camp"
@@ -53,7 +53,7 @@ CreepTypes = {
       {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    50,  38}
     },
     {
-      {"npc_dota_neutral_prowler_shaman",          1700,  500,  90,    3,   200, 151}
+      {"npc_dota_neutral_prowler_shaman",          1700,  400,  90,    3,   200, 151}
     },
     {
       {"npc_dota_neutral_black_dragon",            1700,  500,  90,    3,   200, 151}
@@ -62,7 +62,7 @@ CreepTypes = {
    -- 5 "solo ancient corner camp"
   {
     {
-      {"npc_dota_neutral_custom_black_dragon",     1500,  500,  80,    3,   152, 156}
+      {"npc_dota_neutral_custom_black_dragon",     1500,  300,  85,    3,   152, 156}
     }
   }
 }

--- a/game/scripts/vscripts/components/creeps/item_drop.lua
+++ b/game/scripts/vscripts/components/creeps/item_drop.lua
@@ -34,10 +34,15 @@ ItemPowerTable = {
 
 function CreepItemDrop:Init ()
   DebugPrint ( '[creeps/item_drop] Initialize' )
-  CreepItemDrop = self
+  if self.initialized then
+    print("CreepItemDrop is already initialized and there was an attempt to initialize it again -> preventing")
+    return nil
+  end
 
   --ListenToGameEvent("entity_killed", CreepItemDrop.OnEntityKilled, self)
   Timers:CreateTimer(Dynamic_Wrap(self, 'ItemDropUpgradeTimer'), self)
+  
+  self.initialized = true
 end
 
 function CreepItemDrop:SetPowerLevel (powerLevel)

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -206,6 +206,7 @@ function CreepCamps:SetCreepPropertiesOnHandle(creepHandle, creepProperties)
   creepHandle:SetHealth(math.ceil(targetHealth))
 
   --MANA
+  creepHandle:SetMaxMana(math.ceil(creepProperties[MANA_ENUM]))
   creepHandle:SetMana(math.ceil(creepProperties[MANA_ENUM]))
 
   --DAMAGE

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -143,7 +143,7 @@ function CreepCamps:GetCreepProperties(creepHandle)
   local creepProperties = {}
 
   creepProperties[HEALTH_ENUM] = creepHandle:GetMaxHealth()
-  creepProperties[MANA_ENUM] = creepHandle:GetMana()
+  creepProperties[MANA_ENUM] = creepHandle:GetMaxMana()
   creepProperties[DAMAGE_ENUM] = (creepHandle:GetBaseDamageMin() + creepHandle:GetBaseDamageMax()) / 2
   creepProperties[ARMOR_ENUM] = creepHandle:GetPhysicalArmorBaseValue()
   creepProperties[GOLD_BOUNTY_ENUM] = (creepHandle:GetMinimumGoldBounty() + creepHandle:GetMaximumGoldBounty()) / 2

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -24,19 +24,28 @@ local EXP_BOUNTY_ENUM = 7
 -- profit
 
 function CreepCamps:Init ()
-  DebugPrint ( 'Initializing.' )
-  CreepCamps = self
+  DebugPrint ( 'Initializing CreepCamps' )
+  if self.initialized then
+    print("CreepCamps is already initialized and there was an attempt to initialize it again -> preventing")
+    return nil
+  end
+
   self.CampPRDCounters = {}
   self.firstSpawn = true
-  if not SKIP_TEAM_SETUP then
+  if HudTimer then
     HudTimer:At(INITIAL_CREEP_DELAY, partial(self.CreepSpawnTimer, self))
   else
-    Timers:CreateTimer(Dynamic_Wrap(self, 'CreepSpawnTimer'), self)
+    Timers:CreateTimer(INITIAL_CREEP_DELAY, function()
+      CreepCamps:CreepSpawnTimer()
+	  --return CREEP_SPAWN_INTERVAL
+    end)
   end
 
   Minimap:InitializeCampIcons()
 
   ChatCommand:LinkDevCommand("-spawncamps", Dynamic_Wrap(self, 'CreepSpawnTimer'), self)
+
+  self.initialized = true
 end
 
 function CreepCamps:GetState ()


### PR DESCRIPTION
* **Fixed double initial creep spawn** -> because it was initializing twice. Several oaa components have the same issue.
* Big Wolf Crit Aura now applies **only to wolves**. When dominated/devoured it works normally on all units. -> This means corner dragons and other neutral creeps will not be able to crit.
* Harpy Stormcrafter Null Field Aura now works only when dominated/devoured. -> This means you can be near **neutral** harpies and your magic resistance will be normal.
* Ghost Vortex with Cloak Aura (20% magic resistance aura)
* Ghost base magic resistance from 25% to 5%.
* Ghost Frostburn healing/hp regen reduction decreased from 40% to 35%.
* Ghost Frostburn debuff duration is no longer affected by status resistance.
* Attempted to fix no mana bug on neutral creeps (fixed only for some creeps).
Minor changes:
* Ghost HP increased from 800 to 850.
* Ghost mana removed.
* Big Wolf mana reduced from 480 to 150.
* Kobold Chief mana reduced from 480 to 150.
* Kobold Chief damage increased from 16 to 30.
* Kobold Soldier damage increased from 12 to 20.
* Harpy Stormcrafter mana reduced from 400 to 300.
* Harpy Stormcrafter damage increased from 35 to 40.
* Blue Tomato mana reduced from 400 to 300.
* Blue Tomato damage increased from 35 to 40.
* Blue Potato damage increased from 30 to 35.
* Big Centaur mana reduced from 400 to 300.
* Big Satyr mana reduced from 480 to 400.
* Medium Satyr mana increased from 480 to 600.
* Small Satyr mana increased from 480 to 500.
* Ancient Prowler Shaman mana reduced from 500 to 400.
* Corner Black Dragon mana reduced from 500 to 300.
* Corner Black Dragon damage increased from 80 to 85.