### PR TITLE
Lina nerfs

### DIFF
--- a/game/scripts/npc/abilities/lina_fiery_soul.txt
+++ b/game/scripts/npc/abilities/lina_fiery_soul.txt
@@ -20,7 +20,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "fiery_soul_attack_speed_bonus"                   "40 55 70 85 100 140"
+        "fiery_soul_attack_speed_bonus"                   "40 55 70 85 100 130"
         "LinkedSpecialBonus"                              "special_bonus_unique_lina_2"
       }
       "02"

--- a/game/scripts/npc/abilities/talents/lina_talent2.txt
+++ b/game/scripts/npc/abilities/talents/lina_talent2.txt
@@ -1,32 +1,32 @@
 "DOTAAbilities"
 {
   //=================================================================================================================
-	// Bonus AS/MS Fiery Soul Per Stack
-	//=================================================================================================================
-	"special_bonus_unique_lina_2"
-	{
-		// General
-		//-------------------------------------------------------------------------------------------------------------
-		"ID"					"6313"														// unique ID number for this ability.  Do not change this once established or it will invalidate collected stats.
-		"AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
-		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+  // Bonus AS/MS Fiery Soul Per Stack
+  //=================================================================================================================
+  "special_bonus_unique_lina_2"
+  {
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "ID"					"6313"														// unique ID number for this ability.  Do not change this once established or it will invalidate collected stats.
+    "AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
+    "AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
 
-		// Special
-		//-------------------------------------------------------------------------------------------------------------
-		"AbilitySpecial"
-		{
-			"01"
-			{
-				"var_type"					"FIELD_INTEGER"
-				"value"				"45" //OAA
-        "ad_linked_ability"			"lina_fiery_soul"
-			}
-			"02"
-			{
-				"var_type"					"FIELD_FLOAT"
-				"value2"				"2.0" //OAA
-        "ad_linked_ability"			"lina_fiery_soul"
-			}
-		}
-	}
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "value"                                           "30"
+        "ad_linked_ability"                               "lina_fiery_soul"
+      }
+      "02"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "value2"                                          "2.0" //OAA
+        "ad_linked_ability"                               "lina_fiery_soul"
+      }
+    }
+  }
 }

--- a/game/scripts/npc/heroes/lina.txt
+++ b/game/scripts/npc/heroes/lina.txt
@@ -7,7 +7,7 @@
   {
     // Abilities
     //-------------------------------------------------------------------------------------------------------------
-    "Ability10"                                           "special_bonus_attack_damage_75" // replaces special_bonus_attack_damage_30
+    "Ability10"                                           "special_bonus_attack_damage_60" // replaces special_bonus_attack_damage_30
     "Ability12"                                           "special_bonus_hp_500" // replaces special_bonus_hp_300
   }
 }


### PR DESCRIPTION
* Fiery Soul bonus attack speed per stack reduced at level 6 from 140 to 130.
* Level 10 Talent: +75 Damage reduced to +60.
* Level 20 Talent: +45/2% Fiery Soul AS/MS per stack reduced to +30/2%.