### PR TITLE
Experience changes

### DIFF
--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -26,6 +26,7 @@ Duels.onEnd = DuelEndEvent.listen
 function Duels:Init ()
   DebugPrint('Init duels')
   self.currentDuel = nil
+  self.allowExperienceGain = 0 -- 0 is no; 1 is yes; 2 is first duel (special no)
   iter(zoneNames):foreach(partial(self.RegisterZone, self))
 
   GameEvents:OnHeroDied(function (keys)
@@ -230,6 +231,9 @@ function Duels:StartDuel(options)
   options = options or {}
   if not options.firstDuel then
     Music:SetMusic(12)
+    self.allowExperienceGain = 0
+  else
+    self.allowExperienceGain = 2
   end
   Timers:RemoveTimer('EndDuel')
   self.currentDuel = DUEL_IS_STARTING
@@ -360,6 +364,9 @@ function Duels:SplitDuelPlayers(options)
 
   if options.isFinalDuel or HeroSelection.isCM or options.forceAllPlayers then
     playerSplitOffset = 0
+    if Duels.allowExperienceGain ~= 2 then
+      Duels.allowExperienceGain = 1
+    end
   end
 
   return

--- a/game/scripts/vscripts/components/experience/hero_kills_xp.lua
+++ b/game/scripts/vscripts/components/experience/hero_kills_xp.lua
@@ -27,6 +27,10 @@ function HeroKillXP:HeroDeathHandler(keys)
     return
   end
 
+  if Duels:IsActive() and Duels.allowExperienceGain ~= 1 then
+    return
+  end
+
   local killerEntity = keys.killer
   local killedHero = keys.killed
   -- killer is sometimes nil for some reason

--- a/game/scripts/vscripts/components/filters/bountyrunepick.lua
+++ b/game/scripts/vscripts/components/filters/bountyrunepick.lua
@@ -38,7 +38,7 @@ function BountyRunePick:Filter(filter_table)
     enemy_team = DOTA_TEAM_GOODGUYS
   else
     print("Invalid team picked up the rune")
-	return false
+    return false
   end
 
   -- Player team IDs iterators
@@ -69,7 +69,10 @@ function BountyRunePick:Filter(filter_table)
   end)
 
   local gold_diff = (EnemyTeamGold - AlliedTeamGold) / (EnemyTeamGold + AlliedTeamGold)
-  local xp_diff = (EnemyTeamXP - AlliedTeamXP) / (EnemyTeamXP + AlliedTeamXP)
+  local xp_diff = 0
+  if (EnemyTeamXP + AlliedTeamXP) > 0 then
+    xp_diff = (EnemyTeamXP - AlliedTeamXP) / (EnemyTeamXP + AlliedTeamXP)
+  end
   local gold_difference = math.max(0, gold_diff)
   local xp_difference = math.max(0, xp_diff)
 

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -137,11 +137,11 @@ USE_CUSTOM_HERO_LEVELS = true  -- Should the heroes give a custom amount of XP w
 
 -- Formula for XP on hero kill: (HERO_XP_BOUNTY_BASE + HERO_XP_BOUNTY_STREAK + HERO_XP_BONUS_FACTOR x DyingHeroXP)/number_of_killers
 -- Old formula: DyingHeroBaseXPBounty + (AOE_XP_LEVEL_MULTIPLIER × DyingHeroLevel) + (AOE_XP_BONUS_FACTOR × TeamXPDiff × DyingHeroXP)
-HERO_XP_BOUNTY_BASE = 20             -- 40 in normal dota
-HERO_XP_BOUNTY_STREAK_BASE = 50      -- 400 in normal dota (XP bonus when killing heroes with Killing Spree - 3 kills in a row)
+HERO_XP_BOUNTY_BASE = 100            -- 100 in normal dota
+HERO_XP_BOUNTY_STREAK_BASE = 50      -- lvl * 30 in normal dota (XP bonus when killing heroes with Killing Spree - 3 kills in a row)
 HERO_XP_BOUNTY_STREAK_INCREASE = 100 -- 200 in normal dota
-HERO_XP_BOUNTY_STREAK_MAX = 850      -- 1800 in normal dota (XP bonus when killing heroes with Beyond Godlike - 10+ kills in a row)
-HERO_XP_BONUS_FACTOR = 0.07          -- 0.13 in normal dota
+HERO_XP_BOUNTY_STREAK_MAX = 800      -- 1800 in normal dota (XP bonus when killing heroes with Beyond Godlike - 10+ kills in a row)
+HERO_XP_BONUS_FACTOR = 0.13          -- 0.13 in normal dota
 HERO_KILL_XP_RADIUS = 1500           -- 1500 in normal dota
 
 -- Bounty runes
@@ -204,25 +204,25 @@ XP_PER_LEVEL_TABLE = {
 	1080,
 	1680,
 	2300,
-	2940,
-	3600,
-	4280,
-	5080,
-	5900,
-	6740,
-	7640,
-	8865,
-	10115,
-	11390,
-	12690,
-	14015,
-	15415,
-	16905,
-	18505,
-	20405,
-	22605,
-	25105,
-	27800,
+	2980,
+	3730,
+	4620,
+	5550,
+	6520,
+	7530,
+	8850,
+	9800,
+	11000,
+	12330,
+	13630,
+	14955,
+	16455,
+	18000,
+	19645,
+	21405,
+	23600,
+	25950,
+	28545,
 }
 for i = #XP_PER_LEVEL_TABLE + 1, MAX_LEVEL do
   XP_PER_LEVEL_TABLE[i] = XP_PER_LEVEL_TABLE[i - 1] + (300 * ( i - 15 ))


### PR DESCRIPTION
* Hero kill xp increased from (20 + streak_xp + 0.07 x dying_hero_xp)/# of killers to **(100 + streak_xp + 0.13 x dying_hero_xp)/# of killers**.
* Max streak_xp reduced from 850 to 800.
* Increased experience required for levels above level 7. Experience required for lvl 25 is the same as in normal dota.
* Hero kills in duels will now provide experience only both teams are in one duel arena.
* Hero kills no longer give experience in the first duel.
* Preventing division of 0 by 0 in bounty rune filter because of first duel change.

The goal of these changes is to:
- make kills more relevant
- make gaining experience easier for supports which dont farm
- decrease snowballing of flashfarmers and corner creep farmers