### PR TITLE
Mars buffs

### DIFF
--- a/game/scripts/npc/abilities/mars_arena_of_blood.txt
+++ b/game/scripts/npc/abilities/mars_arena_of_blood.txt
@@ -56,7 +56,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "spear_damage"                                    "120 250 380 770 1160" //OAA
+        "spear_damage"                                    "120 250 380 770 1420" //OAA
       }
       "05"
       {

--- a/game/scripts/npc/abilities/mars_bulwark.txt
+++ b/game/scripts/npc/abilities/mars_bulwark.txt
@@ -21,7 +21,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "physical_damage_reduction"                       "25 35 45 55 65 75" //OAA
+        "physical_damage_reduction"                       "40 45 50 55 65 85" //OAA
       }
       "02"
       {

--- a/game/scripts/npc/abilities/mars_gods_rebuke.txt
+++ b/game/scripts/npc/abilities/mars_gods_rebuke.txt
@@ -81,7 +81,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage_vs_heroes"                          "35"
+        "bonus_damage_vs_heroes"                          "25 30 35 40 80 160" //OAA
       }
       "10"
       {

--- a/game/scripts/npc/abilities/mars_spear.txt
+++ b/game/scripts/npc/abilities/mars_spear.txt
@@ -37,7 +37,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage"                                          "100 175 250 325 650 975"
+        "damage"                                          "100 175 250 325 650 1300"
         "LinkedSpecialBonus"                              "special_bonus_unique_mars_spear_bonus_damage"
       }
       "02"


### PR DESCRIPTION
* Spear damage buffed at level 6 from 975 to 1300.
* God's Rebuke bonus damage against heroes increased from 35 to 25/30/35/40/80/160.
* Bulwark front attack damage reduction increased from 25/35/45/55/65/75% to 40/45/50/55/65/85%.
* Arena of Blood damage at level 5 increased from 1160 to 1420.