### PR TITLE
Clinkz lvl 25 Death Pact talent improvement

### DIFF
--- a/game/resource/English/ability/units/tooltip_clinkz_talents.txt
+++ b/game/resource/English/ability/units/tooltip_clinkz_talents.txt
@@ -1,4 +1,6 @@
 //=============================================================================
-// Clinkz Talent Strafe Cooldown Decrease
+// Clinkz Custom Talents
 //=============================================================================
 "DOTA_Tooltip_ability_special_bonus_clinkz_strafe_cooldown"                     "-{s:value}s Strafe Cooldown"
+"DOTA_Tooltip_ability_special_bonus_clinkz_death_pact_oaa"                      "#{DOTA_Tooltip_ability_special_bonus_unique_clinkz_8}"
+"DOTA_Tooltip_ability_special_bonus_clinkz_death_pact_oaa_Description"          "It also increases max HP gain by {s:value3} and max damage gain by {s:value4}."

--- a/game/scripts/npc/abilities/clinkz_death_pact_oaa.txt
+++ b/game/scripts/npc/abilities/clinkz_death_pact_oaa.txt
@@ -49,24 +49,28 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "health_gain_pct"                                 "40 60 80 100 120"
-        "LinkedSpecialBonus"                              "special_bonus_unique_clinkz_8"
+        "LinkedSpecialBonus"                              "special_bonus_clinkz_death_pact_oaa"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
         "damage_gain_pct"                                 "4 6 8 10 14"
-        "LinkedSpecialBonus"                              "special_bonus_unique_clinkz_8"
+        "LinkedSpecialBonus"                              "special_bonus_clinkz_death_pact_oaa"
         "LinkedSpecialBonusField"                         "value2"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
         "health_gain_max"                                 "1000 1500 2000 2500 3000"
+        "LinkedSpecialBonus"                              "special_bonus_clinkz_death_pact_oaa"
+        "LinkedSpecialBonusField"                         "value3"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
         "damage_gain_max"                                 "100 150 200 250 300"
+        "LinkedSpecialBonus"                              "special_bonus_clinkz_death_pact_oaa"
+        "LinkedSpecialBonusField"                         "value4"
       }
     }
   }

--- a/game/scripts/npc/abilities/talents/clinkz_talent1_oaa.txt
+++ b/game/scripts/npc/abilities/talents/clinkz_talent1_oaa.txt
@@ -1,0 +1,26 @@
+﻿"DOTAAbilities"
+{
+  //=================================================================================================================
+  // Custom Clinkz talent: Modifies cooldown of Strafe
+  //=================================================================================================================
+  "special_bonus_clinkz_strafe_cooldown"
+  {
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "ID"                  "86231"
+    "BaseClass"           "special_bonus_undefined"
+    "AbilityType"         "DOTA_ABILITY_TYPE_ATTRIBUTES"
+    "AbilityBehavior"     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"        "FIELD_FLOAT"
+        "value"           "5"
+      }
+    }
+  }
+}

--- a/game/scripts/npc/abilities/talents/clinkz_talent2_oaa.txt
+++ b/game/scripts/npc/abilities/talents/clinkz_talent2_oaa.txt
@@ -1,16 +1,16 @@
 ﻿"DOTAAbilities"
 {
   //=================================================================================================================
-  // Custom Clinkz talent: Modifies cooldown of Strafe
+  // Custom Clinkz talent: Modifies Death Pact values
   //=================================================================================================================
-  "special_bonus_clinkz_strafe_cooldown"
+  "special_bonus_clinkz_death_pact_oaa"
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"                  "86231"
+    "ID"                  "80495"
     "BaseClass"           "special_bonus_undefined"
     "AbilityType"         "DOTA_ABILITY_TYPE_ATTRIBUTES"
-    "AbilityBehavior"       "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+    "AbilityBehavior"     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------
@@ -18,8 +18,23 @@
     {
       "01"
       {
-        "var_type"        "FIELD_FLOAT"
-        "value"           "5"
+        "var_type"        "FIELD_INTEGER"
+        "value"           "50"
+      }
+      "02"
+      {
+        "var_type"        "FIELD_INTEGER"
+        "value2"          "5"
+      }
+      "03" // Health Max increase
+      {
+        "var_type"        "FIELD_INTEGER"
+        "value3"          "1000"
+      }
+      "04" // Damage Max increase
+      {
+        "var_type"        "FIELD_INTEGER"
+        "value4"          "100"
       }
     }
   }

--- a/game/scripts/npc/heroes/clinkz.txt
+++ b/game/scripts/npc/heroes/clinkz.txt
@@ -10,5 +10,7 @@
     "Ability6"                                            "clinkz_death_pact_oaa" // replaces clinkz_death_pact
 
     "Ability15"                                           "special_bonus_clinkz_strafe_cooldown" // replaces special_bonus_unique_clinkz_11
+
+    "Ability16"                                           "special_bonus_clinkz_death_pact_oaa" // replaces special_bonus_unique_clinkz_8
   }
 }

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -36,7 +36,8 @@
 #base "abilities/electrician_energy_absorption_oaa.txt"
 #base "abilities/electrician_cleansing_shock_oaa.txt"
 
-#base "abilities/talents/clinkz_talent_oaa.txt"
+#base "abilities/talents/clinkz_talent1_oaa.txt"
+#base "abilities/talents/clinkz_talent2_oaa.txt"
 #base "abilities/talents/electrician_talent1_oaa.txt"
 #base "abilities/talents/electrician_talent2_oaa.txt"
 #base "abilities/talents/electrician_talent3_oaa.txt"

--- a/game/scripts/vscripts/abilities/oaa_death_pact.lua
+++ b/game/scripts/vscripts/abilities/oaa_death_pact.lua
@@ -79,11 +79,13 @@ function modifier_clinkz_death_pact_oaa:OnCreated( event )
 
   if IsServer() then
     -- Talent that increases hp and dmg gain
-    local talent = parent:FindAbilityByName("special_bonus_unique_clinkz_8")
+    local talent = parent:FindAbilityByName("special_bonus_clinkz_death_pact_oaa")
     if talent then
       if talent:GetLevel() > 0 then
         healthPct = healthPct + talent:GetSpecialValueFor("value")
         damagePct = damagePct + talent:GetSpecialValueFor("value2")
+        healthMax = healthMax + talent:GetSpecialValueFor("value3")
+        damageMax = damageMax + talent:GetSpecialValueFor("value4")
       end
     end
   end
@@ -135,11 +137,13 @@ function modifier_clinkz_death_pact_oaa:OnRefresh( event )
 
   if IsServer() then
     -- Talent that increases hp and dmg gain
-    local talent = parent:FindAbilityByName("special_bonus_unique_clinkz_8")
+    local talent = parent:FindAbilityByName("special_bonus_clinkz_death_pact_oaa")
     if talent then
       if talent:GetLevel() > 0 then
         healthPct = healthPct + talent:GetSpecialValueFor("value")
         damagePct = damagePct + talent:GetSpecialValueFor("value2")
+        healthMax = healthMax + talent:GetSpecialValueFor("value3")
+        damageMax = damageMax + talent:GetSpecialValueFor("value4")
       end
     end
   end


### PR DESCRIPTION
Making the talent less useless for Clinkz that goes Dominator.