### PR TITLE
Cleave Spark update

### DIFF
--- a/game/scripts/vscripts/modifiers/sparks/modifier_spark_cleave.lua
+++ b/game/scripts/vscripts/modifiers/sparks/modifier_spark_cleave.lua
@@ -42,6 +42,10 @@ function modifier_spark_cleave:OnAttackLanded(keys)
     return
   end
 
+  if keys.no_attack_cooldown then
+    return
+  end
+
   -- To prevent crashes:
   if not target then
     return

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -105,7 +105,7 @@ BOTTLE_DESPAWN_TIME = 60                -- Time until Bottles despawn
 CREEP_POWER_MAX = 1.5                   -- the total max power creeps will get stacked up to (1 = 100%)
 CREEP_BOUNTY_SHARE_RADIUS = 1500        -- the radius in which creep bounty is shared with allies
 CREEP_BOUNTY_SHARE_PERCENT = 40         -- the percentage of the creep's bounty that's given to shared allies
-CREEP_BOUNTY_BONUS_PERCENT_CLEAVE = 15  -- the bonus percentage of the creep's bounty that's given to those that kill with Cleave Spark
+CREEP_BOUNTY_BONUS_PERCENT_CLEAVE = 25  -- the bonus percentage of the creep's bounty that's given to those that kill with Cleave Spark
 CREEP_BOUNTY_BONUS_PERCENT_POWER = 30   -- the bonus percentage of the creep's bounty that's given to those that kill with Power Spark
 
 -- Player


### PR DESCRIPTION
* Buffed Cleave spark bonus gold gain from 15% to 25%.
* Disabled instant attacks (attacks with 0 cd) working with Cleave Spark. 

List of abilities that have instant attacks can be found here: https://dota2.gamepedia.com/Attack_damage#Instant_attacks
In OAA, beside abilities that are mentioned there, we have Sohei E and R.
Instant attack interaction with cleave spark is a bullshit for some heroes (Sohei and Pangolier for example), and for some heroes only viable way of snowballing/flash-farming.

@chrisinajar I will let you decide if this is good for the game or not. I think its good, because it reduces ''one-shotting camps bullshit''. I think Max agrees with me, he wanted this removed since forever. I only recently found out how to fix it. We can always buff heroes that relied too much on this mechanic interaction in order to be good (Mars and Tidehunter for example). 
