### PR TITLE
Dagger of Moriah buffs

### DIFF
--- a/game/resource/English/ability/items/transformation/tooltip_dagger_of_moriah.txt
+++ b/game/resource/English/ability/items/transformation/tooltip_dagger_of_moriah.txt
@@ -3,7 +3,7 @@
 //==================================================================
 "DOTA_Tooltip_Ability_item_dagger_of_moriah"                            "Dagger of Moriah"
 "DOTA_Tooltip_Ability_item_recipe_dagger_of_moriah"                     "Dagger of Moriah Recipe"
-"DOTA_Tooltip_Ability_item_dagger_of_moriah_Description"                "<h1>Active: Sangromancy</h1> Grants %sangromancy_spell_amp%%% spell amplification but reflects %sangromancy_self_damage%%% of the damage you deal with spells back to you, and increases damage you take from enemies by %sangromancy_bonus_damage_from_others%%%. Lasts %duration% seconds.<br>Self-inflicted damage is not lethal."
+"DOTA_Tooltip_Ability_item_dagger_of_moriah_Description"                "<h1>Active: Sangromancy</h1> Grants %sangromancy_spell_amp%%% spell amplification but reflects %sangromancy_self_damage%%% of the damage you deal with spells back to you, and increases damage you take from enemies by %sangromancy_bonus_damage_from_others%%%. Lasts %duration% seconds.<br>Self-inflicted damage is not lethal.\n<h1>Passive: Sorcery</h1>Grants %spell_amp_per_intellect%%% for each point of Intelligence."
 "DOTA_Tooltip_Ability_item_dagger_of_moriah_Note0"                      "Self-inflicted damage is not amplified, it can be reduced and it is of the same type as the spell that caused it."
 //"DOTA_Tooltip_Ability_item_dagger_of_moriah_Note1"                      "#{transformation_note0}"
 "DOTA_Tooltip_Ability_item_dagger_of_moriah_bonus_health_regen"         "+$hp_regen"

--- a/game/scripts/npc/items/custom/item_dagger_of_moriah.txt
+++ b/game/scripts/npc/items/custom/item_dagger_of_moriah.txt
@@ -78,12 +78,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sangromancy_self_damage"                         "100"
+        "sangromancy_self_damage"                         "100 75"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sangromancy_bonus_damage_from_others"            "50"
+        "sangromancy_bonus_damage_from_others"            "50 25"
       }
       "04"
       {
@@ -100,7 +100,12 @@
         "var_type"                                        "FIELD_FLOAT"
         "bonus_mana_regen"                                "3.0 4.0"
       }
-      "07"
+	  "07"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "spell_amp_per_intellect"                         "0.08"
+      }
+      "08"
       {
         "var_type"                                        "FIELD_FLOAT"
         "duration"                                        "6.0"

--- a/game/scripts/npc/items/custom/item_dagger_of_moriah_2.txt
+++ b/game/scripts/npc/items/custom/item_dagger_of_moriah_2.txt
@@ -74,12 +74,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sangromancy_self_damage"                         "100"
+        "sangromancy_self_damage"                         "100 75"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "sangromancy_bonus_damage_from_others"            "50"
+        "sangromancy_bonus_damage_from_others"            "50 25"
       }
       "04"
       {
@@ -96,7 +96,12 @@
         "var_type"                                        "FIELD_FLOAT"
         "bonus_mana_regen"                                "3.0 4.0"
       }
-      "07"
+	  "07"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "spell_amp_per_intellect"                         "0.08"
+      }
+      "08"
       {
         "var_type"                                        "FIELD_FLOAT"
         "duration"                                        "6.0"

--- a/game/scripts/vscripts/items/transformation/dagger_of_moriah.lua
+++ b/game/scripts/vscripts/items/transformation/dagger_of_moriah.lua
@@ -7,16 +7,97 @@ item_dagger_of_moriah = class(TransformationBaseClass)
 require('libraries/timers')
 
 LinkLuaModifier( "modifier_item_dagger_of_moriah_sangromancy", "items/transformation/dagger_of_moriah.lua", LUA_MODIFIER_MOTION_NONE )
-LinkLuaModifier( "modifier_generic_bonus", "modifiers/modifier_generic_bonus.lua", LUA_MODIFIER_MOTION_NONE )
+LinkLuaModifier( "modifier_item_dagger_of_moriah_passives", "items/transformation/dagger_of_moriah.lua", LUA_MODIFIER_MOTION_NONE )
+--LinkLuaModifier( "modifier_generic_bonus", "modifiers/modifier_generic_bonus.lua", LUA_MODIFIER_MOTION_NONE )
 
 --------------------------------------------------------------------------------
 
 function item_dagger_of_moriah:GetIntrinsicModifierName()
-  return "modifier_generic_bonus"
+  return "modifier_item_dagger_of_moriah_passives" --"modifier_generic_bonus"
 end
 
 function item_dagger_of_moriah:GetTransformationModifierName()
   return "modifier_item_dagger_of_moriah_sangromancy"
+end
+
+---------------------------------------------------------------------------------------------------
+
+modifier_item_dagger_of_moriah_passives = class(ModifierBaseClass)
+
+function modifier_item_dagger_of_moriah_passives:IsHidden()
+  return true
+end
+function modifier_item_dagger_of_moriah_passives:IsDebuff()
+  return false
+end
+function modifier_item_dagger_of_moriah_passives:IsPurgable()
+  return false
+end
+
+function modifier_item_dagger_of_moriah_passives:GetAttributes()
+  return MODIFIER_ATTRIBUTE_MULTIPLE
+end
+
+function modifier_item_dagger_of_moriah_passives:OnCreated()
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.stats = ability:GetSpecialValueFor("bonus_all_stats")
+    self.hp_regen = ability:GetSpecialValueFor("bonus_health_regen")
+    self.mp_regen = ability:GetSpecialValueFor("bonus_mana_regen")
+    self.spell_amp = ability:GetSpecialValueFor("spell_amp_per_intellect")
+  end
+end
+
+function modifier_item_dagger_of_moriah_passives:OnRefresh()
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.stats = ability:GetSpecialValueFor("bonus_all_stats")
+    self.hp_regen = ability:GetSpecialValueFor("bonus_health_regen")
+    self.mp_regen = ability:GetSpecialValueFor("bonus_mana_regen")
+    self.spell_amp = ability:GetSpecialValueFor("spell_amp_per_intellect")
+  end
+end
+
+function modifier_item_dagger_of_moriah_passives:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_STATS_STRENGTH_BONUS,
+    MODIFIER_PROPERTY_STATS_AGILITY_BONUS,
+    MODIFIER_PROPERTY_STATS_INTELLECT_BONUS,
+    MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT,
+    MODIFIER_PROPERTY_MANA_REGEN_CONSTANT,
+    MODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE,
+  }
+end
+
+function modifier_item_dagger_of_moriah_passives:GetModifierBonusStats_Strength()
+  return self.stats or self:GetAbility():GetSpecialValueFor("bonus_all_stats")
+end
+
+function modifier_item_dagger_of_moriah_passives:GetModifierBonusStats_Agility()
+  return self.stats or self:GetAbility():GetSpecialValueFor("bonus_all_stats")
+end
+
+function modifier_item_dagger_of_moriah_passives:GetModifierBonusStats_Intellect()
+  return self.stats or self:GetAbility():GetSpecialValueFor("bonus_all_stats")
+end
+
+function modifier_item_dagger_of_moriah_passives:GetModifierConstantHealthRegen()
+  return self.hp_regen or self:GetAbility():GetSpecialValueFor("bonus_health_regen")
+end
+
+function modifier_item_dagger_of_moriah_passives:GetModifierConstantManaRegen()
+  return self.mp_regen or self:GetAbility():GetSpecialValueFor("bonus_mana_regen")
+end
+
+function modifier_item_dagger_of_moriah_passives:GetModifierSpellAmplify_Percentage()
+  local parent = self:GetParent()
+  local spell_amp_per_int = self.spell_amp or self:GetAbility():GetSpecialValueFor("spell_amp_per_intellect")
+  if parent:IsHero() then
+    local int = parent:GetIntellect()
+    return int * spell_amp_per_int
+  end
+
+  return 0
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
* Dagger of Moriah now passively provides 0.08% spell amp for each point of Intelligence.
* Sangromancy self damage reduced from 100% to 100%/75%
* Sangromancy bonus damage from others reduced from 50% to 50%/25%.