### PR TITLE
Lucience update

### DIFF
--- a/game/scripts/npc/items/custom/item_lucience.txt
+++ b/game/scripts/npc/items/custom/item_lucience.txt
@@ -84,7 +84,7 @@
         "var_type"                                        "FIELD_INTEGER"
         "aura_radius"                                     "1200"
       }
-      "05"
+      "05" // unused KV
       {
         "var_type"                                        "FIELD_INTEGER"
         "heals_per_sec"                                   "3"

--- a/game/scripts/npc/items/custom/item_lucience_2.txt
+++ b/game/scripts/npc/items/custom/item_lucience_2.txt
@@ -86,7 +86,7 @@
         "var_type"                                        "FIELD_INTEGER"
         "aura_radius"                                     "1200"
       }
-      "05"
+      "05" // unused KV
       {
         "var_type"                                        "FIELD_INTEGER"
         "heals_per_sec"                                   "3"

--- a/game/scripts/npc/items/custom/item_lucience_3.txt
+++ b/game/scripts/npc/items/custom/item_lucience_3.txt
@@ -85,7 +85,7 @@
         "var_type"                                        "FIELD_INTEGER"
         "aura_radius"                                     "1200"
       }
-      "05"
+      "05" // unused KV
       {
         "var_type"                                        "FIELD_INTEGER"
         "heals_per_sec"                                   "3"

--- a/game/scripts/vscripts/items/lucience.lua
+++ b/game/scripts/vscripts/items/lucience.lua
@@ -86,10 +86,6 @@ function modifier_item_lucience_aura_handler:IsPurgable()
   return false
 end
 
-function modifier_item_lucience_aura_handler:GetAttributes()
-  return MODIFIER_ATTRIBUTE_MULTIPLE
-end
-
 function modifier_item_lucience_aura_handler:GetLuciences()
   local caster = self:GetCaster()
 
@@ -113,8 +109,10 @@ end
 
 function modifier_item_lucience_aura_handler:OnCreated()
   local ability = self:GetAbility()
-  ability.auraHandler = self
-  self.bonusDamage = ability:GetSpecialValueFor("bonus_damage")
+  if ability and not ability:IsNull() then
+    ability.auraHandler = self
+    self.stats = ability:GetSpecialValueFor("bonus_all_stats")
+  end
 
   if IsServer() then
     local parent = self:GetParent()
@@ -132,7 +130,7 @@ function modifier_item_lucience_aura_handler:OnCreated()
       return
     end
 
-    -- Delay adding the aura modifiers by a frame so that illusions won't always spawn with the regen aura
+    -- Delay adding the aura modifiers by a frame
     Timers:CreateTimer(function()
       item_lucience.RemoveLucienceAuras(parent)
       if ability:GetToggleState() then
@@ -149,7 +147,6 @@ modifier_item_lucience_aura_handler.OnRefresh = modifier_item_lucience_aura_hand
 function modifier_item_lucience_aura_handler:OnDestroy()
   if IsServer() then
     local parent = self:GetParent()
-
     local ability = self:GetAbility()
 
     -- If the owner has a higher level Lucience then don't do anything
@@ -170,8 +167,9 @@ function modifier_item_lucience_aura_handler:OnDestroy()
     end
   end
 end
+
 function modifier_item_lucience_aura_handler:GetAttributes()
-   return MODIFIER_ATTRIBUTE_MULTIPLE
+  return MODIFIER_ATTRIBUTE_MULTIPLE
 end
 
 function modifier_item_lucience_aura_handler:DeclareFunctions()
@@ -183,15 +181,15 @@ function modifier_item_lucience_aura_handler:DeclareFunctions()
 end
 
 function modifier_item_lucience_aura_handler:GetModifierBonusStats_Agility()
-  return self:GetAbility():GetSpecialValueFor("bonus_all_stats")
+  return self:GetAbility():GetSpecialValueFor("bonus_all_stats") or self.stats
 end
 
 function modifier_item_lucience_aura_handler:GetModifierBonusStats_Intellect()
-  return self:GetAbility():GetSpecialValueFor("bonus_all_stats")
+  return self:GetAbility():GetSpecialValueFor("bonus_all_stats") or self.stats
 end
 
 function modifier_item_lucience_aura_handler:GetModifierBonusStats_Strength()
-  return self:GetAbility():GetSpecialValueFor("bonus_all_stats")
+  return self:GetAbility():GetSpecialValueFor("bonus_all_stats") or self.stats
 end
 
 ------------------------------------------------------------------------
@@ -235,7 +233,7 @@ function modifier_item_lucience_regen_aura:GetAuraSearchTeam()
 end
 
 function modifier_item_lucience_regen_aura:GetAuraSearchType()
-  return DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC
+  return bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC)
 end
 
 function modifier_item_lucience_regen_aura:GetModifierAura()
@@ -246,11 +244,11 @@ end
 
 modifier_item_lucience_movespeed_aura = class(modifier_item_lucience_regen_aura)
 
--- this is effectively repeated, but it's for the tooltip parser
-
+-- IsHidden is effectively repeated, but it's for the tooltip parser
 function modifier_item_lucience_movespeed_aura:IsHidden()
   return true
 end
+
 function modifier_item_lucience_movespeed_aura:OnCreated()
   if IsServer() then
     local parent = self:GetParent()
@@ -271,21 +269,58 @@ end
 
 modifier_item_lucience_regen_effect = class(ModifierBaseClass)
 
-function modifier_item_lucience_regen_effect:OnCreated()
-  if IsServer() then
-    self.regenBonus = self:GetAbility():GetSpecialValueFor("regen_bonus")
-    self.healInterval = 1 / self:GetAbility():GetSpecialValueFor("heals_per_sec")
-
-    self:StartIntervalThink(self.healInterval)
-  end
+function modifier_item_lucience_regen_effect:IsHidden()
+  return false
 end
 
-modifier_item_lucience_regen_effect.OnRefresh = modifier_item_lucience_regen_effect.OnCreated
+function modifier_item_lucience_regen_effect:IsDebuff()
+  return false
+end
 
-function modifier_item_lucience_regen_effect:OnIntervalThink()
-  local parent = self:GetParent()
+function modifier_item_lucience_regen_effect:OnCreated()
+  local ability = self:GetAbility()
+  local hp_regen = 70
+  --local regen_interval = 1/3
+  if ability and not ability:IsNull() then
+    hp_regen = ability:GetSpecialValueFor("regen_bonus")
+    --regen_interval = 1 / ability:GetSpecialValueFor("heals_per_sec")
+  end
 
-  parent:Heal(self.regenBonus * self.healInterval, self:GetParent())
+  self.regen = hp_regen
+  --self.healInterval = regen_interval
+  --if IsServer() then
+    --self:StartIntervalThink(self.healInterval)
+  --end
+end
+
+function modifier_item_lucience_regen_effect:OnRefresh()
+  local ability = self:GetAbility()
+  local hp_regen = 70
+  --local regen_interval = 1/3
+  if ability and not ability:IsNull() then
+    hp_regen = ability:GetSpecialValueFor("regen_bonus")
+    --regen_interval = 1 / ability:GetSpecialValueFor("heals_per_sec")
+  end
+
+  self.regen = hp_regen
+  --self.healInterval = regen_interval
+end
+
+-- function modifier_item_lucience_regen_effect:OnIntervalThink()
+  -- local parent = self:GetParent()
+  -- local ability = self:GetAbility()
+
+  -- parent:Heal(self.regen * self.healInterval, ability)
+-- end
+
+function modifier_item_lucience_regen_effect:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT
+  }
+end
+
+function modifier_item_lucience_regen_effect:GetModifierConstantHealthRegen()
+  return self.regen
 end
 
 function modifier_item_lucience_regen_effect:GetEffectName()
@@ -304,12 +339,22 @@ end
 
 modifier_item_lucience_movespeed_effect = class(ModifierBaseClass)
 
+function modifier_item_lucience_movespeed_effect:IsHidden()
+  return false
+end
+
+function modifier_item_lucience_movespeed_effect:IsDebuff()
+  return false
+end
+
 function modifier_item_lucience_movespeed_effect:OnCreated()
-  if self:GetAbility() then
-    self.movespeedBonus = self:GetAbility():GetSpecialValueFor("speed_bonus")
-  else
-    self.movespeedBonus = 0
+  local ability = self:GetAbility()
+  local move_speed = 20
+  if ability and not ability:IsNull() then
+    move_speed = ability:GetSpecialValueFor("speed_bonus")
   end
+
+  self.movespeedBonus = move_speed
 end
 
 modifier_item_lucience_movespeed_effect.OnRefresh = modifier_item_lucience_movespeed_effect.OnCreated


### PR DESCRIPTION
* Lucience regen aura changed from healing per second to hp regen.
* Removed extra GetAttributes() for modifier_item_lucience_aura_handler
* Removed outdated line in modifier_item_lucience_aura_handler:OnCreated when Lucience gave bonus damage.
* Deleted some comments about illusions because they are not true.
* Improved stability of Lucience (if item gets destroyed or deleted).