### PR TITLE
Queen of Pain talent nerfs

### DIFF
--- a/game/scripts/npc/heroes/queenofpain.txt
+++ b/game/scripts/npc/heroes/queenofpain.txt
@@ -7,11 +7,11 @@
   {
     // Abilities
     //-------------------------------------------------------------------------------------------------------------
-    "Ability10"   "special_bonus_attack_damage_75" // replaces special_bonus_attack_damage_20
-    "Ability11"   "special_bonus_strength_20" // replaces special_bonus_strength_8
+    "Ability10"   "special_bonus_attack_damage_40" // replaces special_bonus_attack_damage_20
+    "Ability11"   "special_bonus_strength_16" // replaces special_bonus_strength_8
 
     "Ability12"   "special_bonus_cooldown_reduction_10"
-    "Ability13"   "special_bonus_attack_speed_100" // replaces special_bonus_attack_speed_30
+    "Ability13"   "special_bonus_attack_speed_60" // replaces special_bonus_attack_speed_30
 
     "Ability14"   "special_bonus_spell_lifesteal_30" // replaces special_bonus_spell_lifesteal_25
     "Ability15"   "special_bonus_unique_queen_of_pain"


### PR DESCRIPTION
* Level 10 talent +75 Damage reduced to +40.
* Level 10 talent +20 Strength reduced to +16.
* Level 15 talent +100 Attack Speed reduced to +60.