### PR TITLE
Stone Skin mega buffs

### DIFF
--- a/game/resource/English/ability/items/transformation/tooltip_stoneskin.txt
+++ b/game/resource/English/ability/items/transformation/tooltip_stoneskin.txt
@@ -19,5 +19,5 @@
 "DOTA_Tooltip_Ability_item_stoneskin_2_hp_regen_amp"                        "#{DOTA_Tooltip_Ability_item_stoneskin_hp_regen_amp}"
 
 "DOTA_Tooltip_modifier_item_stoneskin_stone_armor"                          "Stone Skin"
-"DOTA_Tooltip_modifier_item_stoneskin_stone_armor_Description"              "Extra %dMODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS% armor, %dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%% magic resistance, %dMODIFIER_PROPERTY_STATUS_RESISTANCE_STACKING%%% status resistance and a chance to block ranged attacks.."
+"DOTA_Tooltip_modifier_item_stoneskin_stone_armor_Description"              "Extra %dMODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS% armor, %dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%% magic resistance, %dMODIFIER_PROPERTY_STATUS_RESISTANCE_STACKING%%% status resistance and a chance to block ranged attacks."
 

--- a/game/resource/English/ability/items/transformation/tooltip_stoneskin.txt
+++ b/game/resource/English/ability/items/transformation/tooltip_stoneskin.txt
@@ -2,19 +2,22 @@
 // Stoneskin Armor
 //========================================================================================
 "DOTA_Tooltip_Ability_item_stoneskin"                                       "Stoneskin Armor"
-"DOTA_Tooltip_Ability_item_stoneskin_Description"                           "<h1>Active: Stone Skin</h1> Grants %stone_armor% armor and %stone_resist%%% magic resistance. Lasts %duration% seconds."
+"DOTA_Tooltip_Ability_item_stoneskin_Description"                           "<h1>Active: Stone Skin</h1> Grants %stone_armor% armor, %stone_magic_resist%%% magic resistance, %stone_status_resist%%% status resistance and %stone_block_chance%%% chance to block ranged attacks. Lasts %duration% seconds."
 "DOTA_Tooltip_Ability_item_stoneskin_Lore"                                  "Massive and hefty ice armor bestows incredible defense on the user."
 //"DOTA_Tooltip_Ability_item_stoneskin_Note0"                                 "#{transformation_note0}"
+"DOTA_Tooltip_Ability_item_stoneskin_Note0"                                 "Stone Skin ranged attack block chance is not evasion!"
 "DOTA_Tooltip_Ability_item_stoneskin_bonus_armor"                           "+$armor"
 "DOTA_Tooltip_Ability_item_stoneskin_bonus_intellect"                       "+$int"
+"DOTA_Tooltip_Ability_item_stoneskin_hp_regen_amp"                          "%+Health Regen Amplification"
 
 "DOTA_Tooltip_Ability_item_stoneskin_2"                                     "#{DOTA_Tooltip_Ability_item_stoneskin}"
 "DOTA_Tooltip_Ability_item_stoneskin_2_Description"                         "#{DOTA_Tooltip_Ability_item_stoneskin_Description}"
 "DOTA_Tooltip_Ability_item_stoneskin_2_Lore"                                "#{DOTA_Tooltip_Ability_item_stoneskin_Lore}"
-//"DOTA_Tooltip_Ability_item_stoneskin_2_Note0"                               "#{DOTA_Tooltip_Ability_item_stoneskin_Note0}"
+"DOTA_Tooltip_Ability_item_stoneskin_2_Note0"                               "#{DOTA_Tooltip_Ability_item_stoneskin_Note0}"
 "DOTA_Tooltip_Ability_item_stoneskin_2_bonus_armor"                         "#{DOTA_Tooltip_Ability_item_stoneskin_bonus_armor}"
 "DOTA_Tooltip_Ability_item_stoneskin_2_bonus_intellect"                     "#{DOTA_Tooltip_Ability_item_stoneskin_bonus_intellect}"
+"DOTA_Tooltip_Ability_item_stoneskin_2_hp_regen_amp"                        "#{DOTA_Tooltip_Ability_item_stoneskin_hp_regen_amp}"
 
 "DOTA_Tooltip_modifier_item_stoneskin_stone_armor"                          "Stone Skin"
-"DOTA_Tooltip_modifier_item_stoneskin_stone_armor_Description"              "Bonus %dMODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS% armor and bonus %dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%% magic resistance."
+"DOTA_Tooltip_modifier_item_stoneskin_stone_armor_Description"              "Extra %dMODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS% armor, %dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%% magic resistance, %dMODIFIER_PROPERTY_STATUS_RESISTANCE_STACKING%%% status resistance and a chance to block ranged attacks.."
 

--- a/game/resource/English/ability/items/transformation/tooltip_stoneskin.txt
+++ b/game/resource/English/ability/items/transformation/tooltip_stoneskin.txt
@@ -2,10 +2,10 @@
 // Stoneskin Armor
 //========================================================================================
 "DOTA_Tooltip_Ability_item_stoneskin"                                       "Stoneskin Armor"
-"DOTA_Tooltip_Ability_item_stoneskin_Description"                           "<h1>Active: Stone Skin</h1> Grants %stone_armor% armor, %stone_magic_resist%%% magic resistance, %stone_status_resist%%% status resistance and %stone_block_chance%%% chance to block ranged attacks. Lasts %duration% seconds."
+"DOTA_Tooltip_Ability_item_stoneskin_Description"                           "<h1>Active: Stone Skin</h1> Grants %stone_armor% armor, %stone_magic_resist%%% magic resistance, %stone_status_resist%%% status resistance and %stone_block_chance%%% chance to block damage from ranged attacks. Lasts %duration% seconds."
 "DOTA_Tooltip_Ability_item_stoneskin_Lore"                                  "Massive and hefty ice armor bestows incredible defense on the user."
 //"DOTA_Tooltip_Ability_item_stoneskin_Note0"                                 "#{transformation_note0}"
-"DOTA_Tooltip_Ability_item_stoneskin_Note0"                                 "Stone Skin ranged attack block chance is not evasion!"
+"DOTA_Tooltip_Ability_item_stoneskin_Note0"                                 "Attack modifiers still work against Stone Skin even if the damage is blocked."
 "DOTA_Tooltip_Ability_item_stoneskin_bonus_armor"                           "+$armor"
 "DOTA_Tooltip_Ability_item_stoneskin_bonus_intellect"                       "+$int"
 "DOTA_Tooltip_Ability_item_stoneskin_hp_regen_amp"                          "%+Health Regen Amplification"
@@ -19,5 +19,5 @@
 "DOTA_Tooltip_Ability_item_stoneskin_2_hp_regen_amp"                        "#{DOTA_Tooltip_Ability_item_stoneskin_hp_regen_amp}"
 
 "DOTA_Tooltip_modifier_item_stoneskin_stone_armor"                          "Stone Skin"
-"DOTA_Tooltip_modifier_item_stoneskin_stone_armor_Description"              "Extra %dMODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS% armor, %dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%% magic resistance, %dMODIFIER_PROPERTY_STATUS_RESISTANCE_STACKING%%% status resistance and a chance to block ranged attacks."
+"DOTA_Tooltip_modifier_item_stoneskin_stone_armor_Description"              "Extra %dMODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS% armor, %dMODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS%%% magic resistance, %dMODIFIER_PROPERTY_STATUS_RESISTANCE_STACKING%%% status resistance and a chance to block damage from ranged attacks."
 

--- a/game/scripts/npc/items/custom/item_stoneskin.txt
+++ b/game/scripts/npc/items/custom/item_stoneskin.txt
@@ -78,12 +78,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "100 150"
+        "bonus_intellect"                                 "90 120"
       }
-      "03" // unused KV
+      "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "stone_move_speed"                                "250"
+        "hp_regen_amp"                                    "25"
       }
       "04"
       {
@@ -93,9 +93,19 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "stone_resist"                                    "10 15"
+        "stone_magic_resist"                              "20"
       }
       "06"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "stone_status_resist"                             "30"
+      }
+      "07"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "stone_block_chance"                              "25"
+      }
+      "08"
       {
         "var_type"                                        "FIELD_FLOAT"
         "duration"                                        "6.0"

--- a/game/scripts/npc/items/custom/item_stoneskin.txt
+++ b/game/scripts/npc/items/custom/item_stoneskin.txt
@@ -103,7 +103,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "stone_block_chance"                              "25"
+        "stone_block_chance"                              "30"
       }
       "08"
       {

--- a/game/scripts/npc/items/custom/item_stoneskin_2.txt
+++ b/game/scripts/npc/items/custom/item_stoneskin_2.txt
@@ -103,7 +103,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "stone_block_chance"                              "25"
+        "stone_block_chance"                              "30"
       }
       "08"
       {

--- a/game/scripts/npc/items/custom/item_stoneskin_2.txt
+++ b/game/scripts/npc/items/custom/item_stoneskin_2.txt
@@ -78,12 +78,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "100 150"
+        "bonus_intellect"                                 "90 120"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "stone_move_speed"                                "250"
+        "hp_regen_amp"                                    "25"
       }
       "04"
       {
@@ -93,9 +93,19 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "stone_resist"                                    "10 15"
+        "stone_magic_resist"                              "20"
       }
       "06"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "stone_status_resist"                             "30"
+      }
+      "07"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "stone_block_chance"                              "25"
+      }
+      "08"
       {
         "var_type"                                        "FIELD_FLOAT"
         "duration"                                        "6.0"

--- a/game/scripts/vscripts/items/transformation/stoneskin.lua
+++ b/game/scripts/vscripts/items/transformation/stoneskin.lua
@@ -102,7 +102,9 @@ function modifier_item_stoneskin_stone_armor:IsPurgable()
 end
 
 function modifier_item_stoneskin_stone_armor:OnCreated()
-  self:GetParent():EmitSound("Hero_EarthSpirit.Petrify")
+  if IsServer() then
+    self:GetParent():EmitSound("Hero_EarthSpirit.Petrify")
+  end
 end
 
 function modifier_item_stoneskin_stone_armor:DeclareFunctions()
@@ -138,7 +140,7 @@ end
 function modifier_item_stoneskin_stone_armor:GetModifierAvoidDamage(event)
   local parent = self:GetParent()
   local ability = self:GetAbility()
-  local chance = 25
+  local chance = 30
   if ability and not ability:IsNull() then
     chance = ability:GetSpecialValueFor("stone_block_chance")
   end

--- a/game/scripts/vscripts/items/transformation/stoneskin.lua
+++ b/game/scripts/vscripts/items/transformation/stoneskin.lua
@@ -1,11 +1,11 @@
 item_stoneskin = class(TransformationBaseClass)
 
---LinkLuaModifier("modifier_item_stoneskin", "items/transformation/stoneskin.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_stoneskin", "items/transformation/stoneskin.lua", LUA_MODIFIER_MOTION_NONE)
 LinkLuaModifier("modifier_item_stoneskin_stone_armor", "items/transformation/stoneskin.lua", LUA_MODIFIER_MOTION_NONE)
-LinkLuaModifier("modifier_generic_bonus", "modifiers/modifier_generic_bonus.lua", LUA_MODIFIER_MOTION_NONE)
+--LinkLuaModifier("modifier_generic_bonus", "modifiers/modifier_generic_bonus.lua", LUA_MODIFIER_MOTION_NONE)
 
 function item_stoneskin:GetIntrinsicModifierName()
-  return "modifier_generic_bonus"
+  return "modifier_item_stoneskin" --"modifier_generic_bonus"
 end
 
 function item_stoneskin:GetTransformationModifierName()
@@ -14,7 +14,59 @@ end
 
 item_stoneskin_2 = item_stoneskin
 ------------------------------------------------------------------------
---modifier_item_stoneskin = class(ModifierBaseClass)
+modifier_item_stoneskin = class(ModifierBaseClass)
+
+function modifier_item_stoneskin:IsHidden()
+  return true
+end
+function modifier_item_stoneskin:IsDebuff()
+  return false
+end
+function modifier_item_stoneskin:IsPurgable()
+  return false
+end
+
+function modifier_item_stoneskin:GetAttributes()
+  return MODIFIER_ATTRIBUTE_MULTIPLE
+end
+
+function modifier_item_stoneskin:OnCreated()
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.int = ability:GetSpecialValueFor("bonus_intellect")
+    self.armor = ability:GetSpecialValueFor("bonus_armor")
+    self.hp_regen_amp = ability:GetSpecialValueFor("hp_regen_amp")
+  end
+end
+
+function modifier_item_stoneskin:OnRefresh()
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.int = ability:GetSpecialValueFor("bonus_intellect")
+    self.armor = ability:GetSpecialValueFor("bonus_armor")
+    self.hp_regen_amp = ability:GetSpecialValueFor("hp_regen_amp")
+  end
+end
+
+function modifier_item_stoneskin:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS,
+    MODIFIER_PROPERTY_STATS_INTELLECT_BONUS,
+    MODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE,
+  }
+end
+
+function modifier_item_stoneskin:GetModifierPhysicalArmorBonus()
+  return self.armor or self:GetAbility():GetSpecialValueFor("bonus_armor")
+end
+
+function modifier_item_stoneskin:GetModifierBonusStats_Intellect()
+  return self.int or self:GetAbility():GetSpecialValueFor("bonus_intellect")
+end
+
+function modifier_item_stoneskin:GetModifierHPRegenAmplify_Percentage()
+  return self.hp_regen_amp or self:GetAbility():GetSpecialValueFor("hp_regen_amp")
+end
 
 -- function modifier_item_stoneskin:OnStackCountChanged(numOldStacks)
 --   -- Echo stack count to a property on the item so that it can be checked for
@@ -57,6 +109,8 @@ function modifier_item_stoneskin_stone_armor:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS,
     MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS,
+    MODIFIER_PROPERTY_AVOID_DAMAGE,
+    MODIFIER_PROPERTY_STATUS_RESISTANCE_STACKING,
     --MODIFIER_PROPERTY_MOVESPEED_ABSOLUTE
   }
 end
@@ -66,7 +120,7 @@ function modifier_item_stoneskin_stone_armor:GetModifierPhysicalArmorBonus()
     if not self:IsNull() then
       self:Destroy()
     end
-    return
+    return 0
   end
   return self:GetAbility():GetSpecialValueFor("stone_armor")
 end
@@ -76,9 +130,33 @@ function modifier_item_stoneskin_stone_armor:GetModifierMagicalResistanceBonus()
     if not self:IsNull() then
       self:Destroy()
     end
-    return
+    return 0
   end
-  return self:GetAbility():GetSpecialValueFor("stone_resist")
+  return self:GetAbility():GetSpecialValueFor("stone_magic_resist")
+end
+
+function modifier_item_stoneskin_stone_armor:GetModifierAvoidDamage(event)
+  local parent = self:GetParent()
+  local ability = self:GetAbility()
+  local chance = 25
+  if ability and not ability:IsNull() then
+    chance = ability:GetSpecialValueFor("stone_block_chance")
+  end
+  if event.ranged_attack == true and event.damage_category == DOTA_DAMAGE_CATEGORY_ATTACK and RollPseudoRandomPercentage(chance, DOTA_PSEUDO_RANDOM_CUSTOM_GAME_1, parent) == true then
+    return 1
+  end
+
+  return 0
+end
+
+function modifier_item_stoneskin_stone_armor:GetModifierStatusResistanceStacking()
+  if not self:GetAbility() then
+    if not self:IsNull() then
+      self:Destroy()
+    end
+    return 0
+  end
+  return self:GetAbility():GetSpecialValueFor("stone_status_resist")
 end
 
 function modifier_item_stoneskin_stone_armor:GetStatusEffectName()


### PR DESCRIPTION
Since certain someone said the item is shit, lets make it good.

* Stone Skin now passively provides 25% HP Regen Amplification.
* Stone Skin active buff bonus magic resistance increased from 10/15% to 20%.
* Stone Skin active buff now also provides 30% status resistance.
* Stone Skin active buff now also provides 30% chance to block damage from ranged attacks. 
Tried to make ranged attack projectile dodging without making dodge/disjoint all projectiles. It didnt work. It only blocks damage from ranged attacks now. Attack modifiers still work against Stone Skin.
* Stone Skin bonus intelligence reduced from 100/150 to 90/120 (same as Shiva's Guard 4-5).