### PR TITLE
Drow Ranger Marksmanship small nerf

### DIFF
--- a/game/scripts/npc/abilities/drow_ranger_marksmanship.txt
+++ b/game/scripts/npc/abilities/drow_ranger_marksmanship.txt
@@ -34,7 +34,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "70 80 90 120 170"
+        "bonus_damage"                                    "70 80 90 110 150"
         "CalculateSpellDamageTooltip"                     "0"
       }
       "03"


### PR DESCRIPTION
* Marksmanship damage nerfed at OAA levels from 120/170 to 110/150.