### PR TITLE
Neutral Creep stat tweaks

### DIFF
--- a/game/scripts/vscripts/components/creeps/creep_power.lua
+++ b/game/scripts/vscripts/components/creeps/creep_power.lua
@@ -13,11 +13,11 @@ function CreepPower:GetBasePowerForMinute (minute)
   if minute > 0 then
     values = {
       minute,                                                                                                           -- minute
-      (24 * ((minute/100) ^ 2) + 2 * (minute/100)) + 1,                                                                 -- hp
+      (24 * ((minute/100) ^ 2) + 1.5 * (minute/100)) + 1,                                                               -- hp
       (30 * ((minute/100) ^ 2) + 3 * (minute/100)) + 1,                                                                 -- mana
-      (48 * ((minute/100) ^ 2) + 5 * (minute/100)) + 1,                                                                 -- damage
+      (48 * ((minute/100) ^ 2) + 4.5 * (minute/100)) + 1,                                                               -- damage
       (minute / 6) + 1,                                                                                                 -- armor
-      (17 * (minute/100)) + 1,                                                                                          -- gold
+      (9 * (minute/100)) + 1,                                                                                           -- gold
       ((9 * minute ^ 2 + 17 * minute + 607)/607) * 2/3                                                                  -- xp
     }
   end

--- a/game/scripts/vscripts/components/creeps/creep_power.lua
+++ b/game/scripts/vscripts/components/creeps/creep_power.lua
@@ -8,16 +8,16 @@ function CreepPower:GetPowerForMinute (minute)
 end
 
 function CreepPower:GetBasePowerForMinute (minute)
-  local values = {   0,        1.0,      1.0,      1.0,      1.0,      1.0,      1.0}
+  local values = {   0,        1.0,      1.0,      1.0,      1.0,      1.0,      0.6} -- Values for first spawn (at 0:00 minute)
 
   if minute > 0 then
     values = {
-      minute,                                   -- minute
-      ((0 * ((minute / 100) ^ 4) - 0 * ((minute/100) ^ 3) + 30 * ((minute/100) ^ 2) + 3 * (minute/100)) + 1) * 0.6,     -- hp
-      (0 * ((minute / 100) ^ 4) - 0 * ((minute/100) ^ 3) + 30 * ((minute/100) ^ 2) + 3 * (minute/100)) + 1,             -- mana
-      ((0 * ((minute / 100) ^ 4) - 0 * ((minute/100) ^ 3) + 60 * ((minute/100) ^ 2) + 6 * (minute/100)) + 1) * 0.8,     -- damage
-      (0 * (minute / 26) ^ 2 + minute / 6) + 1,                                                                         -- armor
-      ((0 * minute ^ 2 + 16 * minute + 49)/90),                                                                         -- gold
+      minute,                                                                                                           -- minute
+      (24 * ((minute/100) ^ 2) + 2 * (minute/100)) + 1,                                                                 -- hp
+      (30 * ((minute/100) ^ 2) + 3 * (minute/100)) + 1,                                                                 -- mana
+      (48 * ((minute/100) ^ 2) + 5 * (minute/100)) + 1,                                                                 -- damage
+      (minute / 6) + 1,                                                                                                 -- armor
+      (17 * (minute/100)) + 1,                                                                                          -- gold
       ((9 * minute ^ 2 + 17 * minute + 607)/607) * 2/3                                                                  -- xp
     }
   end
@@ -32,19 +32,19 @@ function CreepPower:GetBasePowerForMinute (minute)
   return values
 end
 
+-- NOT USED
 function CreepPower:GetBaseCavePowerForMinute (minute)
-  -- NOT USED
   if minute == 0 then
     return {   0,        1.0,      1.0,      1.0,      1.0,      1.0 * self.BootGoldFactor,      1.0 * self.numPlayersXPFactor}
   end
 
   return {
-    minute,                                   -- minute
-    ((0 * ((minute / 100) ^ 4) - 0 * ((minute/100) ^ 3) + 30 * ((minute/100) ^ 2) + 3 * (minute/100)) + 1) * 0.6,     -- hp
-    ((0 * ((minute / 100) ^ 4) - 0 * ((minute/100) ^ 3) + 30 * ((minute/100) ^ 2) + 3 * (minute/100)) + 1),           -- mana
-    ((0 * ((minute / 100) ^ 4) - 0 * ((minute/100) ^ 3) + 60 * ((minute/100) ^ 2) + 6 * (minute/100)) + 1) * 0.8,     -- damage
-    (0 * (minute / 26) ^ 2 + minute / 6) + 1,                                                                         -- armor
-    ((0 * minute ^ 2 + 2 * minute + 15)/(15)) * self.BootGoldFactor,                                                  -- gold
+    minute,                                                                                                           -- minute
+    ((30 * ((minute/100) ^ 2) + 3 * (minute/100)) + 1) * 0.6,                                                         -- hp
+    ((30 * ((minute/100) ^ 2) + 3 * (minute/100)) + 1),                                                               -- mana
+    ((60 * ((minute/100) ^ 2) + 6 * (minute/100)) + 1) * 0.8,                                                         -- damage
+    (minute / 6) + 1,                                                                                                 -- armor
+    ((2 * minute + 15)/15) * self.BootGoldFactor,                                                                     -- gold
     ((9 * minute ^ 2 + 17 * minute + 607) / 607) * self.numPlayersXPFactor                                            -- xp
   }
 end
@@ -65,6 +65,6 @@ function CreepPower:Init ()
     self.numPlayersStatsFactor = 1
   end
 
-  self.BootGoldFactor = _G.BOOT_GOLD_FACTOR
+  self.BootGoldFactor = _G.BOOT_GOLD_FACTOR or 1
   self.initialized = true
 end

--- a/game/scripts/vscripts/components/creeps/creep_types.lua
+++ b/game/scripts/vscripts/components/creeps/creep_types.lua
@@ -1,68 +1,68 @@
-
+-- These values are starting and minimum values for neutral creeps when 5vs5; values increase over time (check creep_power.lua)
 -- "creep name", Health, Mana, Damage, Armor, Gold Bounty, Exp Bounty
 CreepTypes = {
   -- 1 "easy camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_custom_big_wolf",          600,  150,  35,   1.5,   40,  40}, -- expected gold is 100 and XP is 90
-      {"npc_dota_neutral_custom_small_wolf",        400,    0,  15,   0.5,   30,  25},
-      {"npc_dota_neutral_custom_small_wolf",        400,    0,  15,   0.5,   30,  25}
+      {"npc_dota_neutral_custom_big_wolf",          480,  150,  35,   1.5,   20,  40}, -- expected gold is 50 and XP is 90
+      {"npc_dota_neutral_custom_small_wolf",        320,    0,  15,   0.5,   15,  25},
+      {"npc_dota_neutral_custom_small_wolf",        320,    0,  15,   0.5,   15,  25}
     },
     {
-      {"npc_dota_neutral_custom_kobold_foreman",    560,  150,  30,    1,    40,  35},
-      {"npc_dota_neutral_custom_kobold_soldier",    480,    0,  20,    1,    35,  30},
-      {"npc_dota_neutral_custom_kobold",            280,    0,  10,   0.5,   25,  25}
+      {"npc_dota_neutral_custom_kobold_foreman",    450,  150,  30,    1,    20,  35},
+      {"npc_dota_neutral_custom_kobold_soldier",    380,    0,  20,    1,    15,  30},
+      {"npc_dota_neutral_custom_kobold",            250,    0,  10,   0.5,   10,  25}
     },
   },
     -- 2 "medium camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_custom_harpy_storm",       560,  300,  40,   1.2,   45,  82}, -- expected gold is 80 and XP is 143
-      {"npc_dota_neutral_custom_harpy_scout",       480,    0,  40,   0.7,   40,  61}
+      {"npc_dota_neutral_custom_harpy_storm",       650,  300,  40,   1.3,   35,  82}, -- expected gold is 60 and XP is 143
+      {"npc_dota_neutral_custom_harpy_scout",       400,    0,  30,     1,   25,  61}
     },
     {
-      {"npc_dota_neutral_custom_mud_golem",         800,    0,  35,    1,    35,  57} -- multiply gold value by 2 and xp value by 2.5 because they split
+      {"npc_dota_neutral_custom_mud_golem",         650,    0,  35,    1,    30,  57} -- multiply gold value by 2 and xp value by 2.5 because they split
     },
     {
-      {"npc_dota_neutral_custom_blue_tomato",       800,  300,  40,   1.3,   45,  82},
-      {"npc_dota_neutral_custom_blue_potato",       480,    0,  35,   1.3,   40,  61}
+      {"npc_dota_neutral_custom_blue_tomato",       650,  300,  40,   1.3,   35,  82},
+      {"npc_dota_neutral_custom_blue_potato",       400,    0,  35,   1.3,   25,  61}
     }
   },
     -- 3 "hard camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_custom_ghost",             850,    0,  40,   1.5,   75,  60}, -- expected gold is 147 and XP 120
-      {"npc_dota_neutral_custom_ghost",             850,    0,  40,   1.5,   75,  60}
+      {"npc_dota_neutral_custom_ghost",             800,    0,  40,   1.5,   45,  60}, -- expected gold is 90 and XP 120
+      {"npc_dota_neutral_custom_ghost",             800,    0,  40,   1.5,   45,  60}
     },
     {
-      {"npc_dota_neutral_custom_centaur_khan",      900,  300,  50,   1.5,   76,  60},
-      {"npc_dota_neutral_custom_small_centaur",     500,    0,  30,    1,    37,  30},
-      {"npc_dota_neutral_custom_small_centaur",     500,    0,  30,    1,    37,  30}
+      {"npc_dota_neutral_custom_centaur_khan",      800,  300,  50,   1.5,   45,  60},
+      {"npc_dota_neutral_custom_small_centaur",     400,    0,  30,    1,    25,  30},
+      {"npc_dota_neutral_custom_small_centaur",     400,    0,  30,    1,    25,  30}
     },
     {
-      {"npc_dota_neutral_satyr_hellcaller",         900,  400,  50,   1.5,   76,  53},
-      {"npc_dota_neutral_satyr_soulstealer",        600,  600,  30,    1,    38,  40},
-      {"npc_dota_neutral_satyr_trickster",          350,  500,  10,    1,    28,  27}
+      {"npc_dota_neutral_satyr_hellcaller",         800,  400,  50,   1.5,   45,  53},
+      {"npc_dota_neutral_satyr_soulstealer",        500,  600,  30,    1,    25,  40},
+      {"npc_dota_neutral_satyr_trickster",          300,  500,  10,    1,    20,  27}
     }
   },
    -- 4 "ancient camp"
   {
     {                                               --HP  MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_granite_golem",           1400,    0,  50,    2,   100,  75}, -- expected gold is 200 and XP is 151
-      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    50,  38},
-      {"npc_dota_neutral_rock_golem",              1000,    0,  40,    1,    50,  38}
+      {"npc_dota_neutral_granite_golem",           1500,    0,  50,    2,   100,  75}, -- expected gold is 200 and XP is 151
+      {"npc_dota_neutral_rock_golem",              800,     0,  40,    1,    50,  38},
+      {"npc_dota_neutral_rock_golem",              800,     0,  40,    1,    50,  38}
     },
     {
-      {"npc_dota_neutral_prowler_shaman",          1700,  400,  90,    3,   200, 151}
+      {"npc_dota_neutral_prowler_shaman",          1500,  400,  90,    3,   200, 151}
     },
     {
-      {"npc_dota_neutral_black_dragon",            1700,  500,  90,    3,   200, 151}
+      {"npc_dota_neutral_black_dragon",            1500,  500,  90,    3,   200, 151}
     }
   },
    -- 5 "solo ancient corner camp"
   {
     {
-      {"npc_dota_neutral_custom_black_dragon",     1500,  300,  85,    3,   152, 156}
+      {"npc_dota_neutral_custom_black_dragon",     1500,  300,  80,    3,   100, 150}
     }
   }
 }

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -206,8 +206,8 @@ function CreepCamps:SetCreepPropertiesOnHandle(creepHandle, creepProperties)
   creepHandle:SetHealth(math.ceil(targetHealth))
 
   --MANA
-  creepHandle:SetMaxMana(math.ceil(creepProperties[MANA_ENUM]))
-  creepHandle:SetMana(math.ceil(creepProperties[MANA_ENUM]))
+  --creepHandle:SetMaxMana(math.ceil(creepProperties[MANA_ENUM]))
+  --creepHandle:SetMana(math.ceil(creepProperties[MANA_ENUM]))
 
   --DAMAGE
   creepHandle:SetBaseDamageMin(math.ceil(creepProperties[DAMAGE_ENUM]))


### PR DESCRIPTION
* Stats in creep_types.lua are now starting stats. It was intended to be like that anyway.
* Neutral Creeps spawned at 0:00 no longer get worse stats over time.
* Simplified HP, DMG and GOLD bounty formula for upgrading creeps over time (on every minute mark).
* Starting stats adjusted:
- Experience bounty of first spawned creeps when killed between 0 and minute 1 is now 40% less.
- Easy camps starting hp nerfed.
- Easy camps starting gold nerfed.
- Harpy Storm starting hp buffed. (to match other medium camp creeps)
- Harpy Storm starting armor slightly buffed. (to match other medium camp creeps)
- Other medium camps starting hp nerfed.
- Medium camps starting gold bounty slightly nerfed.
- Hard camps starting hp slightly nerfed.
- Hard camps starting gold nerfed.
- Ancient camps starting hp nerfed.
- Corner Dragon dmg, gold bounty, xp bounty slightly nerfed.

* Neutral creeps mana no longer scales over time. This will hopefully fix the 0 mana bug on neutral creeps.

TLDR: Creeps now only get stronger over time. All creeps (except easy camps) will give slightly more gold when killed but they will be harder to kill because their HP and damage is higher than before. 