### PR TITLE
Scale score limit extension with number of players

### DIFF
--- a/game/scripts/vscripts/abilities/misc/core_guy_score_limit.lua
+++ b/game/scripts/vscripts/abilities/misc/core_guy_score_limit.lua
@@ -2,7 +2,7 @@ LinkLuaModifier( "modifier_core_shrine", "abilities/misc/core_shrine.lua", LUA_M
 
 core_guy_score_limit = class(AbilityBaseClass)
 
-function core_guy_score_limit:GetIntrinsicModifierName ()
+function core_guy_score_limit:GetIntrinsicModifierName()
   return "modifier_core_shrine"
 end
 
@@ -13,8 +13,9 @@ function core_guy_score_limit:OnSpellStart()
   self.timesUsed = self.timesUsed + 1
 
   if IsServer() then
-    print("Trying to increase score limit!")
-    PointsManager:IncreaseLimit(KILL_LIMIT_INCREASE)
+    --print("Trying to increase score limit!")
+    local scoreLimitIncrease = PlayerResource:GetTeamPlayerCount() * KILL_LIMIT_INCREASE
+    PointsManager:IncreaseLimit(scoreLimitIncrease)
   end
 end
 

--- a/game/scripts/vscripts/components/boss/spawn.lua
+++ b/game/scripts/vscripts/components/boss/spawn.lua
@@ -196,7 +196,8 @@ function BossSpawner:SpawnBoss (pit, boss, bossTier, isProtected)
     pit.killCount = pit.killCount + 1
     if not BossSpawner.hasKilledTiers[bossTier] then
       BossSpawner.hasKilledTiers[bossTier] = true
-      PointsManager:IncreaseLimit(KILL_LIMIT_INCREASE)
+      local scoreLimitIncrease = PlayerResource:GetTeamPlayerCount() * KILL_LIMIT_INCREASE
+      PointsManager:IncreaseLimit(scoreLimitIncrease)
     end
     Timers:CreateTimer(BOSS_RESPAWN_TIMER, function()
       BossSpawner:SpawnBossAtPit(pit, bossTier)

--- a/game/scripts/vscripts/components/duels/final-duel.lua
+++ b/game/scripts/vscripts/components/duels/final-duel.lua
@@ -125,6 +125,6 @@ function FinalDuel:EndDuelHandler (currentDuel)
   self.goodCanWin = false
   self.badCanWin = false
 
-  local addToLimit = limitIncreaseAmounts[PointsManager:GetGameLength()]
+  local addToLimit = limitIncreaseAmounts[PointsManager:GetGameLength()]  -- this is 10; if you want to change put: PlayerResource:GetTeamPlayerCount() * KILL_LIMIT_INCREASE
   PointsManager:IncreaseLimit(addToLimit)
 end

--- a/game/scripts/vscripts/components/points/points.lua
+++ b/game/scripts/vscripts/components/points/points.lua
@@ -19,10 +19,12 @@ function PointsManager:Init ()
   self.hasGameEnded = false
 
   local scoreLimit = NORMAL_KILL_LIMIT
+  local scoreLimitIncrease = 10 -- if you want to change put: PlayerResource:GetTeamPlayerCount() * KILL_LIMIT_INCREASE
   if HeroSelection.is10v10 then
     scoreLimit = TEN_V_TEN_KILL_LIMIT
+    scoreLimitIncrease = scoreLimitIncrease/2
   end
-  scoreLimit = scoreLimit * PlayerResource:GetTeamPlayerCount() + KILL_LIMIT_INCREASE
+  scoreLimit = scoreLimit * PlayerResource:GetTeamPlayerCount() + scoreLimitIncrease
   CustomNetTables:SetTableValue( 'team_scores', 'limit', { value = scoreLimit, name = 'normal' } )
 
   CustomNetTables:SetTableValue( 'team_scores', 'score', {

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -34,9 +34,9 @@ ABANDON_DIFF_NEEDED = 2                   -- how many more abandons you need on 
 ABANDON_NEEDED = 3                        -- how many total abandons you need before auto win conditions can trigger
 
 -- kill limits
-NORMAL_KILL_LIMIT = 3
+NORMAL_KILL_LIMIT = 3                     -- Starting KILL_LIMIT - equal to 3 x number of players + actual KILL_LIMIT_INCREASE (for 5v5 its 40; for 3v3 its 24 etc.)
 TEN_V_TEN_KILL_LIMIT = 2
-KILL_LIMIT_INCREASE = 10
+KILL_LIMIT_INCREASE = 1                   -- Actual KILL_LIMIT_INCREASE is equal to number of players (for 10v10 map its 1/2 of the number of players)
 
 -- poop wards
 POOP_WARD_DURATION = 360


### PR DESCRIPTION
* I didnt change the starting score limits.
* I didnt change how much score limit is extended when you lose the final duel (still 10).
* I didnt change the score limit extension shrine cooldown (maybe it should scale with number of players too - debatable).