### PR TITLE
Regen Crystal Rework

### DIFF
--- a/game/resource/English/ability/items/tooltip_regen_crystal.txt
+++ b/game/resource/English/ability/items/tooltip_regen_crystal.txt
@@ -1,5 +1,5 @@
 //=============================================================================
-// Postactive Reflex 3c
+// Regeneration Crystal
 //=============================================================================
 "DOTA_Tooltip_Ability_item_regen_crystal_1"                                             "Regeneration Crystal"
 "DOTA_Tooltip_Ability_item_recipe_regen_crystal_1"                                      "Regeneration Crystal Recipe"
@@ -24,3 +24,6 @@
 "DOTA_Tooltip_Ability_item_regen_crystal_3_bonus_health"                                "#{DOTA_Tooltip_Ability_item_regen_crystal_1_bonus_health}"
 "DOTA_Tooltip_Ability_item_regen_crystal_3_bonus_strength"                              "#{DOTA_Tooltip_Ability_item_regen_crystal_1_bonus_strength}"
 "DOTA_Tooltip_Ability_item_regen_crystal_3_max_mana_to_hp_regen"                        "#{DOTA_Tooltip_Ability_item_regen_crystal_1_max_mana_to_hp_regen}"
+
+"DOTA_Tooltip_modifier_item_regen_crystal_active"                                       "Regeneration Crystal Outlast"
+"DOTA_Tooltip_modifier_item_regen_crystal_active_Description"                           "Increased hp regen and hp regen amplification."

--- a/game/resource/English/ability/items/tooltip_regen_crystal.txt
+++ b/game/resource/English/ability/items/tooltip_regen_crystal.txt
@@ -3,11 +3,11 @@
 //=============================================================================
 "DOTA_Tooltip_Ability_item_regen_crystal_1"                                             "Regeneration Crystal"
 "DOTA_Tooltip_Ability_item_recipe_regen_crystal_1"                                      "Regeneration Crystal Recipe"
-"DOTA_Tooltip_Ability_item_regen_crystal_1_Description"                                 "<h1>Active: Outlast</h1> Gives %active_health_regen% additional health regeneration for %duration% seconds."
+"DOTA_Tooltip_Ability_item_regen_crystal_1_Description"                                 "<h1>Active: Outlast</h1> Gives %active_hp_regen% additional health regeneration and increases all health regeneration by %active_hp_regen_amp%%% for %duration% seconds."
 "DOTA_Tooltip_Ability_item_regen_crystal_1_Lore"                                        "A magical crystal of life."
 "DOTA_Tooltip_Ability_item_regen_crystal_1_bonus_health"                                "+$health"
 "DOTA_Tooltip_Ability_item_regen_crystal_1_bonus_strength"                              "+$str"
-"DOTA_Tooltip_Ability_item_regen_crystal_1_bonus_health_regen"                          "+$hp_regen"
+"DOTA_Tooltip_Ability_item_regen_crystal_1_max_mana_to_hp_regen"                        "%+Max Mana as HP Regen"
 
 "DOTA_Tooltip_Ability_item_regen_crystal_2"                                             "#{DOTA_Tooltip_Ability_item_regen_crystal_1}"
 "DOTA_Tooltip_Ability_item_recipe_regen_crystal_2"                                      "#{DOTA_Tooltip_Ability_item_recipe_regen_crystal_1}"
@@ -15,7 +15,7 @@
 "DOTA_Tooltip_Ability_item_regen_crystal_2_Lore"                                        "#{DOTA_Tooltip_Ability_item_regen_crystal_1_Lore}"
 "DOTA_Tooltip_Ability_item_regen_crystal_2_bonus_health"                                "#{DOTA_Tooltip_Ability_item_regen_crystal_1_bonus_health}"
 "DOTA_Tooltip_Ability_item_regen_crystal_2_bonus_strength"                              "#{DOTA_Tooltip_Ability_item_regen_crystal_1_bonus_strength}"
-"DOTA_Tooltip_Ability_item_regen_crystal_2_bonus_health_regen"                          "#{DOTA_Tooltip_Ability_item_regen_crystal_1_bonus_health_regen}"
+"DOTA_Tooltip_Ability_item_regen_crystal_2_max_mana_to_hp_regen"                        "#{DOTA_Tooltip_Ability_item_regen_crystal_1_max_mana_to_hp_regen}"
 
 "DOTA_Tooltip_Ability_item_regen_crystal_3"                                             "#{DOTA_Tooltip_Ability_item_regen_crystal_1}"
 "DOTA_Tooltip_Ability_item_recipe_regen_crystal_3"                                      "#{DOTA_Tooltip_Ability_item_recipe_regen_crystal_1}"
@@ -23,4 +23,4 @@
 "DOTA_Tooltip_Ability_item_regen_crystal_3_Lore"                                        "#{DOTA_Tooltip_Ability_item_regen_crystal_1_Lore}"
 "DOTA_Tooltip_Ability_item_regen_crystal_3_bonus_health"                                "#{DOTA_Tooltip_Ability_item_regen_crystal_1_bonus_health}"
 "DOTA_Tooltip_Ability_item_regen_crystal_3_bonus_strength"                              "#{DOTA_Tooltip_Ability_item_regen_crystal_1_bonus_strength}"
-"DOTA_Tooltip_Ability_item_regen_crystal_3_bonus_health_regen"                          "#{DOTA_Tooltip_Ability_item_regen_crystal_1_bonus_health_regen}"
+"DOTA_Tooltip_Ability_item_regen_crystal_3_max_mana_to_hp_regen"                        "#{DOTA_Tooltip_Ability_item_regen_crystal_1_max_mana_to_hp_regen}"

--- a/game/resource/English/modifier/items/reflex/modifier_item_postactive_regen.txt
+++ b/game/resource/English/modifier/items/reflex/modifier_item_postactive_regen.txt
@@ -1,5 +1,0 @@
-//=============================================================================
-// Postactive 2 B
-//=============================================================================
-"DOTA_Tooltip_modifier_item_postactive_regen"               "Regeneration"
-"DOTA_Tooltip_modifier_item_postactive_regen_Description"   "Unit is healing for %MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT%%% per second."

--- a/game/scripts/npc/items/custom/item_regen_crystal_1.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_1.txt
@@ -1,7 +1,7 @@
 "DOTAAbilities"
 {
   //=================================================================================================================
-  // Recipe: Postactive Reflex 3c
+  // Recipe: Regeneration Crystal 1
   //=================================================================================================================
   "item_recipe_regen_crystal_1"
   {
@@ -29,7 +29,7 @@
   }
 
   //=================================================================================================================
-  // Postactive Reflex 3c
+  // Regeneration Crystal 1
   //=================================================================================================================
   "item_regen_crystal_1"
   {
@@ -51,12 +51,12 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityManaCost"                                     "200"
+    "AbilityManaCost"                                     "75"
     "ItemCost"                                            "8800"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "regen crystal"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special
@@ -76,7 +76,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "max_mana_to_hp_regen"                            "2 2.5 3"
+        "max_mana_to_hp_regen"                            "3"
       }
       "04"
       {

--- a/game/scripts/npc/items/custom/item_regen_crystal_1.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_1.txt
@@ -75,18 +75,18 @@
       }
       "03"
       {
-        "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "300 400 500"
+        "var_type"                                        "FIELD_FLOAT"
+        "max_mana_to_hp_regen"                            "2 2.5 3"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen_amp"                             "75"
+        "active_hp_regen"                                 "500"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "max_mana_to_hp_regen"                            "3"
+        "active_hp_regen_amp"                             "100"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_regen_crystal_1.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_1.txt
@@ -66,24 +66,29 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "1200 2300 3400"
+        "bonus_health"                                    "1600 2500 3400"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "60 70 80"
+        "bonus_strength"                                  "40 60 80"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "30 40 50"
+        "bonus_health_regen"                              "300 400 500"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_health_regen"                             "500 650 800"
+        "active_hp_regen_amp"                             "75"
       }
       "05"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "max_mana_to_hp_regen"                            "3"
+      }
+      "06"
       {
         "var_type"                                        "FIELD_INTEGER"
         "duration"                                        "5"

--- a/game/scripts/npc/items/custom/item_regen_crystal_2.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_2.txt
@@ -67,24 +67,29 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "1200 2300 3400"
+        "bonus_health"                                    "1600 2500 3400"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "60 70 80"
+        "bonus_strength"                                  "40 60 80"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "30 40 50"
+        "bonus_health_regen"                              "300 400 500"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_health_regen"                             "500 650 800"
+        "active_hp_regen_amp"                             "75"
       }
       "05"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "max_mana_to_hp_regen"                            "3"
+      }
+      "06"
       {
         "var_type"                                        "FIELD_INTEGER"
         "duration"                                        "5"

--- a/game/scripts/npc/items/custom/item_regen_crystal_2.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_2.txt
@@ -1,7 +1,7 @@
 "DOTAAbilities"
 {
   //=================================================================================================================
-  // Recipe: Postactive Reflex 4c
+  // Recipe: Regeneration Crystal 2
   //=================================================================================================================
   "item_recipe_regen_crystal_2"
   {
@@ -30,7 +30,7 @@
   }
 
   //=================================================================================================================
-  // Postactive Reflex 4c
+  // Regeneration Crystal 2
   //=================================================================================================================
   "item_regen_crystal_2"
   {
@@ -52,12 +52,12 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityManaCost"                                     "200"
+    "AbilityManaCost"                                     "75"
     "ItemCost"                                            "16800"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
-    "ItemAliases"                                         "regen crystal 4"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemAliases"                                         "regen crystal 2"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special
@@ -77,7 +77,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "max_mana_to_hp_regen"                            "2 2.5 3"
+        "max_mana_to_hp_regen"                            "3"
       }
       "04"
       {

--- a/game/scripts/npc/items/custom/item_regen_crystal_2.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_2.txt
@@ -76,18 +76,18 @@
       }
       "03"
       {
-        "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "300 400 500"
+        "var_type"                                        "FIELD_FLOAT"
+        "max_mana_to_hp_regen"                            "2 2.5 3"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen_amp"                             "75"
+        "active_hp_regen"                                 "500"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "max_mana_to_hp_regen"                            "3"
+        "active_hp_regen_amp"                             "100"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_regen_crystal_3.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_3.txt
@@ -77,18 +77,18 @@
       }
       "03"
       {
-        "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "300 400 500"
+        "var_type"                                        "FIELD_FLOAT"
+        "max_mana_to_hp_regen"                            "2 2.5 3"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen_amp"                             "75"
+        "active_hp_regen"                                 "500"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "max_mana_to_hp_regen"                            "3"
+        "active_hp_regen_amp"                             "100"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_regen_crystal_3.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_3.txt
@@ -68,24 +68,29 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "1200 2300 3400"
+        "bonus_health"                                    "1600 2500 3400"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "60 70 80"
+        "bonus_strength"                                  "40 60 80"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "30 40 50"
+        "bonus_health_regen"                              "300 400 500"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_health_regen"                             "500 650 800"
+        "active_hp_regen_amp"                             "75"
       }
       "05"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "max_mana_to_hp_regen"                            "3"
+      }
+      "06"
       {
         "var_type"                                        "FIELD_INTEGER"
         "duration"                                        "5"

--- a/game/scripts/npc/items/custom/item_regen_crystal_3.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_3.txt
@@ -1,7 +1,7 @@
 "DOTAAbilities"
 {
   //=================================================================================================================
-  // Recipe: Postactive Reflex 5c
+  // Recipe: Regeneration Crystal 3
   //=================================================================================================================
   "item_recipe_regen_crystal_3"
   {
@@ -31,7 +31,7 @@
   }
 
   //=================================================================================================================
-  // Postactive Reflex 5c
+  // Regeneration Crystal 3
   //=================================================================================================================
   "item_regen_crystal_3"
   {
@@ -53,12 +53,12 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityManaCost"                                     "200"
+    "AbilityManaCost"                                     "75"
     "ItemCost"                                            "36800"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
-    "ItemAliases"                                         "regen crystal"
-    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_ALWAYS"
+    "ItemAliases"                                         "regen crystal 3"
+    "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
 
     // Special
@@ -78,7 +78,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "max_mana_to_hp_regen"                            "2 2.5 3"
+        "max_mana_to_hp_regen"                            "3"
       }
       "04"
       {

--- a/game/scripts/vscripts/items/reflex/postactive_regen.lua
+++ b/game/scripts/vscripts/items/reflex/postactive_regen.lua
@@ -1,4 +1,4 @@
-LinkLuaModifier( "modifier_item_postactive_regen", "items/reflex/postactive_regen.lua", LUA_MODIFIER_MOTION_NONE )
+LinkLuaModifier("modifier_item_postactive_regen", "items/reflex/postactive_regen.lua", LUA_MODIFIER_MOTION_NONE)
 LinkLuaModifier("modifier_generic_bonus", "modifiers/modifier_generic_bonus.lua", LUA_MODIFIER_MOTION_NONE)
 
 item_regen_crystal_1 = class(ItemBaseClass)
@@ -11,27 +11,87 @@ end
 
 function item_regen_crystal_1:OnSpellStart()
   local caster = self:GetCaster()
-  caster:AddNewModifier(caster, self, 'modifier_item_postactive_regen', {
-    duration = self:GetSpecialValueFor( "duration" )
-  })
+  caster:AddNewModifier(caster, self, "modifier_item_postactive_regen", {duration = self:GetSpecialValueFor("duration")})
 end
 
+function item_regen_crystal_1:ProcsMagicStick()
+  return false
+end
+
+---------------------------------------------------------------------------------------------------
 modifier_item_postactive_regen = class(ModifierBaseClass)
 
+function modifier_item_postactive_regen:IsHidden()
+  return false
+end
 
-function modifier_item_postactive_regen:OnCreated( kv )
+function modifier_item_postactive_regen:IsDebuff()
+  return false
+end
+
+function modifier_item_postactive_regen:IsPurgable()
+  return false
+end
+
+function modifier_item_postactive_regen:OnCreated()
+  local parent = self:GetParent()
   if IsServer() then
     if self.nPreviewFX == nil then
-      self.nPreviewFX = ParticleManager:CreateParticle( "particles/items/regen_crystal/regen_ambient.vpcf", PATTACH_ABSORIGIN_FOLLOW, self:GetParent() )
-      ParticleManager:SetParticleControlEnt( self.nPreviewFX, 0, self:GetParent(), PATTACH_ABSORIGIN_FOLLOW, nil, self:GetParent():GetOrigin(), true )
+      self.nPreviewFX = ParticleManager:CreateParticle("particles/items/regen_crystal/regen_ambient.vpcf", PATTACH_ABSORIGIN_FOLLOW, parent)
+      ParticleManager:SetParticleControlEnt(self.nPreviewFX, 0, parent, PATTACH_ABSORIGIN_FOLLOW, nil, parent:GetOrigin(), true)
     end
+  end
+  local ability = self:GetAbility()
+  local max_mana_to_hp_regen = 3
+  if ability and not ability:IsNull() then
+    self.hp_regen_amp = ability:GetSpecialValueFor("active_hp_regen_amp")
+    max_mana_to_hp_regen = ability:GetSpecialValueFor("max_mana_to_hp_regen")
+  end
+  local max_mana = parent:GetMaxMana()
+  self.bonus_hp_regen = max_mana*max_mana_to_hp_regen/100
+  if IsServer() and parent:IsHero() then
+    parent:CalculateStatBonus()
+  end
+  self:StartIntervalThink(0.5)
+end
+
+function modifier_item_postactive_regen:OnRefresh()
+  local parent = self:GetParent()
+  local ability = self:GetAbility()
+  local max_mana_to_hp_regen = 3
+  if ability and not ability:IsNull() then
+    self.hp_regen_amp = ability:GetSpecialValueFor("active_hp_regen_amp")
+    max_mana_to_hp_regen = ability:GetSpecialValueFor("max_mana_to_hp_regen")
+  end
+  local max_mana = parent:GetMaxMana()
+  self.bonus_hp_regen = max_mana*max_mana_to_hp_regen/100
+  if IsServer() and parent:IsHero() then
+    parent:CalculateStatBonus()
   end
 end
 
-function modifier_item_postactive_regen:OnDestroy(  )
+function modifier_item_postactive_regen:OnIntervalThink()
+  local parent = self:GetParent()
+  if not self.bonus_hp_regen then
+    self:ForceRefresh()
+    return
+  end
+
+  local ability = self:GetAbility()
+  local max_mana_to_hp_regen = 3
+  if ability and not ability:IsNull() then
+    max_mana_to_hp_regen = ability:GetSpecialValueFor("max_mana_to_hp_regen")
+  end
+  local max_mana = parent:GetMaxMana()
+  if self.bonus_hp_regen ~= max_mana*max_mana_to_hp_regen/100 then
+    self:ForceRefresh()
+  end
+end
+
+function modifier_item_postactive_regen:OnDestroy()
   if IsServer() then
-    if self.nPreviewFX ~= nil then
-      ParticleManager:DestroyParticle( self.nPreviewFX, false )
+    if self.nPreviewFX then
+      ParticleManager:DestroyParticle(self.nPreviewFX, false)
       ParticleManager:ReleaseParticleIndex(self.nPreviewFX)
       self.nPreviewFX = nil
     end
@@ -40,10 +100,15 @@ end
 
 function modifier_item_postactive_regen:DeclareFunctions()
   return {
-    MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT
+    MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT,
+    MODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE,
   }
 end
 
 function modifier_item_postactive_regen:GetModifierConstantHealthRegen()
-  return self:GetAbility():GetSpecialValueFor( "active_health_regen" )
+  return self.bonus_hp_regen
+end
+
+function modifier_item_postactive_regen:GetModifierHPRegenAmplify_Percentage()
+  return self.hp_regen_amp or self:GetAbility():GetSpecialValueFor("active_hp_regen_amp")
 end

--- a/game/scripts/vscripts/items/reflex/postactive_regen.lua
+++ b/game/scripts/vscripts/items/reflex/postactive_regen.lua
@@ -175,7 +175,7 @@ function modifier_item_regen_crystal_active:OnCreated()
   end
   local ability = self:GetAbility()
   if ability and not ability:IsNull() then
-    self.hp_regen = = ability:GetSpecialValueFor("active_hp_regen")
+    self.hp_regen = ability:GetSpecialValueFor("active_hp_regen")
     self.hp_regen_amp = ability:GetSpecialValueFor("active_hp_regen_amp")
   end
 end
@@ -183,7 +183,7 @@ end
 function modifier_item_regen_crystal_active:OnRefresh()
   local ability = self:GetAbility()
   if ability and not ability:IsNull() then
-    self.hp_regen = = ability:GetSpecialValueFor("active_hp_regen")
+    self.hp_regen = ability:GetSpecialValueFor("active_hp_regen")
     self.hp_regen_amp = ability:GetSpecialValueFor("active_hp_regen_amp")
   end
 end

--- a/game/scripts/vscripts/items/reflex/postactive_regen.lua
+++ b/game/scripts/vscripts/items/reflex/postactive_regen.lua
@@ -97,7 +97,7 @@ end
 function modifier_item_regen_crystal_non_stacking_stats:OnCreated()
   local parent = self:GetParent()
   local ability = self:GetAbility()
-  local max_mana_to_hp_regen = 1
+  local max_mana_to_hp_regen = 3
   if ability and not ability:IsNull() then
     max_mana_to_hp_regen = ability:GetSpecialValueFor("max_mana_to_hp_regen")
   end
@@ -112,7 +112,7 @@ end
 function modifier_item_regen_crystal_non_stacking_stats:OnRefresh()
   local parent = self:GetParent()
   local ability = self:GetAbility()
-  local max_mana_to_hp_regen = 1
+  local max_mana_to_hp_regen = 3
   if ability and not ability:IsNull() then
     max_mana_to_hp_regen = ability:GetSpecialValueFor("max_mana_to_hp_regen")
   end
@@ -131,7 +131,7 @@ function modifier_item_regen_crystal_non_stacking_stats:OnIntervalThink()
   end
 
   local ability = self:GetAbility()
-  local max_mana_to_hp_regen = 1
+  local max_mana_to_hp_regen = 3
   if ability and not ability:IsNull() then
     max_mana_to_hp_regen = ability:GetSpecialValueFor("max_mana_to_hp_regen")
   end

--- a/game/scripts/vscripts/items/reflex/postactive_regen.lua
+++ b/game/scripts/vscripts/items/reflex/postactive_regen.lua
@@ -1,50 +1,104 @@
-LinkLuaModifier("modifier_item_postactive_regen", "items/reflex/postactive_regen.lua", LUA_MODIFIER_MOTION_NONE)
-LinkLuaModifier("modifier_generic_bonus", "modifiers/modifier_generic_bonus.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_intrinsic_multiplexer", "modifiers/modifier_intrinsic_multiplexer.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_regen_crystal_stacking_stats", "items/reflex/postactive_regen.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_regen_crystal_non_stacking_stats", "items/reflex/postactive_regen.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_regen_crystal_active", "items/reflex/postactive_regen.lua", LUA_MODIFIER_MOTION_NONE)
 
 item_regen_crystal_1 = class(ItemBaseClass)
 item_regen_crystal_2 = item_regen_crystal_1
 item_regen_crystal_3 = item_regen_crystal_1
 
 function item_regen_crystal_1:GetIntrinsicModifierName()
-  return "modifier_generic_bonus"
+  return "modifier_intrinsic_multiplexer"
+end
+
+function item_regen_crystal_1:GetIntrinsicModifierNames()
+  return {
+    "modifier_item_regen_crystal_stacking_stats",
+    "modifier_item_regen_crystal_non_stacking_stats"
+  }
 end
 
 function item_regen_crystal_1:OnSpellStart()
   local caster = self:GetCaster()
-  caster:AddNewModifier(caster, self, "modifier_item_postactive_regen", {duration = self:GetSpecialValueFor("duration")})
+  caster:AddNewModifier(caster, self, "modifier_item_regen_crystal_active", {duration = self:GetSpecialValueFor("duration")})
 end
 
 function item_regen_crystal_1:ProcsMagicStick()
   return false
 end
 
----------------------------------------------------------------------------------------------------
-modifier_item_postactive_regen = class(ModifierBaseClass)
+--------------------------------------------------------------------------
+-- Parts of Regen Crystal that should stack with other items
 
-function modifier_item_postactive_regen:IsHidden()
+modifier_item_regen_crystal_stacking_stats = class(ModifierBaseClass)
+
+function modifier_item_regen_crystal_stacking_stats:GetAttributes()
+  return MODIFIER_ATTRIBUTE_MULTIPLE
+end
+
+function modifier_item_regen_crystal_stacking_stats:IsHidden()
+  return true
+end
+function modifier_item_regen_crystal_stacking_stats:IsDebuff()
+  return false
+end
+function modifier_item_regen_crystal_stacking_stats:IsPurgable()
   return false
 end
 
-function modifier_item_postactive_regen:IsDebuff()
-  return false
-end
-
-function modifier_item_postactive_regen:IsPurgable()
-  return false
-end
-
-function modifier_item_postactive_regen:OnCreated()
-  local parent = self:GetParent()
-  if IsServer() then
-    if self.nPreviewFX == nil then
-      self.nPreviewFX = ParticleManager:CreateParticle("particles/items/regen_crystal/regen_ambient.vpcf", PATTACH_ABSORIGIN_FOLLOW, parent)
-      ParticleManager:SetParticleControlEnt(self.nPreviewFX, 0, parent, PATTACH_ABSORIGIN_FOLLOW, nil, parent:GetOrigin(), true)
-    end
-  end
+function modifier_item_regen_crystal_stacking_stats:OnCreated()
   local ability = self:GetAbility()
-  local max_mana_to_hp_regen = 3
   if ability and not ability:IsNull() then
-    self.hp_regen_amp = ability:GetSpecialValueFor("active_hp_regen_amp")
+    self.str = ability:GetSpecialValueFor("bonus_strength")
+    self.hp = ability:GetSpecialValueFor("bonus_health")
+  end
+end
+
+function modifier_item_regen_crystal_stacking_stats:OnRefresh()
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.str = ability:GetSpecialValueFor("bonus_strength")
+    self.hp = ability:GetSpecialValueFor("bonus_health")
+  end
+end
+
+function modifier_item_regen_crystal_stacking_stats:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_STATS_STRENGTH_BONUS,
+    MODIFIER_PROPERTY_HEALTH_BONUS,
+  }
+end
+
+function modifier_item_regen_crystal_stacking_stats:GetModifierBonusStats_Strength()
+  return self.str or self:GetAbility():GetSpecialValueFor("bonus_strength")
+end
+
+function modifier_item_regen_crystal_stacking_stats:GetModifierHealthBonus()
+  return self.hp or self:GetAbility():GetSpecialValueFor("bonus_health")
+end
+
+---------------------------------------------------------------------------------------------------
+-- Parts of Regen Crystal that should NOT stack with other Regen Crystals
+
+modifier_item_regen_crystal_non_stacking_stats = class(ModifierBaseClass)
+
+function modifier_item_regen_crystal_non_stacking_stats:IsHidden()
+  return true
+end
+
+function modifier_item_regen_crystal_non_stacking_stats:IsDebuff()
+  return false
+end
+
+function modifier_item_regen_crystal_non_stacking_stats:IsPurgable()
+  return false
+end
+
+function modifier_item_regen_crystal_non_stacking_stats:OnCreated()
+  local parent = self:GetParent()
+  local ability = self:GetAbility()
+  local max_mana_to_hp_regen = 1
+  if ability and not ability:IsNull() then
     max_mana_to_hp_regen = ability:GetSpecialValueFor("max_mana_to_hp_regen")
   end
   local max_mana = parent:GetMaxMana()
@@ -55,12 +109,11 @@ function modifier_item_postactive_regen:OnCreated()
   self:StartIntervalThink(0.5)
 end
 
-function modifier_item_postactive_regen:OnRefresh()
+function modifier_item_regen_crystal_non_stacking_stats:OnRefresh()
   local parent = self:GetParent()
   local ability = self:GetAbility()
-  local max_mana_to_hp_regen = 3
+  local max_mana_to_hp_regen = 1
   if ability and not ability:IsNull() then
-    self.hp_regen_amp = ability:GetSpecialValueFor("active_hp_regen_amp")
     max_mana_to_hp_regen = ability:GetSpecialValueFor("max_mana_to_hp_regen")
   end
   local max_mana = parent:GetMaxMana()
@@ -70,7 +123,7 @@ function modifier_item_postactive_regen:OnRefresh()
   end
 end
 
-function modifier_item_postactive_regen:OnIntervalThink()
+function modifier_item_regen_crystal_non_stacking_stats:OnIntervalThink()
   local parent = self:GetParent()
   if not self.bonus_hp_regen then
     self:ForceRefresh()
@@ -78,7 +131,7 @@ function modifier_item_postactive_regen:OnIntervalThink()
   end
 
   local ability = self:GetAbility()
-  local max_mana_to_hp_regen = 3
+  local max_mana_to_hp_regen = 1
   if ability and not ability:IsNull() then
     max_mana_to_hp_regen = ability:GetSpecialValueFor("max_mana_to_hp_regen")
   end
@@ -88,7 +141,54 @@ function modifier_item_postactive_regen:OnIntervalThink()
   end
 end
 
-function modifier_item_postactive_regen:OnDestroy()
+function modifier_item_regen_crystal_non_stacking_stats:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT,
+  }
+end
+
+function modifier_item_regen_crystal_non_stacking_stats:GetModifierConstantHealthRegen()
+  return self.bonus_hp_regen
+end
+---------------------------------------------------------------------------------------------------
+modifier_item_regen_crystal_active = class(ModifierBaseClass)
+
+function modifier_item_regen_crystal_active:IsHidden()
+  return false
+end
+
+function modifier_item_regen_crystal_active:IsDebuff()
+  return false
+end
+
+function modifier_item_regen_crystal_active:IsPurgable()
+  return false
+end
+
+function modifier_item_regen_crystal_active:OnCreated()
+  local parent = self:GetParent()
+  if IsServer() then
+    if self.nPreviewFX == nil then
+      self.nPreviewFX = ParticleManager:CreateParticle("particles/items/regen_crystal/regen_ambient.vpcf", PATTACH_ABSORIGIN_FOLLOW, parent)
+      ParticleManager:SetParticleControlEnt(self.nPreviewFX, 0, parent, PATTACH_ABSORIGIN_FOLLOW, nil, parent:GetOrigin(), true)
+    end
+  end
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.hp_regen = = ability:GetSpecialValueFor("active_hp_regen")
+    self.hp_regen_amp = ability:GetSpecialValueFor("active_hp_regen_amp")
+  end
+end
+
+function modifier_item_regen_crystal_active:OnRefresh()
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.hp_regen = = ability:GetSpecialValueFor("active_hp_regen")
+    self.hp_regen_amp = ability:GetSpecialValueFor("active_hp_regen_amp")
+  end
+end
+
+function modifier_item_regen_crystal_active:OnDestroy()
   if IsServer() then
     if self.nPreviewFX then
       ParticleManager:DestroyParticle(self.nPreviewFX, false)
@@ -98,17 +198,17 @@ function modifier_item_postactive_regen:OnDestroy()
   end
 end
 
-function modifier_item_postactive_regen:DeclareFunctions()
+function modifier_item_regen_crystal_active:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT,
     MODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE,
   }
 end
 
-function modifier_item_postactive_regen:GetModifierConstantHealthRegen()
-  return self.bonus_hp_regen
+function modifier_item_regen_crystal_active:GetModifierConstantHealthRegen()
+  return self.hp_regen or self:GetAbility():GetSpecialValueFor("active_hp_regen")
 end
 
-function modifier_item_postactive_regen:GetModifierHPRegenAmplify_Percentage()
+function modifier_item_regen_crystal_active:GetModifierHPRegenAmplify_Percentage()
   return self.hp_regen_amp or self:GetAbility():GetSpecialValueFor("active_hp_regen_amp")
 end


### PR DESCRIPTION
* Bonus HP increased from 1200/2300/3400 to 1600/2500/3400.
* Bonus STR reduced from 60/70/80 to 40/60/80. (Total HP same as Hearts)
* Bonus HP regen changed from +30/40/50 flat hp regen to **3% Max Mana as HP regen**. Doesn't stack with other Regen Crystals.
* Regen Crystal Outlast buff now provides **500 hp regen and 100% HP regen amplification** at all levels.
* Regen Crystal Outlast buff is **no longer dispellable**.
* Regen Crystal mana cost reduced from 200 to 75.
* Regen Crystal cannot be disassembled anymore.