### PR TITLE
Hand of Midas buffs

### DIFF
--- a/game/scripts/npc/items/item_hand_of_midas.txt
+++ b/game/scripts/npc/items/item_hand_of_midas.txt
@@ -16,7 +16,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "1750"
+    "ItemCost"                                            "1500"
     "ItemShopTags"                                        ""
     "ItemAliases"                                         "hom"
 
@@ -24,7 +24,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "ItemRecipe"                                          "1"
     "ItemResult"                                          "item_hand_of_midas_1"
-    "AbilityTextureName"                                  "item_recipe"
+
     "ItemRequirements"
     {
       "01"                                                "item_gloves"
@@ -59,7 +59,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "0"
-    "ItemCost"                                            "2200"
+    "ItemCost"                                            "1950"
     "ItemShopTags"                                        "attack_speed;hard_to_tag"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "hand of midas;midas"
@@ -77,12 +77,12 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "xp_multiplier"                                   "2.1 3 4"
+        "xp_multiplier"                                   "2 4 6"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_gold"                                      "160 350 550"
+        "bonus_gold"                                      "150 350 550"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_hand_of_midas_2.txt
+++ b/game/scripts/npc/items/item_hand_of_midas_2.txt
@@ -14,7 +14,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "2000"
+    "ItemCost"                                            "2250"
     "ItemShopTags"                                        ""
     "ItemAliases"                                         "hom"
 
@@ -22,6 +22,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "ItemRecipe"                                          "1"
     "ItemResult"                                          "item_hand_of_midas_2"
+
     "ItemRequirements"
     {
       "01"                                                "item_hand_of_midas_1"
@@ -74,12 +75,12 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "xp_multiplier"                                   "2.1 3 4"
+        "xp_multiplier"                                   "2 4 6"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_gold"                                      "160 350 550"
+        "bonus_gold"                                      "150 350 550"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_hand_of_midas_3.txt
+++ b/game/scripts/npc/items/item_hand_of_midas_3.txt
@@ -10,6 +10,7 @@
     "ID"                                                  "3185"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "BaseClass"                                           "item_datadriven"
     "Model"                                               "models/props_gameplay/recipe.mdl"
+    "AbilityTextureName"                                  "item_recipe"
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
@@ -21,7 +22,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "ItemRecipe"                                          "1"
     "ItemResult"                                          "item_hand_of_midas_3"
-    "AbilityTextureName"                                  "item_recipe"
+
     "ItemRequirements"
     {
       "01"                                                "item_hand_of_midas_2"
@@ -74,12 +75,12 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "xp_multiplier"                                   "2.1 3 4"
+        "xp_multiplier"                                   "2 4 6"
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_gold"                                      "160 350 550"
+        "bonus_gold"                                      "150 350 550"
       }
       "04"
       {

--- a/game/scripts/vscripts/items/hand_of_midas.lua
+++ b/game/scripts/vscripts/items/hand_of_midas.lua
@@ -42,7 +42,7 @@ function item_hand_of_midas_1:OnSpellStart()
   if player then
     -- Overhead gold amount popup
     SendOverheadEventMessage(player, OVERHEAD_ALERT_GOLD, target, bonusGold, player)
-    -- If the Hand of Midas user is a Spirit Bear or Arc Warden Temepest Double:
+    -- If the Hand of Midas user is a Spirit Bear or Arc Warden Tempest Double:
     if not caster:IsHero() or caster:IsTempestDouble() then
       caster = player:GetAssignedHero()
     end


### PR DESCRIPTION
* Hand of Midas 1 recipe cost reduced from 1750 to 1500.
* Hand of Midas 2 recipe cost increased from 2000 to 2250.
* Hand of Midas experience multiplier rescaled from 2.1/3/4 to 2/4/6.
* Hand of Midas 1 bonus gold reduced from 160 to 150.