### PR TITLE
Giant Form and Hurricane Pike strength buff

### DIFF
--- a/game/scripts/npc/items/custom/item_giant_form.txt
+++ b/game/scripts/npc/items/custom/item_giant_form.txt
@@ -70,7 +70,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "42 62"
+        "bonus_strength"                                  "50 70"
       }
       "03" // ranged only
       {

--- a/game/scripts/npc/items/custom/item_giant_form_2.txt
+++ b/game/scripts/npc/items/custom/item_giant_form_2.txt
@@ -69,7 +69,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "42 62"
+        "bonus_strength"                                  "50 70"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_hurricane_pike.txt
+++ b/game/scripts/npc/items/item_hurricane_pike.txt
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "12 17 27 42 62" //OAA
+        "bonus_strength"                                  "15 20 30 45 65"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_hurricane_pike_2.txt
+++ b/game/scripts/npc/items/item_hurricane_pike_2.txt
@@ -83,7 +83,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "12 17 27 42 62" //OAA
+        "bonus_strength"                                  "15 20 30 45 65"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_hurricane_pike_3.txt
+++ b/game/scripts/npc/items/item_hurricane_pike_3.txt
@@ -83,7 +83,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "12 17 27 42 62" //OAA
+        "bonus_strength"                                  "15 20 30 45 65"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_hurricane_pike_4.txt
+++ b/game/scripts/npc/items/item_hurricane_pike_4.txt
@@ -83,7 +83,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "12 17 27 42 62" //OAA
+        "bonus_strength"                                  "15 20 30 45 65"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_hurricane_pike_5.txt
+++ b/game/scripts/npc/items/item_hurricane_pike_5.txt
@@ -84,7 +84,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "12 17 27 42 62" //OAA
+        "bonus_strength"                                  "15 20 30 45 65"
       }
       "05"
       {


### PR DESCRIPTION
* Hurricane Pike bonus strength increased from 12/17/27/42/62 to 15/20/30/45/65. This was nerfed for no reason.
* Giant Form bonus strength increased from 42/62 to 50/70. (to match bonus AGI, thematically giants have more strength etc.)
