### PR TITLE
Pull Staff Fixes

### DIFF
--- a/game/resource/English/ability/items/tooltip_pull_staff.txt
+++ b/game/resource/English/ability/items/tooltip_pull_staff.txt
@@ -49,3 +49,9 @@
 "DOTA_Tooltip_Ability_item_pull_staff_4_bonus_armor"                    "#{DOTA_Tooltip_Ability_item_pull_staff_bonus_armor}"
 "DOTA_Tooltip_Ability_item_pull_staff_4_bonus_health_regen"             "#{DOTA_Tooltip_Ability_item_pull_staff_bonus_health_regen}"
 //"DOTA_Tooltip_Ability_item_pull_staff_4_bonus_pull_length"                "+PULL LENGTH:"
+
+"oaa_hud_error_pull_staff_black_hole"                                   "Ability Can't Target Units in Black Hole"
+"oaa_hud_error_pull_staff_chronosphere"                                 "Ability Can't Target Units in Chronosphere"
+"oaa_hud_error_pull_staff_duel"                                         "Ability Can't Target Dueling Heroes"
+"oaa_hud_error_pull_staff_lasso"                                        "Ability Can't Target Lassoed Units"
+"oaa_hud_error_pull_staff_kinetic_field"                                "Ability Can't Target Enemies in Kinetic Field"

--- a/game/scripts/npc/items/custom/item_pull_staff.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff.txt
@@ -68,7 +68,6 @@
     "AbilityManaCost"                                     "25"
     "ItemCost"                                            "3675"
 
-    "ItemKillable"                                        "0"
     "ItemSellable"                                        "1"
     "ItemPurchasable"                                     "1"
     "ItemDroppable"                                       "1"

--- a/game/scripts/npc/items/custom/item_pull_staff.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff.txt
@@ -51,14 +51,14 @@
     "Effect"                                              "particles/generic_gameplay/dropped_item.vpcf"
     "AbilityCastAnimation"                                "ACT_DOTA_IDLE"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
-    "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH | DOTA_UNIT_TARGET_TEAM_CUSTOM"
-    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_CUSTOM"
+    "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH"
+    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "CastFilterRejectCaster"                              "1"
     "FightRecapLevel"                                     "1"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCastRange"                                    "800"
+    "AbilityCastRange"                                    "600 700 800 900"
     "AbilityCastPoint"                                    "0.0"
     "AbilityCooldown"                                     "18"
     "AbilitySharedCooldown"                               "pull"
@@ -120,17 +120,17 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "speed"                                           "1500"
+        "speed"                                           "1200"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_range"                                   "800"
+        "tooltip_range"                                   "600 700 800 900"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "distance"                                        "500 600 700 800"
+        "distance"                                        "600 700 800 900"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_pull_staff_2.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_2.txt
@@ -69,7 +69,6 @@
     "AbilityManaCost"                                     "25"
     "ItemCost"                                            "7175"
 
-    "ItemKillable"                                        "0"
     "ItemSellable"                                        "1"
     "ItemPurchasable"                                     "1"
     "ItemDroppable"                                       "1"

--- a/game/scripts/npc/items/custom/item_pull_staff_2.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_2.txt
@@ -52,14 +52,14 @@
     "Effect"                                              "particles/generic_gameplay/dropped_item.vpcf"
     "AbilityCastAnimation"                                "ACT_DOTA_IDLE"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
-    "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH | DOTA_UNIT_TARGET_TEAM_CUSTOM"
-    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_CUSTOM"
+    "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH"
+    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "CastFilterRejectCaster"                              "1"
     "FightRecapLevel"                                     "1"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCastRange"                                    "800"
+    "AbilityCastRange"                                    "600 700 800 900"
     "AbilityCastPoint"                                    "0.0"
     "AbilityCooldown"                                     "18"
     "AbilitySharedCooldown"                               "pull"
@@ -121,17 +121,17 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "speed"                                           "1500"
+        "speed"                                           "1200"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_range"                                   "800"
+        "tooltip_range"                                   "600 700 800 900"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "distance"                                        "500 600 700 800"
+        "distance"                                        "600 700 800 900"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_pull_staff_3.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_3.txt
@@ -69,7 +69,6 @@
     "AbilityManaCost"                                     "25"
     "ItemCost"                                            "15175"
 
-    "ItemKillable"                                        "0"
     "ItemSellable"                                        "1"
     "ItemPurchasable"                                     "1"
     "ItemDroppable"                                       "1"

--- a/game/scripts/npc/items/custom/item_pull_staff_3.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_3.txt
@@ -52,14 +52,14 @@
     "Effect"                                              "particles/generic_gameplay/dropped_item.vpcf"
     "AbilityCastAnimation"                                "ACT_DOTA_IDLE"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
-    "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH | DOTA_UNIT_TARGET_TEAM_CUSTOM"
-    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_CUSTOM"
+    "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH"
+    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "CastFilterRejectCaster"                              "1"
     "FightRecapLevel"                                     "1"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCastRange"                                    "800"
+    "AbilityCastRange"                                    "600 700 800 900"
     "AbilityCastPoint"                                    "0.0"
     "AbilityCooldown"                                     "18"
     "AbilitySharedCooldown"                               "pull"
@@ -121,17 +121,17 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "speed"                                           "1500"
+        "speed"                                           "1200"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_range"                                   "800"
+        "tooltip_range"                                   "600 700 800 900"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "distance"                                        "500 600 700 800"
+        "distance"                                        "600 700 800 900"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_pull_staff_4.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_4.txt
@@ -52,14 +52,14 @@
     "Effect"                                              "particles/generic_gameplay/dropped_item.vpcf"
     "AbilityCastAnimation"                                "ACT_DOTA_IDLE"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
-    "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH | DOTA_UNIT_TARGET_TEAM_CUSTOM"
-    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_CUSTOM"
+    "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH"
+    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "CastFilterRejectCaster"                              "1"
     "FightRecapLevel"                                     "1"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCastRange"                                    "800"
+    "AbilityCastRange"                                    "600 700 800 900"
     "AbilityCastPoint"                                    "0.0"
     "AbilityCooldown"                                     "18"
     "AbilitySharedCooldown"                               "pull"
@@ -121,17 +121,17 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "speed"                                           "1500"
+        "speed"                                           "1200"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "tooltip_range"                                   "800"
+        "tooltip_range"                                   "600 700 800 900"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "distance"                                        "500 600 700 800"
+        "distance"                                        "600 700 800 900"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_pull_staff_4.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_4.txt
@@ -69,7 +69,6 @@
     "AbilityManaCost"                                     "25"
     "ItemCost"                                            "35175"
 
-    "ItemKillable"                                        "0"
     "ItemSellable"                                        "1"
     "ItemPurchasable"                                     "1"
     "ItemDroppable"                                       "1"

--- a/game/scripts/vscripts/items/pull_staff.lua
+++ b/game/scripts/vscripts/items/pull_staff.lua
@@ -16,7 +16,7 @@ function item_pull_staff:CastFilterResultTarget(target)
     return UF_FAIL_CUSTOM
   end
 
-  local forbidden_modifiers = { 
+  local forbidden_modifiers = {
     "modifier_enigma_black_hole_pull",
     "modifier_faceless_void_chronosphere_freeze",
     "modifier_legion_commander_duel",

--- a/game/scripts/vscripts/items/pull_staff.lua
+++ b/game/scripts/vscripts/items/pull_staff.lua
@@ -7,67 +7,15 @@ function item_pull_staff:GetIntrinsicModifierName()
   return "modifier_generic_bonus"
 end
 
-function item_pull_staff:OnSpellStart()
-  local target = self:GetCursorTarget()
-  self.target = target
-  local caster = self:GetCaster()
-
-  if target:TriggerSpellAbsorb(self) then
-    return
-  end
-
-  if target == nil or caster == nil then
-    self:StartCooldown(0)
-    return
-  end
-
-  local speed = self:GetSpecialValueFor("speed")
-  local maxDistance = self:GetSpecialValueFor("distance")
-
-  local casterposition = caster:GetAbsOrigin()
-  local targetposition = target:GetAbsOrigin()
-
-  local vVelocity = casterposition - targetposition
-  vVelocity.z = 0.0
-
-  local flDistance = vVelocity:Length2D() - caster:GetPaddedCollisionRadius() - target:GetPaddedCollisionRadius()
-  if flDistance > maxDistance then
-    flDistance = maxDistance
-  end
-  vVelocity = vVelocity:Normalized() * speed
-
-  -- To prevent griefing allies that are channeling abilities
-  if target:GetTeamNumber() ~= caster:GetTeamNumber() then
-    target:Stop()
-  end
-
-  local info = {
-    Ability = self,
-    --EffectName = "particles/econ/events/ti6/force_staff_ti6.vpcf",
-    --EffectName = "particles/econ/items/mirana/mirana_crescent_arrow/mirana_spell_crescent_arrow.vpcf",
-    vSpawnOrigin = targetposition,
-    vVelocity = vVelocity,
-    fDistance = flDistance,
-    Source = target,
-  }
-  local projectile = ProjectileManager:CreateLinearProjectile(info)
-
-  self.particle = ParticleManager:CreateParticle("particles/econ/events/ti6/force_staff_ti6.vpcf", PATTACH_ABSORIGIN_FOLLOW, target)
-  target:EmitSound("DOTA_Item.ForceStaff.Activate")
-
-  --DebugDrawLine(targetposition, targetposition + vVelocity, 255, 0, 0, true, 10)
-  --DebugDrawLine(targetposition + Vector(0, 0, 128), casterposition + Vector(0, 0, 128), 0, 255, 0, true, 10)
-  --DebugDrawLine(targetposition + Vector(0, 0, 64), targetposition + ProjectileManager:GetLinearProjectileVelocity(projectile) + Vector(0, 0, 64), 0, 0, 255, true, 10)
-end
-
 function item_pull_staff:CastFilterResultTarget(target)
   local caster = self:GetCaster()
   local defaultFilterResult = self.BaseClass.CastFilterResultTarget(self, target)
-  if defaultFilterResult ~= UF_SUCCESS then
-    return defaultFilterResult
-  elseif target == caster then
+
+  if target == caster then
     return UF_FAIL_CUSTOM
   end
+
+  return defaultFilterResult
 end
 
 function item_pull_staff:GetCustomCastErrorTarget(target)
@@ -77,19 +25,156 @@ function item_pull_staff:GetCustomCastErrorTarget(target)
   end
 end
 
-function item_pull_staff:OnProjectileThink(vLocation)
-  vLocation.z = GetGroundHeight(vLocation, self.target)
-  self.target:SetAbsOrigin(vLocation)
-end
+function item_pull_staff:OnSpellStart()
+  local target = self:GetCursorTarget()
+  local caster = self:GetCaster()
 
-function item_pull_staff:OnProjectileHit(hTarget, vLocation)
-  vLocation.z = GetGroundHeight(vLocation, self.target)
-  ParticleManager:DestroyParticle(self.particle, false)
-  ParticleManager:ReleaseParticleIndex(self.particle)
-  FindClearSpaceForUnit(self.target, vLocation, true)
-  return true
+  -- Check if target and caster entities exist
+  if not target or not caster then
+    return
+  end
+
+  -- Check if target has spell block
+  if target:TriggerSpellAbsorb(self) then
+    return
+  end
+
+  -- Interrupt enemies only
+  if target:GetTeamNumber() ~= caster:GetTeamNumber() then
+    target:Stop()
+  end
+
+  -- Remove particles of the previous pull staff instance in case of refresher
+  if target.pull_staff_particle then
+    ParticleManager:DestroyParticle(target.pull_staff_particle, false)
+    ParticleManager:ReleaseParticleIndex(target.pull_staff_particle)
+    target.pull_staff_particle = nil
+  end
+
+  -- KV variables
+  local speed = self:GetSpecialValueFor("speed")
+  local maxDistance = self:GetSpecialValueFor("distance")
+
+  -- Positions
+  local casterposition = caster:GetAbsOrigin()
+  local targetposition = target:GetAbsOrigin()
+
+  -- Calculate direction and distance
+  local direction = casterposition - targetposition
+  local distance = direction:Length2D() - caster:GetPaddedCollisionRadius() - target:GetPaddedCollisionRadius()
+  if distance > maxDistance then
+    distance = maxDistance
+  end
+  if distance < 0 then
+    distance = 0
+  end
+  direction.z = 0
+  direction = direction:Normalized()
+
+  -- Particle
+  target.pull_staff_particle = ParticleManager:CreateParticle("particles/econ/events/ti6/force_staff_ti6.vpcf", PATTACH_ABSORIGIN_FOLLOW, target)
+
+  -- Sound
+  target:EmitSound("DOTA_Item.ForceStaff.Activate")
+
+  -- Actual Effect
+  target:AddNewModifier(caster, self, "modifier_pull_staff_active_buff", {
+    distance = distance,
+    speed = speed,
+    direction_x = direction.x,
+    direction_y = direction.y,
+  })
+
 end
 
 item_pull_staff_2 = item_pull_staff
 item_pull_staff_3 = item_pull_staff
 item_pull_staff_4 = item_pull_staff
+
+---------------------------------------------------------------------------------------------------
+modifier_pull_staff_active_buff = class(ModifierBaseClass)
+
+function modifier_pull_staff_active_buff:IsHidden()
+  return true
+end
+
+function modifier_pull_staff_active_buff:IsDebuff()
+  return false
+end
+
+function modifier_pull_staff_active_buff:IsPurgable()
+  return false
+end
+
+function modifier_pull_staff_active_buff:GetPriority()
+  return DOTA_MOTION_CONTROLLER_PRIORITY_HIGHEST
+end
+
+function modifier_pull_staff_active_buff:CheckState()
+  return {
+    [MODIFIER_STATE_FLYING_FOR_PATHING_PURPOSES_ONLY] = true
+  }
+end
+if IsServer() then
+  function modifier_pull_staff_active_buff:OnCreated(event)
+    local parent = self:GetParent()
+    if parent:IsCurrentlyHorizontalMotionControlled() then
+      parent:InterruptMotionControllers(false)
+    end
+
+    -- Data sent with AddNewModifier
+    self.direction = Vector(event.direction_x, event.direction_y, 0)
+    self.distance = event.distance + 1
+    self.speed = event.speed
+
+    if self:ApplyHorizontalMotionController() == false then
+      self:Destroy()
+      return
+    end
+  end
+
+  function modifier_pull_staff_active_buff:UpdateHorizontalMotion(parent, deltaTime)
+    local parentOrigin = parent:GetAbsOrigin()
+
+    local tickTraveled = deltaTime * self.speed
+    tickTraveled = math.min(tickTraveled, self.distance)
+    if tickTraveled <= 0 then
+      self:Destroy()
+    end
+    local tickOrigin = parentOrigin + tickTraveled * self.direction
+    tickOrigin = Vector(tickOrigin.x, tickOrigin.y, GetGroundHeight(tickOrigin, parent))
+
+    parent:SetAbsOrigin(tickOrigin)
+
+    self.distance = self.distance - tickTraveled
+
+    GridNav:DestroyTreesAroundPoint(tickOrigin, 200, false)
+  end
+
+  function modifier_pull_staff_active_buff:OnHorizontalMotionInterrupted()
+    self:Destroy()
+  end
+
+  function modifier_pull_staff_active_buff:OnDestroy()
+    local parent = self:GetParent()
+    if parent and not parent:IsNull() then
+      parent:RemoveHorizontalMotionController(self)
+      FindClearSpaceForUnit(parent, parent:GetAbsOrigin(), false)
+      local parent_origin = parent:GetAbsOrigin()
+      ResolveNPCPositions(parent_origin, 128)
+      if parent.pull_staff_particle then
+        ParticleManager:DestroyParticle(parent.pull_staff_particle, false)
+        ParticleManager:ReleaseParticleIndex(parent.pull_staff_particle)
+        parent.pull_staff_particle = nil
+      end
+    end
+  end
+end
+
+--function modifier_pull_staff_active_buff:GetEffectName()
+  --return "particles/units/heroes/hero_earth_spirit/espirit_geomagentic_grip_target.vpcf"
+--end
+
+--function modifier_pull_staff_active_buff:GetEffectAttachType()
+  --return PATTACH_ABSORIGIN_FOLLOW
+--end


### PR DESCRIPTION
* Pull Staff cast range rescaled from 800 to 600/700/800/900.
* Pull Staff max distance increased from 500/600/700/800 to 600/700/800/900.
* Pull Staff pull speed reduced from 1500 to 1200.
* Pull Staff cant target units in Black Hole, Chronosphere and Kinetic Field anymore.
* Pull Staff can't target Dueled heroes and Lassoed units anymore.
* Pull Staff doesn't actually let you target mentioned units above unlike Force Staff.
* It now uses motion controller buff instead of linear projectile -> effect should be instant when you use the item instead of having a weird delay or not working sometimes.
* Fixed particles not going away if used on a target already affected by Pull Staff (it was possible with Refresher and multiple Pull Staves).
* Pulling animation should be smoother and above ground the whole time now.
* Fixed not being able to destroy Pull Staff item when dropped on the ground.
