### PR TITLE
Another Wanderer update

### DIFF
--- a/game/resource/English/ability/units/tooltip_boss_wanderer.txt
+++ b/game/resource/English/ability/units/tooltip_boss_wanderer.txt
@@ -6,9 +6,10 @@
 "DOTA_Tooltip_modifier_wanderer_team_buff_Description"    "Bonus 20%% movement speed, and 20%% attack damage"
 
 "DOTA_Tooltip_ability_wanderer_aoe_cleanse"                                     "Cleanse"
-"DOTA_Tooltip_ability_wanderer_aoe_cleanse_Description"                         "When below half health, Wanderer tries to cleanse vermin around him. Applies knockback, purges and damages to enemies around him. Kills player-controlled wards."
+"DOTA_Tooltip_ability_wanderer_aoe_cleanse_Description"                         "When below half health, Wanderer tries to cleanse vermin around him. Applies knockback, purge and damage to enemies around him. Kills player-controlled wards."
 "DOTA_Tooltip_ability_wanderer_aoe_cleanse_radius"                              "RADIUS:"
-"DOTA_Tooltip_ability_wanderer_aoe_cleanse_damage"                              "DAMAGE:"
+"DOTA_Tooltip_ability_wanderer_aoe_cleanse_damage"                              "BASE DAMAGE:"
+"DOTA_Tooltip_ability_wanderer_aoe_cleanse_max_hp_percent"                      "%MAX HP AS DAMAGE:"
 
 "DOTA_Tooltip_ability_wanderer_net"                                             "Wanderer's Net"
 "DOTA_Tooltip_ability_wanderer_net_Description"                                 "Roots, breaks and disables healing."

--- a/game/scripts/npc/abilities/wanderer/wanderer_aoe_cleanse.txt
+++ b/game/scripts/npc/abilities/wanderer/wanderer_aoe_cleanse.txt
@@ -39,7 +39,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage"                                          "2500"
+        "damage"                                          "5000"
       }
       "03"
       {

--- a/game/scripts/npc/abilities/wanderer/wanderer_aoe_cleanse.txt
+++ b/game/scripts/npc/abilities/wanderer/wanderer_aoe_cleanse.txt
@@ -39,7 +39,12 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage"                                          "5000"
+        "damage"                                          "2500"
+      }
+      "03"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "max_hp_percent"                                  "50"
       }
     }
   }

--- a/game/scripts/npc/abilities/wanderer/wanderer_sticky_blood.txt
+++ b/game/scripts/npc/abilities/wanderer/wanderer_sticky_blood.txt
@@ -19,7 +19,7 @@
 
     "MaxLevel"                                            "1"
 
-    "AbilityCooldown"                                     "3.0"
+    "AbilityCooldown"                                     "1.0"
 
     "AbilityManaCost"                                     "0"
 

--- a/game/scripts/npc/units/wanderer/npc_dota_boss_wanderer.txt
+++ b/game/scripts/npc/units/wanderer/npc_dota_boss_wanderer.txt
@@ -24,6 +24,7 @@
     "Ability4"                                            "wanderer_point_aversion"
     "Ability5"                                            "boss_resistance"
     "Ability6"                                            "boss_regen"
+    "Ability7"                                            "siltbreaker_boss_protection"
 
     // Armor
     //----------------------------------------------------------------
@@ -123,6 +124,7 @@
     "Ability4"                                            "wanderer_point_aversion"
     "Ability5"                                            "boss_resistance"
     "Ability6"                                            "boss_regen"
+    "Ability7"                                            "siltbreaker_boss_protection"
 
     // Armor
     //----------------------------------------------------------------

--- a/game/scripts/vscripts/abilities/wanderer/oaa_wanderer_aoe_cleanse.lua
+++ b/game/scripts/vscripts/abilities/wanderer/oaa_wanderer_aoe_cleanse.lua
@@ -38,6 +38,7 @@ function wanderer_aoe_cleanse:OnSpellStart()
   local caster = self:GetCaster()
   local radius = self:GetSpecialValueFor("radius")
   local damage = self:GetSpecialValueFor("damage")
+  local hp_percent = self:GetSpecialValueFor("max_hp_percent")
 
   local caster_location = caster:GetAbsOrigin()
 
@@ -78,20 +79,24 @@ function wanderer_aoe_cleanse:OnSpellStart()
     false
   )
 
+  -- Damage table constants
+  local damage_table = {}
+  damage_table.attacker = caster
+  damage_table.damage_type = DAMAGE_TYPE_PHYSICAL
+  damage_table.damage_flags = DOTA_DAMAGE_FLAG_BYPASSES_BLOCK
+  damage_table.ability = self
+
   for _, enemy in pairs(enemies) do
     if enemy and not enemy:IsNull() and not enemy:IsMagicImmune() and not enemy:IsInvulnerable() then
       -- Purge - Offensive Basic Dispel - removes buffs
       enemy:Purge(true, false, false, false, false)
       -- Apply knockback
       enemy:AddNewModifier(caster, self, "modifier_knockback", knockback_table)
-      -- Apply Damage
-      local damage_table = {}
+      -- Damage table variables
       damage_table.victim = enemy
-      damage_table.attacker = caster
-      damage_table.damage = damage
-      damage_table.damage_type = DAMAGE_TYPE_PHYSICAL
-      damage_table.damage_flags = DOTA_DAMAGE_FLAG_BYPASSES_BLOCK
-      damage_table.ability = self
+      -- Calculate damage
+      damage_table.damage = damage + enemy:GetMaxHealth() * hp_percent
+      -- Apply Damage
       ApplyDamage(damage_table)
     end
   end


### PR DESCRIPTION
* Cleanse damage changed from 5000 to 5000+50% of max hp. Reminder: Its physical damage that can be blocked with spell immunity. And for reference, Swiper's damage is 6500.
* Added Siltbreaker boss protection to all Wanderers.
* Sticky Blood cooldown reduced from 3 to 1 second.