### PR TITLE
Wanderer tweaks

### DIFF
--- a/game/scripts/npc/abilities/wanderer/wanderer_point_aversion.txt
+++ b/game/scripts/npc/abilities/wanderer/wanderer_point_aversion.txt
@@ -25,7 +25,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage_per_point_difference"                     "25"
+        "damage_per_point_difference"                     "75"
       }
     }
   }

--- a/game/scripts/npc/units/wanderer/npc_dota_boss_wanderer.txt
+++ b/game/scripts/npc/units/wanderer/npc_dota_boss_wanderer.txt
@@ -222,6 +222,7 @@
     "Ability4"                                            "wanderer_point_aversion"
     "Ability5"                                            "boss_resistance"
     "Ability6"                                            "boss_regen"
+    "Ability7"                                            "siltbreaker_boss_protection"
 
     // Armor
     //----------------------------------------------------------------

--- a/game/scripts/vscripts/abilities/wanderer/oaa_wanderer_net.lua
+++ b/game/scripts/vscripts/abilities/wanderer/oaa_wanderer_net.lua
@@ -40,11 +40,11 @@ function wanderer_net:OnSpellStart()
   }
 
   ProjectileManager:CreateTrackingProjectile(info)
-  
+
   -- Calculate distance and max particle duration
   local distance = (target:GetAbsOrigin() - caster:GetAbsOrigin()):Length2D()
   local particle_duration = distance/speed
-  
+
   -- Apply the warning particle (with a modifier)
   target:AddNewModifier(caster, self, "modifier_wanderer_net_target", {duration = particle_duration})
 

--- a/game/scripts/vscripts/abilities/wanderer/oaa_wanderer_sticky_blood.lua
+++ b/game/scripts/vscripts/abilities/wanderer/oaa_wanderer_sticky_blood.lua
@@ -59,7 +59,7 @@ function modifier_wanderer_sticky_blood_passive:OnTakeDamage(event)
     local attacker = event.attacker
     local damage = event.damage
     local damaged_unit = event.unit
-    local caster = self:GetCaster() or self:GetParent()
+    local caster = self:GetParent() or self:GetCaster()
     local ability = self:GetAbility()
 
     -- Continue only if the caster/parent is the damaged unit
@@ -74,6 +74,11 @@ function modifier_wanderer_sticky_blood_passive:OnTakeDamage(event)
 
     -- If caster or ability don't exist -> don't continue
     if not caster or caster:IsNull() or not ability or ability:IsNull() then
+      return
+    end
+
+    -- if Wanderer is not aggroed -> don't continue (It will continue if caster.isAggro is true or nil - intentional)
+    if caster.isAggro == false then
       return
     end
 

--- a/game/scripts/vscripts/components/boss/wanderer.lua
+++ b/game/scripts/vscripts/components/boss/wanderer.lua
@@ -42,6 +42,7 @@ function Wanderer:SpawnWanderer ()
   self.level = self.level + 1
 
   local bossHandle = CreateUnitByName("npc_dota_boss_wanderer_" .. math.min(3, self.level), Vector(0, 0, 0), true, nil, nil, DOTA_TEAM_NEUTRALS)
+  bossHandle.BossTier = self.level + 2
   self.wanderer = bossHandle
 
   -- reward handling
@@ -85,7 +86,6 @@ function Wanderer:SpawnWanderer ()
           end
         end
       end)
-
     end)
     -- Give the thinker some vision so that spectators can always see the capture point
     capturePointThinker:SetDayTimeVisionRange(1)


### PR DESCRIPTION
* Point Aversion bonus damage per point difference increased from 25 to 75.
* Increased boss tier (for boss regen and degen) from 1 to 3/4/5. This means all Wanderers will be harder to kill with Bleeding.
* Each Wanderer kill increases its regen tier. This means Wanderers that spawn after Wanderer 3 (wanderers that give only points) will be way harder to kill with Bleeding.
* Spawning Wanderer with a cheat will set the regen tier to 3.
* Added more comments to ai_wanderer.lua and did some cleanup.
* Wanderers 3 and those that spawn after now have Siltbreaker protection (immunity to most stuns and silences).
I am still thinking about if Wanderer 2 should have this as well because normal tier 3 bosses and some tier 4 bosses have this Siltbreaker protection and they are not that hard to kill.
* Disable Sticky Blood proccing if Wanderer is not aggroed.