### PR TITLE
Error fixes

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2728,6 +2728,7 @@ read_globals = { -- these globals can only be accessed.
 "DOTA_UNIT_ORDER_HOLD_POSITION",
 "DOTA_UNIT_ORDER_DROP_ITEM",
 "DOTA_ModifyGold_Buyback",
+"DOTA_ModifyGold_BountyRune",
 "DOTA_HEROPICK_STATE_AP_SELECT",
 "ACT_RANGE_ATTACK_THROW",
 "DOTA_UNIT_ORDER_MOVE_ITEM",

--- a/game/scripts/npc/abilities/boss/boss_cliffwalk.txt
+++ b/game/scripts/npc/abilities/boss/boss_cliffwalk.txt
@@ -9,7 +9,6 @@
     "BaseClass"                                           "ability_datadriven"
     "AbilityTextureName"                                  "winter_wyvern_arctic_burn"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
-    "AbilityType"                                         "DOTA_ABILITY_TYPE_ULTIMATE"
 
     "MaxLevel"                                            "1"
     "RequiredLevel"                                       "1"

--- a/game/scripts/npc/abilities/boss/boss_regen.txt
+++ b/game/scripts/npc/abilities/boss/boss_regen.txt
@@ -10,7 +10,6 @@
     "ScriptFile"                                          "abilities/boss_regen.lua"
     "AbilityTextureName"                                  "dragon_knight_dragon_blood"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
-    "AbilityType"                                         "DOTA_ABILITY_TYPE_ULTIMATE"
 
     "MaxLevel"                                            "1"
     "RequiredLevel"                                       "1"

--- a/game/scripts/npc/abilities/boss/boss_resistance.txt
+++ b/game/scripts/npc/abilities/boss/boss_resistance.txt
@@ -5,18 +5,15 @@
   //=================================================================================================================
   "boss_resistance"
   {
-
     "ID"                                                  "9900"
     "BaseClass"                                           "ability_lua"
     "ScriptFile"                                          "abilities/boss_resistance.lua"
     "AbilityTextureName"                                  "tidehunter_kraken_shell"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
-    "AbilityType"                                         "DOTA_ABILITY_TYPE_ULTIMATE"
 
     "MaxLevel"                                            "1"
     "RequiredLevel"                                       "1"
     "LevelsBetweenUpgrades"                               "1"
-
 
     "AbilitySpecial"
     {

--- a/game/scripts/vscripts/abilities/boss_resistance.lua
+++ b/game/scripts/vscripts/abilities/boss_resistance.lua
@@ -235,6 +235,10 @@ if IsServer() then
     local parent = self:GetParent()
     local caster = self:GetCaster()
 
+    if not caster or caster:IsNull() then
+      return {}
+    end
+
     -- Only reveal when within reveal_max_distance of boss
     if (parent:GetAbsOrigin() - caster:GetAbsOrigin()):Length2D() <= self.maxRevealDist then
       return {
@@ -261,6 +265,11 @@ end
 function modifier_boss_truesight:IsHidden()
   local parent = self:GetParent()
   local caster = self:GetCaster()
+
+  if not caster or caster:IsNull() then
+    return true
+  end
+
   return (parent:GetAbsOrigin() - caster:GetAbsOrigin()):Length2D() > self.maxRevealDist
 end
 

--- a/game/scripts/vscripts/abilities/boss_resistance.lua
+++ b/game/scripts/vscripts/abilities/boss_resistance.lua
@@ -231,7 +231,7 @@ if IsServer() then
     local parent = self:GetParent()
     local caster = self:GetCaster()
 
-    if not caster or caster:IsNull() then
+    if not caster or caster:IsNull() or parent:HasModifier("modifier_slark_shadow_dance") then
       return {}
     end
 
@@ -240,9 +240,9 @@ if IsServer() then
       return {
         [MODIFIER_STATE_INVISIBLE] = false
       }
-    else
-      return {}
     end
+
+    return {}
   end
 end
 
@@ -262,11 +262,19 @@ function modifier_boss_truesight:IsHidden()
   local parent = self:GetParent()
   local caster = self:GetCaster()
 
-  if not caster or caster:IsNull() then
+  if not caster or caster:IsNull() or parent:HasModifier("modifier_slark_shadow_dance") then
     return true
   end
 
   return (parent:GetAbsOrigin() - caster:GetAbsOrigin()):Length2D() > self.maxRevealDist
+end
+
+function modifier_boss_truesight:GetEffectName()
+  return "particles/items2_fx/true_sight_debuff.vpcf"
+end
+
+function modifier_boss_truesight:GetEffectAttachType()
+  return PATTACH_OVERHEAD_FOLLOW
 end
 
 function modifier_boss_truesight:GetPriority()

--- a/game/scripts/vscripts/abilities/boss_resistance.lua
+++ b/game/scripts/vscripts/abilities/boss_resistance.lua
@@ -7,10 +7,6 @@ function boss_resistance:GetIntrinsicModifierName()
   return "modifier_boss_resistance"
 end
 
-function boss_resistance:GetBehavior()
-  return DOTA_ABILITY_BEHAVIOR_PASSIVE
-end
-
 -----------------------------------------------------------------------------------------
 
 modifier_boss_resistance = class(ModifierBaseClass)

--- a/game/scripts/vscripts/abilities/shielder/boss_shielder_shield.lua
+++ b/game/scripts/vscripts/abilities/shielder/boss_shielder_shield.lua
@@ -14,7 +14,3 @@ end
 function boss_shielder_shield:GetIntrinsicModifierName()
   return "modifier_boss_shielder_shielded_buff"
 end
-
-function boss_shielder_shield:GetBehavior ()
-  return DOTA_ABILITY_BEHAVIOR_PASSIVE
-end

--- a/game/scripts/vscripts/abilities/stopfightingyourself/debuff_mirror.lua
+++ b/game/scripts/vscripts/abilities/stopfightingyourself/debuff_mirror.lua
@@ -12,12 +12,6 @@ function boss_stopfightingyourself_debuff_mirror:GetIntrinsicModifierName()
   return "modifier_boss_stopfightingyourself_debuff_mirror"
 end
 
-function boss_stopfightingyourself_debuff_mirror:GetBehavior()
-  return DOTA_ABILITY_BEHAVIOR_PASSIVE
-end
-
-
-
 modifier_boss_stopfightingyourself_debuff_mirror = class(ModifierBaseClass)
 
 function modifier_boss_stopfightingyourself_debuff_mirror:DeclareFunctions()

--- a/game/scripts/vscripts/abilities/tiny_grow.lua
+++ b/game/scripts/vscripts/abilities/tiny_grow.lua
@@ -18,10 +18,6 @@ function tiny_grow_oaa:GetIntrinsicModifierName()
   return "modifier_tiny_grow_oaa"
 end
 
-function tiny_grow_oaa:GetBehavior ()
-  return DOTA_ABILITY_BEHAVIOR_PASSIVE
-end
-
 function tiny_grow_oaa:OnUpgrade()
   if IsServer() then
     if self:GetCaster():GetUnitName() == "npc_dota_hero_tiny" then

--- a/game/scripts/vscripts/components/filters/bountyrunepick.lua
+++ b/game/scripts/vscripts/components/filters/bountyrunepick.lua
@@ -29,7 +29,12 @@ function BountyRunePick:Filter(filter_table)
   -- Hero that picked up the rune
   local hero_with_rune = PlayerResource:GetSelectedHeroEntity(playerID)
   -- Team that picked up the rune
-  local allied_team = hero_with_rune:GetTeamNumber()
+  local allied_team
+  if hero_with_rune then
+    allied_team = hero_with_rune:GetTeamNumber()
+  else
+    print("Invalid unit picked up the bounty rune!")
+  end
 
   local enemy_team
   if allied_team == DOTA_TEAM_GOODGUYS then
@@ -37,7 +42,7 @@ function BountyRunePick:Filter(filter_table)
   elseif allied_team == DOTA_TEAM_BADGUYS then
     enemy_team = DOTA_TEAM_GOODGUYS
   else
-    print("Invalid team picked up the rune")
+    print("Invalid team picked up the bounty rune!")
     return false
   end
 
@@ -78,13 +83,30 @@ function BountyRunePick:Filter(filter_table)
 
   local gold_reward = (BOUNTY_RUNE_INITIAL_TEAM_GOLD*game_time*(1 + (1 - (1 - gold_difference)*(1 - gold_difference))*game_time/12)) - (10 * (game_time)/(game_time+0.3))
   local xp_reward = (BOUNTY_RUNE_INITIAL_TEAM_XP*game_time*(1 + (1 - (1 - xp_difference)*(1 - xp_difference))*game_time/12)) - (10 * (game_time)/(game_time+0.3))
+  --gold_reward = math.max(vanilla_gold_bounty, gold_reward)
   xp_reward = math.ceil(xp_reward)
 
   allied_player_ids:each(function (playerid)
     local hero = PlayerResource:GetSelectedHeroEntity(playerid)
 
-    if hero and xp_reward > 0 then
-      hero:AddExperience(xp_reward, DOTA_ModifyXP_Unspecified, false, true)
+    if hero then
+      if xp_reward > 0 then
+        hero:AddExperience(xp_reward, DOTA_ModifyXP_Unspecified, false, true)
+        SendOverheadEventMessage(PlayerResource:GetPlayer(playerid), OVERHEAD_ALERT_MANA_ADD, hero, xp_reward, nil)
+      end
+      -- Check for Alchemist Greevil's Greed bounty rune gold multiplier
+      local alchemist_ability = hero:FindAbilityByName("alchemist_goblins_greed")
+      if alchemist_ability then
+        local alchemist_ability_level = alchemist_ability:GetLevel()
+        if alchemist_ability_level > 0 then
+          local multiplier = alchemist_ability:GetLevelSpecialValueFor("bounty_multiplier", alchemist_ability_level-1)
+          if multiplier > 1 then
+            local bonus_gold = (multiplier-1)*gold_reward
+            Gold:ModifyGold(playerid, bonus_gold, true, DOTA_ModifyGold_BountyRune)
+            SendOverheadEventMessage(PlayerResource:GetPlayer(playerid), OVERHEAD_ALERT_GOLD, hero, bonus_gold, nil)
+          end
+        end
+      end
     end
   end)
 

--- a/game/scripts/vscripts/components/filters/bountyrunepick.lua
+++ b/game/scripts/vscripts/components/filters/bountyrunepick.lua
@@ -92,7 +92,7 @@ function BountyRunePick:Filter(filter_table)
     if hero then
       if xp_reward > 0 then
         hero:AddExperience(xp_reward, DOTA_ModifyXP_Unspecified, false, true)
-        SendOverheadEventMessage(PlayerResource:GetPlayer(playerid), OVERHEAD_ALERT_MANA_ADD, hero, xp_reward, nil)
+        SendOverheadEventMessage(PlayerResource:GetPlayer(playerid), OVERHEAD_ALERT_XP, hero, xp_reward, nil)
       end
       -- Check for Alchemist Greevil's Greed bounty rune gold multiplier
       local alchemist_ability = hero:FindAbilityByName("alchemist_goblins_greed")

--- a/game/scripts/vscripts/items/bloodstone.lua
+++ b/game/scripts/vscripts/items/bloodstone.lua
@@ -289,6 +289,16 @@ function modifier_item_bloodstone_non_stacking_stats:IsPurgable()
   return false
 end
 
+function modifier_item_bloodstone_non_stacking_stats:OnCreated()
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.mana_regen_amp = ability:GetSpecialValueFor("mana_regen_multiplier")
+    self.manacost_reduction = ability:GetSpecialValueFor("manacost_reduction")
+  end
+end
+
+modifier_item_bloodstone_non_stacking_stats.OnRefresh = modifier_item_bloodstone_non_stacking_stats.OnCreated
+
 function modifier_item_bloodstone_non_stacking_stats:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_MP_REGEN_AMPLIFY_PERCENTAGE, -- GetModifierMPRegenAmplify_Percentage
@@ -300,7 +310,7 @@ end
 function modifier_item_bloodstone_non_stacking_stats:GetModifierMPRegenAmplify_Percentage()
   local parent = self:GetParent()
   if not parent:HasModifier("modifier_item_kaya") and not parent:HasModifier("modifier_item_yasha_and_kaya") and not parent:HasModifier("modifier_item_kaya_and_sange") then
-    return self:GetAbility():GetSpecialValueFor("mana_regen_multiplier")
+    return self.mana_regen_amp or self:GetAbility():GetSpecialValueFor("mana_regen_multiplier")
   end
   return 0
 end
@@ -308,6 +318,9 @@ end
 function modifier_item_bloodstone_non_stacking_stats:GetModifierSpellAmplify_Percentage()
   local ability = self:GetAbility()
   local parent = self:GetParent()
+  if not ability or ability:IsNull() then
+    return 0
+  end
   if not parent:HasModifier("modifier_item_kaya") and not parent:HasModifier("modifier_item_yasha_and_kaya") and not parent:HasModifier("modifier_item_kaya_and_sange") then
     return ability:GetSpecialValueFor("spell_amp") + (ability:GetCurrentCharges() * ability:GetSpecialValueFor("amp_per_charge"))
   end
@@ -317,7 +330,7 @@ end
 function modifier_item_bloodstone_non_stacking_stats:GetModifierPercentageManacostStacking()
   --local parent = self:GetParent()
   --if not parent:HasModifier("modifier_item_kaya") and not parent:HasModifier("modifier_item_yasha_and_kaya") and not parent:HasModifier("modifier_item_kaya_and_sange") then
-  return self:GetAbility():GetSpecialValueFor("manacost_reduction")
+  return self.manacost_reduction or self:GetAbility():GetSpecialValueFor("manacost_reduction")
   --end
   --return 0
 end

--- a/game/scripts/vscripts/items/farming/greater_guardian_greaves.lua
+++ b/game/scripts/vscripts/items/farming/greater_guardian_greaves.lua
@@ -113,6 +113,14 @@ function modifier_item_greater_guardian_greaves:GetAttributes()
 end
 
 function modifier_item_greater_guardian_greaves:OnCreated()
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.bonus_ms = ability:GetSpecialValueFor("bonus_movement")
+    self.bonus_stats = ability:GetSpecialValueFor("bonus_all_stats")
+    self.bonus_mana = ability:GetSpecialValueFor("bonus_mana")
+    self.bonus_armor = ability:GetSpecialValueFor("bonus_armor")
+    self.aura_radius = ability:GetSpecialValueFor("aura_radius")
+  end
   if IsServer() then
     local parent = self:GetParent()
     -- Remove effect modifiers from units in radius to force refresh
@@ -120,7 +128,7 @@ function modifier_item_greater_guardian_greaves:OnCreated()
       parent:GetTeamNumber(),
       parent:GetAbsOrigin(),
       nil,
-      self:GetAbility():GetSpecialValueFor("aura_radius"),
+      self.aura_radius,
       DOTA_UNIT_TARGET_TEAM_FRIENDLY,
       bit.bor(DOTA_UNIT_TARGET_BASIC, DOTA_UNIT_TARGET_HERO),
       DOTA_UNIT_TARGET_FLAG_NONE,
@@ -150,22 +158,22 @@ function modifier_item_greater_guardian_greaves:DeclareFunctions()
 end
 
 function modifier_item_greater_guardian_greaves:GetModifierBonusStats_Agility()
-  return self:GetAbility():GetSpecialValueFor("bonus_all_stats")
+  return self.bonus_stats or self:GetAbility():GetSpecialValueFor("bonus_all_stats")
 end
 function modifier_item_greater_guardian_greaves:GetModifierBonusStats_Intellect()
-  return self:GetAbility():GetSpecialValueFor("bonus_all_stats")
+  return self.bonus_stats or self:GetAbility():GetSpecialValueFor("bonus_all_stats")
 end
 function modifier_item_greater_guardian_greaves:GetModifierBonusStats_Strength()
-  return self:GetAbility():GetSpecialValueFor("bonus_all_stats")
+  return self.bonus_stats or self:GetAbility():GetSpecialValueFor("bonus_all_stats")
 end
 function modifier_item_greater_guardian_greaves:GetModifierMoveSpeedBonus_Special_Boots()
-  return self:GetAbility():GetSpecialValueFor("bonus_movement")
+  return self.bonus_ms or self:GetAbility():GetSpecialValueFor("bonus_movement")
 end
 function modifier_item_greater_guardian_greaves:GetModifierManaBonus()
-  return self:GetAbility():GetSpecialValueFor("bonus_mana")
+  return self.bonus_mana or self:GetAbility():GetSpecialValueFor("bonus_mana")
 end
 function modifier_item_greater_guardian_greaves:GetModifierPhysicalArmorBonus()
-  return self:GetAbility():GetSpecialValueFor("bonus_armor")
+  return self.bonus_armor or self:GetAbility():GetSpecialValueFor("bonus_armor")
 end
 
 --------------------------------------------------------------------------
@@ -184,7 +192,7 @@ function modifier_item_greater_guardian_greaves:GetAuraSearchTeam()
 end
 
 function modifier_item_greater_guardian_greaves:GetAuraRadius()
-  return self:GetAbility():GetSpecialValueFor("aura_radius")
+  return self.aura_radius or self:GetAbility():GetSpecialValueFor("aura_radius")
 end
 
 function modifier_item_greater_guardian_greaves:GetModifierAura()

--- a/game/scripts/vscripts/items/reflex/reactive_reflect.lua
+++ b/game/scripts/vscripts/items/reflex/reactive_reflect.lua
@@ -151,7 +151,7 @@ function modifier_item_reactive_reflect:GetReflectSpell(kv)
       return nil
     end
 
-    -- If this is a reflected ability from other Reflection shard, do nothing 
+    -- If this is a reflected ability from other Reflection shard, do nothing
     -- (reflecting reflected spells should not be possible)
     if kv.ability.reflected_spell then
       return nil
@@ -172,7 +172,7 @@ function modifier_item_reactive_reflect:GetReflectSpell(kv)
       end
     end
 
-    -- If target has reflecting modifiers do nothing to prevent infinite loops 
+    -- If target has reflecting modifiers do nothing to prevent infinite loops
     -- (reflecting reflected spells should not be possible)
     if found then
       return nil

--- a/game/scripts/vscripts/items/reflex/reactive_reflect.lua
+++ b/game/scripts/vscripts/items/reflex/reactive_reflect.lua
@@ -135,10 +135,15 @@ function modifier_item_reactive_reflect:GetReflectSpell(kv)
     local target = kv.ability:GetCaster()
     local ability_level = kv.ability:GetLevel()
     local ability_behaviour = kv.ability:GetBehavior()
+    if type(ability_behaviour) == 'userdata' then
+      ability_behaviour = tonumber(tostring(ability_behaviour))
+    end
 
     local exception_list = {
       ["rubick_spell_steal"] = true,
-      --["legion_commander_duel"] = true, -- uncomment this if Duel becomes buggy
+      ["morphling_replicate"] = true,
+      --["grimstroke_soul_chain"] = true, -- uncomment this if Grimstroke Soul Bind becomes buggy
+      --["legion_commander_duel"] = true, -- uncomment this if Legion Commander's Duel becomes buggy
     }
 
     -- Do not reflect allied spells for any reason

--- a/game/scripts/vscripts/items/reflex/reactive_reflect.lua
+++ b/game/scripts/vscripts/items/reflex/reactive_reflect.lua
@@ -146,13 +146,30 @@ function modifier_item_reactive_reflect:GetReflectSpell(kv)
       return nil
     end
 
-    -- If this is a reflected ability from other Reflection shard, do nothing (reflecting reflected spells should not be possible)
+    -- If this is a reflected ability from other Reflection shard, do nothing 
+    -- (reflecting reflected spells should not be possible)
     if kv.ability.reflected_spell then
       return nil
     end
 
-    -- If target has reflecting modifiers (lotus orb or reflection shard) do nothing to prevent looping (reflecting reflected spells should not be possible)
-    if target:HasModifier("modifier_item_lotus_orb_active") or target:HasModifier("modifier_item_reactive_reflect") then
+    local reflecting_modifiers = {
+      "modifier_item_lotus_orb_active", -- Lotus Orb active
+      "modifier_item_reactive_reflect", -- Reflection Shard active
+      "modifier_item_mirror_shield",    -- Mirror Shield
+      "modifier_antimage_counterspell", -- Anti-Mage Counter Spell active
+    }
+    -- Check for reflecting modifiers
+    local found = false
+    for i = 1, #reflecting_modifiers do
+      if target:HasModifier(reflecting_modifiers[i]) then
+        found = true
+        break
+      end
+    end
+
+    -- If target has reflecting modifiers do nothing to prevent infinite loops 
+    -- (reflecting reflected spells should not be possible)
+    if found then
       return nil
     end
 

--- a/game/scripts/vscripts/items/satanic_core.lua
+++ b/game/scripts/vscripts/items/satanic_core.lua
@@ -41,17 +41,23 @@ modifier_item_satanic_core = class(ModifierBaseClass)
 function modifier_item_satanic_core:IsHidden()
   return true
 end
---[[
+
 function modifier_item_satanic_core:OnCreated()
-  self.lifesteal_percent = self:GetAbility():GetSpecialValueFor("hero_lifesteal")
-  self.unholy_lifesteal_percent = self:GetAbility():GetSpecialValueFor("unholy_hero_spell_lifesteal")
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    --self.lifesteal_percent = ability:GetSpecialValueFor("hero_lifesteal")
+    --self.unholy_lifesteal_percent = ability:GetSpecialValueFor("unholy_hero_spell_lifesteal")
+    self.bonus_str = ability:GetSpecialValueFor("bonus_strength")
+    self.bonus_int = ability:GetSpecialValueFor("bonus_intelligence")
+    self.bonus_hp = ability:GetSpecialValueFor("bonus_health")
+    self.bonus_mana = ability:GetSpecialValueFor("bonus_mana")
+    self.bonus_status_resist = ability:GetSpecialValueFor("bonus_status_resist")
+    self.bonus_magic_resist = ability:GetSpecialValueFor("bonus_magic_resist")
+  end
 end
 
-function modifier_item_satanic_core:OnRefresh()
-  self.lifesteal_percent = self:GetAbility():GetSpecialValueFor("hero_lifesteal")
-  self.unholy_lifesteal_percent = self:GetAbility():GetSpecialValueFor("unholy_hero_spell_lifesteal")
-end
-]]
+modifier_item_satanic_core.OnRefresh = modifier_item_satanic_core.OnCreated
+
 function modifier_item_satanic_core:IsPurgable()
   return false
 end
@@ -70,27 +76,27 @@ function modifier_item_satanic_core:DeclareFunctions()
 end
 
 function modifier_item_satanic_core:GetModifierBonusStats_Strength()
-  return self:GetAbility():GetSpecialValueFor("bonus_strength")
+  return self.bonus_str or self:GetAbility():GetSpecialValueFor("bonus_strength")
 end
 
 function modifier_item_satanic_core:GetModifierBonusStats_Intellect()
-  return self:GetAbility():GetSpecialValueFor("bonus_intelligence")
+  return self.bonus_int or self:GetAbility():GetSpecialValueFor("bonus_intelligence")
 end
 
 function modifier_item_satanic_core:GetModifierHealthBonus()
-  return self:GetAbility():GetSpecialValueFor("bonus_health")
+  return self.bonus_hp or self:GetAbility():GetSpecialValueFor("bonus_health")
 end
 
 function modifier_item_satanic_core:GetModifierManaBonus()
-  return self:GetAbility():GetSpecialValueFor("bonus_mana")
+  return self.bonus_mana or self:GetAbility():GetSpecialValueFor("bonus_mana")
 end
 
 function modifier_item_satanic_core:GetModifierStatusResistanceStacking()
-  return self:GetAbility():GetSpecialValueFor("bonus_status_resist")
+  return self.bonus_status_resist or self:GetAbility():GetSpecialValueFor("bonus_status_resist")
 end
 
 function modifier_item_satanic_core:GetModifierMagicalResistanceBonus()
-  return self:GetAbility():GetSpecialValueFor("bonus_magic_resist")
+  return self.bonus_magic_resist or self:GetAbility():GetSpecialValueFor("bonus_magic_resist")
 end
 
 --[[
@@ -122,6 +128,15 @@ function modifier_satanic_core_unholy:IsPurgable()
   return true
 end
 
+function modifier_satanic_core_unholy:OnCreated()
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.tooltip = ability:GetSpecialValueFor("unholy_hero_spell_lifesteal")
+  end
+end
+
+modifier_satanic_core_unholy.OnRefresh = modifier_satanic_core_unholy.OnCreated
+
 function modifier_satanic_core_unholy:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_TOOLTIP
@@ -129,7 +144,7 @@ function modifier_satanic_core_unholy:DeclareFunctions()
 end
 
 function modifier_satanic_core_unholy:OnTooltip()
-  return self:GetAbility():GetSpecialValueFor("unholy_hero_spell_lifesteal")
+  return self.tooltip
 end
 
 function modifier_satanic_core_unholy:GetEffectName()

--- a/game/scripts/vscripts/items/transformation/vampire.lua
+++ b/game/scripts/vscripts/items/transformation/vampire.lua
@@ -29,7 +29,17 @@ function modifier_item_vampire:OnCreated(keys)
   if not self.procRecords then
     self.procRecords = {}
   end
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.bonus_dmg = ability:GetSpecialValueFor("bonus_damage")
+    self.bonus_str = ability:GetSpecialValueFor("bonus_strength")
+    self.bonus_status_resist = ability:GetSpecialValueFor("bonus_status_resistance")
+    self.bonus_attack_speed = ability:GetSpecialValueFor("bonus_attack_speed")
+    self.bonus_night_vision = ability:GetSpecialValueFor("bonus_night_vision")
+  end
 end
+
+modifier_item_vampire.OnRefresh = modifier_item_vampire.OnCreated
 
 function modifier_item_vampire:DeclareFunctions()
   local funcs = {
@@ -46,27 +56,27 @@ function modifier_item_vampire:DeclareFunctions()
 end
 
 function modifier_item_vampire:GetModifierPreAttack_BonusDamage()
-  return self:GetAbility():GetSpecialValueFor("bonus_damage")
+  return self.bonus_dmg or self:GetAbility():GetSpecialValueFor("bonus_damage")
 end
 
 function modifier_item_vampire:GetModifierBonusStats_Strength()
-  return self:GetAbility():GetSpecialValueFor("bonus_strength")
+  return self.bonus_str or self:GetAbility():GetSpecialValueFor("bonus_strength")
 end
 
 function modifier_item_vampire:GetModifierStatusResistanceStacking()
   if not self:GetParent():HasModifier( "modifier_item_vampire_active" ) then
-    return self:GetAbility():GetSpecialValueFor("bonus_status_resistance")
+    return self.bonus_status_resist or self:GetAbility():GetSpecialValueFor("bonus_status_resistance")
   else
     return 0
   end
 end
 
 function modifier_item_vampire:GetModifierAttackSpeedBonus_Constant()
-  return self:GetAbility():GetSpecialValueFor("bonus_attack_speed")
+  return self.bonus_attack_speed or self:GetAbility():GetSpecialValueFor("bonus_attack_speed")
 end
 
 function modifier_item_vampire:GetBonusNightVision()
-  return self:GetAbility():GetSpecialValueFor("bonus_night_vision")
+  return self.bonus_night_vision or self:GetAbility():GetSpecialValueFor("bonus_night_vision")
 end
 
 -- Have to check for process_procs flag in OnAttackLanded as the flag won't be set in OnTakeDamage
@@ -108,10 +118,16 @@ function modifier_item_vampire_active:OnCreated()
     if not self.procRecords then
       self.procRecords = {}
     end
-    self:StartIntervalThink(1 / self:GetAbility():GetSpecialValueFor('ticks_per_second'))
-    self:GetParent():EmitSound("Vampire.Activate.Begin")
+    local parent = self:GetParent()
+    local ability = self:GetAbility()
+    local interval = 1/4
+    if ability and not ability:IsNull() then
+      interval = 1 / ability:GetSpecialValueFor("ticks_per_second")
+    end
+    self:StartIntervalThink(interval)
+    parent:EmitSound("Vampire.Activate.Begin")
     if self.nPreviewFX == nil then
-      self.nPreviewFX = ParticleManager:CreateParticle( "particles/items/vampire/vampire.vpcf", PATTACH_ABSORIGIN_FOLLOW, self:GetParent() )
+      self.nPreviewFX = ParticleManager:CreateParticle( "particles/items/vampire/vampire.vpcf", PATTACH_ABSORIGIN_FOLLOW, parent )
     end
   end
 end

--- a/game/scripts/vscripts/units/stopfightingyourself.lua
+++ b/game/scripts/vscripts/units/stopfightingyourself.lua
@@ -15,6 +15,9 @@ end
 local function UseAbility(ability, caster, target, maxRange)
   local randomPosition = RandomVector(maxRange) + caster:GetAbsOrigin()
   local behavior = ability:GetBehavior()
+  if type(behavior) == 'userdata' then
+    behavior = tonumber(tostring(behavior))
+  end
 
   -- Ability's behavior is
   if bit.band(behavior, DOTA_ABILITY_BEHAVIOR_PASSIVE) ~= 0 then --luacheck: ignore


### PR DESCRIPTION
* Fixed an error with boss resistance true sight when the boss is killed too fast.
* Fixed GetBehavior errors introduced with Diretide patch.
* Reflection Shard: Preventing Anti-Mage's Counter Spell and Mirror Shield reflected spells to be reflected by Reflection Shard. It was causing an infinite loop and server crash.
* Reflection Shard: Preventing Morphling Morph to be reflected by Reflection Shard. It was causing a server crash.
* Reflection Shard: Fixed custom unit-target abilities not being reflected.
* Added more ability nil checks to:
1) bloodstone.lua
2) greater_guardian_greaves.lua
3) satanic_core.lua
4) vampire.lua
* Bounty Runes: Fixed Alchemist passive not working with Bounty Runes (not multiplying the gold value for the Alchemist).
* Bounty Runes: Fixed an error when an entity without playerID picks up the rune.
* Bounty Runes: Added overhead number notification for the experience gained.