### PR TITLE
Illusionist Cape buff

### DIFF
--- a/game/scripts/npc/items/item_illusionsts_cape.txt
+++ b/game/scripts/npc/items/item_illusionsts_cape.txt
@@ -60,17 +60,17 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "illusion_duration"                               "30"
+        "illusion_duration"                               "20"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "outgoing_damage"                                 "-50"
+        "outgoing_damage"                                 "0"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "outgoing_damage_tooltip"                         "50"
+        "outgoing_damage_tooltip"                         "100"
       }
       "05"
       {


### PR DESCRIPTION
* Illusion damage dealt increased from 50% to 100%.
* Illusion duration reduced from 30 to 20 seconds.