### PR TITLE
Slardar Bash Rework

### DIFF
--- a/game/resource/English/ability/units/tooltip_slardar_bash.txt
+++ b/game/resource/English/ability/units/tooltip_slardar_bash.txt
@@ -2,10 +2,10 @@
 // Slardar's Bash of the Deep
 //=============================================================================
 "DOTA_Tooltip_ability_slardar_bash_oaa"                       "#{DOTA_Tooltip_ability_slardar_bash}"
-"DOTA_Tooltip_ability_slardar_bash_oaa_Description"           "Grants a chance that an attack will do bonus damage and stun an enemy. <font color='#FFA500'>Bash of the Deep has a %tooltip_cooldown% seconds cooldown.</font>"
+"DOTA_Tooltip_ability_slardar_bash_oaa_Description"           "Slardar will do bonus damage and stun an enemy for a single strike. <font color='#FFA500'>Bash of the Deep has a %tooltip_cooldown% seconds cooldown.</font>"
 "DOTA_Tooltip_ability_slardar_bash_oaa_Lore"                  "#{DOTA_Tooltip_ability_slardar_bash_Lore}"
 "DOTA_Tooltip_ability_slardar_bash_oaa_Note0"                 "Does not stack with Abyssal Blade."
-"DOTA_Tooltip_ability_slardar_bash_oaa_chance"                "%BASH CHANCE:"
+//"DOTA_Tooltip_ability_slardar_bash_oaa_chance"                "%BASH CHANCE:"
 "DOTA_Tooltip_ability_slardar_bash_oaa_bonus_damage"          "#{DOTA_Tooltip_ability_slardar_bash_bonus_damage}"
 "DOTA_Tooltip_ability_slardar_bash_oaa_duration"              "#{DOTA_Tooltip_ability_slardar_bash_duration}"
 

--- a/game/scripts/npc/abilities/slardar_bash.txt
+++ b/game/scripts/npc/abilities/slardar_bash.txt
@@ -28,7 +28,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "50 100 150 200 400 600"
+        "bonus_damage"                                    "50 100 150 200 400 800"
         "LinkedSpecialBonus"                              "special_bonus_unique_slardar_2"
       }
       "02"
@@ -39,12 +39,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "attack_count"                                    "3"
+        "attack_count"                                    "1" //OAA
       }
       "04" //OAA, for picking screen tooltip
       {
         "var_type"                                        "FIELD_FLOAT"
-        "tooltip_cooldown"                                "1.65"
+        "tooltip_cooldown"                                "8.0"
       }
     }
   }

--- a/game/scripts/npc/abilities/slardar_bash_oaa.txt
+++ b/game/scripts/npc/abilities/slardar_bash_oaa.txt
@@ -26,7 +26,7 @@
 
     // Time
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "1.65"
+    "AbilityCooldown"                                     "8.0"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------
@@ -35,12 +35,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "chance"                                          "25"
+        "chance"                                          "100"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "50 100 150 200 400 600"
+        "bonus_damage"                                    "50 100 150 200 400 800"
         "LinkedSpecialBonus"                              "special_bonus_unique_slardar_2"
       }
       "03"
@@ -56,7 +56,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "tooltip_cooldown"                                "1.65"
+        "tooltip_cooldown"                                "8.0"
       }
     }
   }


### PR DESCRIPTION
* Now it procs every time its off cooldown (like Kunkka Tidebringer but its still a passive ability).
* Cooldown increased from 1.65 to 8 seconds.
* Bonus damage increased at level 6 from 600 to 800.

The goal is to make the ability similar to the vanilla Bash of the Deep -> less RNG involved, more utility oriented.