### PR TITLE
GPM and Midas spark changes

### DIFF
--- a/content/panorama/layout/custom_game/spark_selection.xml
+++ b/content/panorama/layout/custom_game/spark_selection.xml
@@ -11,7 +11,7 @@
   <Panel class="SparkSelectionHolder" hittest='false'>
     <Button class='PopupButton' id="ChangeSpark" onactivate='OpenSparkSelection()'>
       <Label id='ChangeSparkCooldown' text='69'/>
-      <Label text='Change Spark'/>
+      <Label text='#spark_selection_button'/>
     </Button>
     <Panel id='SparkSelection'>
       <Panel class='TopLabel'>
@@ -29,10 +29,10 @@
               </Panel>
 
               <Panel class='TopLabel'>
-                <Label text='GPM'/>
+                <Label text='#spark_selection_gpm'/>
               </Panel>
               <Panel class='Description'>
-                <Label text='Gain additional gold passively over time'/>
+                <Label text='#spark_selection_gpm_desc'/>
               </Panel>
             </Panel>
             <Panel class='SparkPanel' id='midasPanel' onactivate='SelectSpark("midas")'>
@@ -41,10 +41,10 @@
               </Panel>
 
               <Panel class='TopLabel'>
-                <Label text='Midas'/>
+                <Label text='#spark_selection_midas'/>
               </Panel>
               <Panel class='Description'>
-                <Label text='One-shot creeps for bonus gold on a cooldown.'/>
+                <Label text='#spark_selection_midas_desc'/>
               </Panel>
             </Panel>
           </Panel>
@@ -60,13 +60,13 @@
               </Panel>
 
               <Panel class='TopLabel'>
-                <Label text='Power'/>
+                <Label text='#spark_selection_power'/>
               </Panel>
               <Panel class='Description'>
-                <Label text='Attacks deal additional pure damage to creeps.'/>
+                <Label text='#spark_selection_power_desc'/>
               </Panel>
               <Panel class='Description'>
-                <Label text='Gains bonus gold on creep kills.'/>
+                <Label text='#spark_selection_bonus_gold'/>
               </Panel>
             </Panel>
             <Panel class='SparkPanel' id='cleavePanel' onactivate='SelectSpark("cleave")'>
@@ -75,16 +75,16 @@
               </Panel>
 
               <Panel class='TopLabel'>
-                <Label text='Cleave'/>
+                <Label text='#spark_selection_cleave'/>
               </Panel>
               <Panel class='Description'>
-                <Label text='Attacks splinter to nearby creeps.'/>
+                <Label text='#spark_selection_cleave_desc'/>
               </Panel>
               <Panel class='Description'>
                 &nbsp;
               </Panel>
               <Panel class='Description'>
-                <Label text='Gains bonus gold on creep kills.'/>
+                <Label text='#spark_selection_bonus_gold'/>
               </Panel>
             </Panel>
           </Panel>

--- a/game/resource/English/modifier/tooltip_modifier_sparks.txt
+++ b/game/resource/English/modifier/tooltip_modifier_sparks.txt
@@ -1,11 +1,11 @@
 "DOTA_Tooltip_modifier_spark_cleave"                      "Cleave Spark"
-"DOTA_Tooltip_modifier_spark_cleave_Description"          "Deals 50%% of attack damage as physical damage to up to 4 random neutral creeps in 400 radius around the attacked target. 15%% more gold from killing neutral creeps."
+"DOTA_Tooltip_modifier_spark_cleave_Description"          "Deals 50%% of attack damage as physical damage to up to 4 random neutral creeps in 400 radius around the attacked target. 25%% more gold from killing neutral creeps."
 
 "DOTA_Tooltip_modifier_spark_gpm"                         "GPM Spark"
-"DOTA_Tooltip_modifier_spark_gpm_Description"             "Grants %dMODIFIER_PROPERTY_TOOLTIP% unreliable gold per minute."
+"DOTA_Tooltip_modifier_spark_gpm_Description"             "Grants %dMODIFIER_PROPERTY_TOOLTIP% gold per minute."
 
-"DOTA_Tooltip_modifier_spark_midas"                       "Midas Spark"
-"DOTA_Tooltip_modifier_spark_midas_Description"           "Generate charges every second. At 100 charges, your next attack on a non-ancient neutral creep will instantly kill it for %dMODIFIER_PROPERTY_TOOLTIP% additional gold."
+"DOTA_Tooltip_modifier_spark_midas"                       "XP Spark"
+"DOTA_Tooltip_modifier_spark_midas_Description"           "Generates 2 charges every second. At 100 charges, your next attack on a non-ancient neutral creep will instantly kill it for %dMODIFIER_PROPERTY_TOOLTIP% additional gold and 25%% extra experience."
 
 "DOTA_Tooltip_modifier_spark_power"                       "Power Spark"
 "DOTA_Tooltip_modifier_spark_power_Description"           "Bonus %dMODIFIER_PROPERTY_TOOLTIP% pure damage against neutral creeps. 30%% more gold from killing neutral creeps."

--- a/game/resource/English/panorama/spark_selection.txt
+++ b/game/resource/English/panorama/spark_selection.txt
@@ -1,6 +1,21 @@
 //=============================================================================
 // Farming spark selection UI
 //=============================================================================
-"spark_selection_header"              "Select Your Farming Spark"
-"spark_selection_support"             "Gold Generating"
-"spark_selection_carry"               "Creep Killing"
+"spark_selection_button"              "Change Spark"
+"spark_selection_header"              "Select Your Spark"
+"spark_selection_support"             "Support"
+"spark_selection_carry"               "Farming"
+
+"spark_selection_gpm"                 "GPM"
+"spark_selection_gpm_desc"            "Gain additional gold passively over time."
+
+"spark_selection_midas"               "XP"
+"spark_selection_midas_desc"          "One-shot a non-ancient creep for bonus gold and experience when off cooldown."
+
+"spark_selection_power"               "Power"
+"spark_selection_power_desc"          "Attacks deal additional pure damage to creeps."
+
+"spark_selection_cleave"              "Cleave"
+"spark_selection_cleave_desc"         "Attacks splinter to nearby creeps."
+
+"spark_selection_bonus_gold"          "Gains bonus gold on creep kills."

--- a/game/scripts/vscripts/modifiers/sparks/modifier_spark_gpm.lua
+++ b/game/scripts/vscripts/modifiers/sparks/modifier_spark_gpm.lua
@@ -6,6 +6,7 @@ end
 
 modifier_spark_gpm.OnRefresh = modifier_spark_gpm.OnCreated
 
+--[[
 function modifier_spark_gpm:GetSparkLevel()
   local gameTime = HudTimer:GetGameTime()
 
@@ -25,28 +26,39 @@ function modifier_spark_gpm:GetSparkLevel()
 
   return 1
 end
+]]
 
 function modifier_spark_gpm:GetTexture()
   return "custom/spark_gpm"
 end
 
-if IsServer() then
-  function modifier_spark_gpm:OnIntervalThink()
-    if not PlayerResource then
-      -- sometimes for no reason the player resource isn't there, usually only at the start of games in tools mode
-      return
-    end
-    local caster = self:GetParent()
-    local gpmChart = {500, 1800, 3200, 5500, 10000}
-    local gpm = gpmChart[self:GetSparkLevel()]
-    -- Don't give gold on illusions, Tempest Doubles, or Meepo clones, or during duels
-    if caster:IsIllusion() or caster:IsTempestDouble() or caster:IsClone() or not Gold:IsGoldGenActive() then
-      return
-    end
-    Gold:ModifyGold(caster:GetPlayerOwnerID(), gpm / 60, true, DOTA_ModifyGold_GameTick)
-
-    self:SetStackCount(gpm)
+function modifier_spark_gpm:OnIntervalThink()
+  if not IsServer() then
+    return
   end
+
+  if not HudTimer or not Gold then
+    return
+  end
+
+  local caster = self:GetParent()
+  local gpm = self:CalculateGPM()
+
+  -- Don't give gold on illusions, Tempest Doubles, or Meepo clones, or during duels
+  if caster:IsIllusion() or caster:IsTempestDouble() or caster:IsClone() or not Gold:IsGoldGenActive() then
+    return
+  end
+
+  Gold:ModifyGold(caster:GetPlayerOwnerID(), math.ceil(gpm / 60), true, DOTA_ModifyGold_GameTick)
+
+  self:SetStackCount(gpm)
+end
+
+function modifier_spark_gpm:CalculateGPM()
+  local gameTime = HudTimer:GetGameTime()
+  --local gpmChart = {500, 1800, 3200, 5500, 10000}
+  --local gpm = gpmChart[self:GetSparkLevel()]
+  return math.floor(gpm)
 end
 
 function modifier_spark_gpm:IsHidden()

--- a/game/scripts/vscripts/modifiers/sparks/modifier_spark_gpm.lua
+++ b/game/scripts/vscripts/modifiers/sparks/modifier_spark_gpm.lua
@@ -6,15 +6,21 @@ end
 
 modifier_spark_gpm.OnRefresh = modifier_spark_gpm.OnCreated
 
---[[
 function modifier_spark_gpm:GetSparkLevel()
   local gameTime = HudTimer:GetGameTime()
 
-  if not SPARK_LEVEL_1_TIME then
-    return 1
-  end
+  local SPARK_LEVEL_2_TIME = 300                -- 5 minutes
+  local SPARK_LEVEL_3_TIME = 600                -- 10 minutes
+  local SPARK_LEVEL_4_TIME = 900                -- 15 minutes
+  local SPARK_LEVEL_5_TIME = 1500               -- 25 minutes
+  local SPARK_LEVEL_6_TIME = 2100               -- 35 minutes
+  local SPARK_LEVEL_7_TIME = 2700               -- 45 minutes
 
-  if gameTime > SPARK_LEVEL_5_TIME then
+  if gameTime > SPARK_LEVEL_7_TIME then
+    return 7
+  elseif gameTime > SPARK_LEVEL_6_TIME then
+    return 6
+  elseif gameTime > SPARK_LEVEL_5_TIME then
     return 5
   elseif gameTime > SPARK_LEVEL_4_TIME then
     return 4
@@ -26,7 +32,6 @@ function modifier_spark_gpm:GetSparkLevel()
 
   return 1
 end
-]]
 
 function modifier_spark_gpm:GetTexture()
   return "custom/spark_gpm"
@@ -42,22 +47,23 @@ function modifier_spark_gpm:OnIntervalThink()
   end
 
   local caster = self:GetParent()
-  local gpm = self:CalculateGPM()
 
   -- Don't give gold on illusions, Tempest Doubles, or Meepo clones, or during duels
   if caster:IsIllusion() or caster:IsTempestDouble() or caster:IsClone() or not Gold:IsGoldGenActive() then
     return
   end
 
+  local gpm = self:CalculateGPM()
   Gold:ModifyGold(caster:GetPlayerOwnerID(), math.ceil(gpm / 60), true, DOTA_ModifyGold_GameTick)
 
   self:SetStackCount(gpm)
 end
 
+-- Formula for GPM scaling
 function modifier_spark_gpm:CalculateGPM()
-  local gameTime = HudTimer:GetGameTime()
-  --local gpmChart = {500, 1800, 3200, 5500, 10000}
-  --local gpm = gpmChart[self:GetSparkLevel()]
+  local gpmChart = {500, 1000, 2000, 4000, 6000, 10000, 20000}
+  local gpm = gpmChart[self:GetSparkLevel()]
+
   return math.floor(gpm)
 end
 

--- a/game/scripts/vscripts/modifiers/sparks/modifier_spark_midas.lua
+++ b/game/scripts/vscripts/modifiers/sparks/modifier_spark_midas.lua
@@ -33,8 +33,8 @@ function modifier_spark_midas:OnCreated()
   -- Midas Spark variables
   self.max_charges = 400
   self.charges_needed_for_kill = 100
-  self.bonus_gold = {300, 1300, 2300, 4300, 8300} -- max allowed values: {400, 1500, 2600, 4500, 8300} - which is slightly less than gpm spark
-  self.bonus_xp = {0, 0, 0, 0, 0}
+  self.bonus_gold = {375, 750, 1500, 3000, 4500, 7500, 15000} -- gpmChart = {500, 1000, 2000, 4000, 6000, 10000, 20000} * 3/4
+  self.bonus_xp = 25 -- 1/4
 end
 
 if IsServer() then
@@ -42,7 +42,7 @@ if IsServer() then
     local parent = self:GetParent()
 
     -- disable everything here for illusions or during duels / pre 0:00
-    if parent:IsIllusion() or not Gold:IsGoldGenActive() then
+    if parent:IsIllusion() or parent:IsTempestDouble() or parent:IsClone() or not Gold:IsGoldGenActive() then
       return
     end
 
@@ -61,15 +61,18 @@ function modifier_spark_midas:GetSparkLevel()
     gameTime = GameRules:GetDOTATime(false, false) - (self:GetStackCount() / 2)
   end
 
-  if not SPARK_LEVEL_1_TIME then
-    SPARK_LEVEL_1_TIME = 0
-    SPARK_LEVEL_2_TIME = 240
-    SPARK_LEVEL_3_TIME = 900
-    SPARK_LEVEL_4_TIME = 1500
-    SPARK_LEVEL_5_TIME = 2100
-  end
+  local SPARK_LEVEL_2_TIME = 300                -- 5 minutes
+  local SPARK_LEVEL_3_TIME = 600                -- 10 minutes
+  local SPARK_LEVEL_4_TIME = 900                -- 15 minutes
+  local SPARK_LEVEL_5_TIME = 1500               -- 25 minutes
+  local SPARK_LEVEL_6_TIME = 2100               -- 35 minutes
+  local SPARK_LEVEL_7_TIME = 2700               -- 45 minutes
 
-  if gameTime > SPARK_LEVEL_5_TIME then
+  if gameTime > SPARK_LEVEL_7_TIME then
+    return 7
+  elseif gameTime > SPARK_LEVEL_6_TIME then
+    return 6
+  elseif gameTime > SPARK_LEVEL_5_TIME then
     return 5
   elseif gameTime > SPARK_LEVEL_4_TIME then
     return 4
@@ -134,7 +137,7 @@ if IsServer() then
       local spark_level = self:GetSparkLevel()
 
       local bonus_gold = self.bonus_gold[spark_level]
-      local bonus_xp = self.bonus_xp[spark_level]
+      local bonus_xp = self.bonus_xp
 
       -- bonus gold
       Gold:ModifyGold(player:GetPlayerID(), bonus_gold, false, DOTA_ModifyGold_CreepKill)
@@ -142,7 +145,10 @@ if IsServer() then
 
       -- bonus experience
       if bonus_xp > 0 then
+        local XPBounty = target:GetDeathXP()
+        bonus_xp = bonus_xp * XPBounty / 100
         parent:AddExperience(bonus_xp, DOTA_ModifyXP_CreepKill, false, true)
+        SendOverheadEventMessage(player, OVERHEAD_ALERT_XP, parent, bonus_xp, player)
       end
 
       -- particle

--- a/game/scripts/vscripts/modifiers/sparks/modifier_spark_power.lua
+++ b/game/scripts/vscripts/modifiers/sparks/modifier_spark_power.lua
@@ -112,27 +112,6 @@ function modifier_spark_power:OnIntervalThink()
     self:SetStackCount(self.bonus_damage)
   end
 end
---[[
-function modifier_spark_power:GetSparkLevel()
-  local gameTime = HudTimer:GetGameTime()
-
-  if not SPARK_LEVEL_1_TIME then
-    return 1
-  end
-
-  if gameTime > SPARK_LEVEL_5_TIME then
-    return 5
-  elseif gameTime > SPARK_LEVEL_4_TIME then
-    return 4
-  elseif gameTime > SPARK_LEVEL_3_TIME then
-    return 3
-  elseif gameTime > SPARK_LEVEL_2_TIME then
-    return 2
-  end
-
-  return 1
-end
-]]
 
 function modifier_spark_power:DeclareFunctions()
   return {

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -75,13 +75,6 @@ DUEL_RUNE_TIMER = 30                    -- how long until the highground object 
 DUEL_INTERVAL = 480                     -- time from duel ending until dnext duel countdown begins
 DUEL_START_PROTECTION_TIME = 2          -- duel start protection duration
 
--- Sparks
-SPARK_LEVEL_1_TIME = 0                  -- just a placeholder so the other names make more sense
-SPARK_LEVEL_2_TIME = 240                -- 4 minutes
-SPARK_LEVEL_3_TIME = 900                -- 15 minutes
-SPARK_LEVEL_4_TIME = 1500               -- 25 minutes
-SPARK_LEVEL_5_TIME = 2100               -- 35 minutes
-
 -- CapturePoints
 INITIAL_CAPTURE_POINT_DELAY = 660       -- how long after the clock hits 0 should the initial Capture Point start counting down
 CAPTURE_FIRST_WARN = 60                 -- how many seconds before spawn of capture points the first ping on minimap will show


### PR DESCRIPTION
* GPM spark rescaled:
1) Upgrading times changed from 4/15/25/35 minutes to 5/10/15/25/35/45 minutes.
2) GPM changed from 1800/3200/5500/10000 to 1000/2000/4000/6000/10000/20000.
* Tooltips:
1) Added spark selection screen tooltips all to one place and made it possible for people to translate parts of it.
2) Renamed Midas spark to XP spark.
3) Updated spark modifier tooltips.
4) Updated spark selection screen tooltips.
* Midas/XP parity temporary rework: Reduced gold gain but it also gives bonus xp on creep kill.

Reasons for this? 
GPM scales too hard, at 4 minutes it jumps from 500 to 1800 and gives too much gold. And after 35 min you need more gold than you have.
Midas spark is known for being bad, this is an experimental change to see if this will make it good but not op.