### PR TITLE
Boots of Travel update

### DIFF
--- a/game/resource/English/ability/items/tooltip_greater_travel_boots.txt
+++ b/game/resource/English/ability/items/tooltip_greater_travel_boots.txt
@@ -6,7 +6,7 @@
 "DOTA_Tooltip_Ability_item_greater_travel_boots_Description"                    "#{item_greater_travel_boots_ability_Description}"
 "DOTA_Tooltip_Ability_item_greater_travel_boots_Lore"                           "The boots of a once renowned legendary merchant."
 "DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_movement_speed"           "+$move_speed"
-"item_greater_travel_boots_ability_Description"                                 "<h1>Active: Teleport</h1> Teleports you to any allied structure or unit, including heroes. Teleporting to a unit is interrupted if the target unit dies."
+"item_greater_travel_boots_ability_Description"                                 "<h1>Active: Teleport</h1> Teleports you to any allied structure or unit, including heroes. Teleporting is interrupted if the target dies or if you become rooted."
 
 "DOTA_Tooltip_Ability_item_greater_travel_boots_2"                              "#{DOTA_Tooltip_Ability_item_greater_travel_boots}"
 "DOTA_Tooltip_Ability_item_recipe_greater_travel_boots_2"                       "#{DOTA_Tooltip_Ability_item_recipe_greater_travel_boots}"
@@ -31,6 +31,12 @@
 "DOTA_Tooltip_Ability_item_greater_travel_boots_5_Description"                  "#{DOTA_Tooltip_Ability_item_greater_travel_boots_Description}"
 "DOTA_Tooltip_Ability_item_greater_travel_boots_5_Lore"                         "#{DOTA_Tooltip_Ability_item_greater_travel_boots_Lore}"
 "DOTA_Tooltip_Ability_item_greater_travel_boots_5_bonus_movement_speed"         "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_movement_speed}"
+
+"DOTA_Tooltip_Ability_item_travel_boots_oaa"                                    "#{DOTA_Tooltip_Ability_item_travel_boots}"
+"DOTA_Tooltip_Ability_item_recipe_travel_boots_oaa"                             "#{DOTA_Tooltip_Ability_item_recipe_travel_boots}"
+"DOTA_Tooltip_Ability_item_travel_boots_oaa_Description"                        "<h1>Active: Teleport</h1> Teleports you to any allied structure or unit, but not to heroes. Teleporting is interrupted if the target dies or if you become rooted. \nMovement speed bonuses from multiple pairs of boots do not stack."
+"DOTA_Tooltip_Ability_item_travel_boots_oaa_Lore"                               "#{DOTA_Tooltip_ability_item_travel_boots_Lore}"
+"DOTA_Tooltip_Ability_item_travel_boots_oaa_bonus_movement_speed"               "+$move_speed"
 
 //"DOTA_Tooltip_Ability_item_travel_origin"                                       "Travel Spark"
 //"DOTA_Tooltip_Ability_item_recipe_travel_origin"                                "Travel Spark Recipe"

--- a/game/scripts/npc/items/farming/item_greater_phase_boots.txt
+++ b/game/scripts/npc/items/farming/item_greater_phase_boots.txt
@@ -25,7 +25,7 @@
       "01"                                                "item_phase_boots;item_upgrade_core"
       "02"                                                "item_power_treads;item_upgrade_core"
       "03"                                                "item_tranquil_boots;item_upgrade_core"
-      "04"                                                "item_travel_boots;item_upgrade_core"
+      "04"                                                "item_travel_boots_oaa;item_upgrade_core"
       "05"                                                "item_arcane_boots;item_upgrade_core"
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_power_treads.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads.txt
@@ -25,7 +25,7 @@
       "01"                                                "item_power_treads;item_upgrade_core"
       "02"                                                "item_phase_boots;item_upgrade_core"
       "03"                                                "item_tranquil_boots;item_upgrade_core"
-      "04"                                                "item_travel_boots;item_upgrade_core"
+      "04"                                                "item_travel_boots_oaa;item_upgrade_core"
       "05"                                                "item_arcane_boots;item_upgrade_core"
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots.txt
@@ -23,7 +23,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_tranquil_boots;item_upgrade_core"
-      "02"                                                "item_travel_boots;item_upgrade_core"
+      "02"                                                "item_travel_boots_oaa;item_upgrade_core"
       "03"                                                "item_phase_boots;item_upgrade_core"
       "04"                                                "item_power_treads;item_upgrade_core"
       "05"                                                "item_arcane_boots;item_upgrade_core"

--- a/game/scripts/npc/items/farming/item_greater_travel_boots.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots.txt
@@ -23,7 +23,7 @@
     "ItemResult"                                          "item_greater_travel_boots"
     "ItemRequirements"
     {
-      "01"                                                "item_travel_boots;item_upgrade_core"
+      "01"                                                "item_travel_boots_oaa;item_upgrade_core"
       "02"                                                "item_tranquil_boots;item_upgrade_core"
       "03"                                                "item_phase_boots;item_upgrade_core"
       "04"                                                "item_power_treads;item_upgrade_core"
@@ -41,7 +41,7 @@
     "ID"                                                  "3024"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/farming/greater_travel_boots.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_CHANNELLED | DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_CHANNELLED | DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK | DOTA_ABILITY_BEHAVIOR_ROOT_DISABLES"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_FRIENDLY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_CREEP | DOTA_UNIT_TARGET_BUILDING"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
@@ -50,7 +50,6 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "30"
-
     "AbilitySharedCooldown"                               "travel"
     "AbilityChannelTime"                                  "3.0 2.5 2.0 1.5"
 
@@ -62,11 +61,9 @@
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "bot;boots of travel;greater boots of travel"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
+
     "MaxUpgradeLevel"                                     "4"
     "ItemBaseLevel"                                       "1"
-
-    //"UpgradesItems"                                     "item_greater_travel_boots;item_greater_travel_boots_2;item_greater_travel_boots_3;item_greater_travel_boots_4"
-    //"UpgradeRecipe"                                     "item_recipe_greater_travel_boots"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/farming/item_greater_travel_boots_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots_2.txt
@@ -41,7 +41,7 @@
     "ID"                                                  "3025"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/farming/greater_travel_boots.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_CHANNELLED | DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_CHANNELLED | DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK | DOTA_ABILITY_BEHAVIOR_ROOT_DISABLES"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_FRIENDLY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_CREEP | DOTA_UNIT_TARGET_BUILDING"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_INVULNERABLE"

--- a/game/scripts/npc/items/farming/item_greater_travel_boots_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots_3.txt
@@ -41,7 +41,7 @@
     "ID"                                                  "3026"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/farming/greater_travel_boots.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_CHANNELLED | DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_CHANNELLED | DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK | DOTA_ABILITY_BEHAVIOR_ROOT_DISABLES"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_FRIENDLY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_CREEP | DOTA_UNIT_TARGET_BUILDING"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_INVULNERABLE"

--- a/game/scripts/npc/items/farming/item_greater_travel_boots_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots_4.txt
@@ -42,7 +42,7 @@
     "ID"                                                  "3027"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/farming/greater_travel_boots.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_CHANNELLED | DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_CHANNELLED | DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK | DOTA_ABILITY_BEHAVIOR_ROOT_DISABLES"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_FRIENDLY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_CREEP | DOTA_UNIT_TARGET_BUILDING"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_INVULNERABLE"

--- a/game/scripts/npc/items/item_travel_boots.txt
+++ b/game/scripts/npc/items/item_travel_boots.txt
@@ -1,64 +1,68 @@
 "DOTAAbilities"
 {
+  "item_recipe_travel_boots"                              "REMOVE"
+  "item_travel_boots"                                     "REMOVE"
+
   //=================================================================================================================
-  // Recipe: Travel Boots
+  // Recipe: Travel Boots (OAA rework)
   //=================================================================================================================
-  "item_recipe_travel_boots"
+  "item_recipe_travel_boots_oaa"
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"                                                  "47"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "3522"
+    "BaseClass"                                           "item_datadriven"
     "Model"                                               "models/props_gameplay/recipe.vmdl"
-    "AbilityTextureName"                                  "item_recipe"
+    "AbilityTextureName"                                  "custom/recipe/recipe_1"
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "550" //OAA
+    "ItemCost"                                            "550"
     "ItemShopTags"                                        ""
 
     // Recipe
     //-------------------------------------------------------------------------------------------------------------
     "ItemRecipe"                                          "1"
-    "ItemResult"                                          "item_travel_boots"
-    "ItemRequirements" //OAA
+    "ItemResult"                                          "item_travel_boots_oaa"
+    "ItemRequirements"
     {
       "01"                                                "item_boots"
     }
   }
 
   //=================================================================================================================
-  // Travel Boots
+  // Travel Boots (OAA rework)
   //=================================================================================================================
-  "item_travel_boots"
+  "item_travel_boots_oaa"
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"                                                  "48"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
-    //"AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_CHANNELLED | DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK | DOTA_ABILITY_BEHAVIOR_ROOT_DISABLES"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+    "ID"                                                  "3523"
+    "BaseClass"                                           "item_lua"
+    "ScriptFile"                                          "items/farming/greater_travel_boots.lua"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_CHANNELLED | DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK | DOTA_ABILITY_BEHAVIOR_ROOT_DISABLES"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_FRIENDLY"
-    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_CREEP | DOTA_UNIT_TARGET_BUILDING"
+    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_CREEP | DOTA_UNIT_TARGET_BUILDING"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
     "AbilityTextureName"                                  "item_travel_boots"
+
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    //"AbilityCooldown"                                     "90" // OAA
-    //"AbilitySharedCooldown"                               "travel"
-    //"AbilityChannelTime"                                  "3.0"
+    "AbilityCooldown"                                     "90"
+    "AbilitySharedCooldown"                               "travel"
+    "AbilityChannelTime"                                  "3.0"
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    //"AbilityManaCost"                                     "75"
-    "ItemCost"                                            "1050" // OAA
+    "AbilityManaCost"                                     "75"
+    "ItemCost"                                            "1050"
     "ItemShopTags"                                        "teleport;move_speed"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "bot;boots of travel"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_TO_SPECTATORS"
+
     "MaxUpgradeLevel"                                     "1"
     "ItemBaseLevel"                                       "1"
-
-    "UpgradesItems"                                       "item_travel_boots"
-    "UpgradeRecipe"                                       "item_recipe_travel_boots"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------
@@ -67,22 +71,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_movement_speed"                            "45" // OAA -- you get these boots a lot earlier, so lvl 1 has move speed nerf
-      }
-      "02"
-      {
-        "var_type"                                        "FIELD_INTEGER"
-        "maximum_distance"                                "575"
-      }
-      "03"
-      {
-        "var_type"                                        "FIELD_INTEGER"
-        "vision_radius"                                   "200"
-      }
-      "04"
-      {
-        "var_type"                                        "FIELD_INTEGER"
-        "tp_cooldown"                                     "40"
+        "bonus_movement_speed"                            "50" // you get these boots a lot earlier,
       }
     }
   }

--- a/game/scripts/vscripts/items/farming/greater_travel_boots.lua
+++ b/game/scripts/vscripts/items/farming/greater_travel_boots.lua
@@ -1,8 +1,7 @@
-item_greater_travel_boots = class(ItemBaseClass)
-modifier_item_greater_travel_boots = class(ModifierBaseClass)
-
 --LinkLuaModifier( "modifier_intrinsic_multiplexer", "modifiers/modifier_intrinsic_multiplexer.lua", LUA_MODIFIER_MOTION_NONE )
 LinkLuaModifier( "modifier_item_greater_travel_boots", "items/farming/greater_travel_boots.lua", LUA_MODIFIER_MOTION_NONE )
+
+item_greater_travel_boots = class(ItemBaseClass)
 
 function item_greater_travel_boots:GetIntrinsicModifierName()
   return "modifier_item_greater_travel_boots" -- "modifier_intrinsic_multiplexer"
@@ -90,7 +89,7 @@ function item_greater_travel_boots:OnSpellStart()
 end
 
 function item_greater_travel_boots:OnChannelThink (delta)
-  if not self.targetEntity:IsAlive() then
+  if not self.targetEntity:IsAlive() or self:GetCaster():IsRooted() then
     self:EndChannel(true)
   end
 end
@@ -124,6 +123,10 @@ function item_greater_travel_boots:OnChannelFinish(wasInterupted)
   FindClearSpaceForUnit(self:GetCaster(), self.targetEntity:GetAbsOrigin(), true)
 end
 
+---------------------------------------------------------------------------------------------------
+
+modifier_item_greater_travel_boots = class(ModifierBaseClass)
+
 function modifier_item_greater_travel_boots:IsHidden()
   return true
 end
@@ -134,10 +137,6 @@ end
 
 function modifier_item_greater_travel_boots:IsPurgable()
   return false
-end
-
-function modifier_item_greater_travel_boots:GetAttributes()
-  return MODIFIER_ATTRIBUTE_MULTIPLE
 end
 
 function modifier_item_greater_travel_boots:DeclareFunctions()
@@ -159,4 +158,5 @@ item_greater_travel_boots_2 = class(item_greater_travel_boots)
 item_greater_travel_boots_3 = class(item_greater_travel_boots)
 item_greater_travel_boots_4 = class(item_greater_travel_boots)
 item_greater_travel_boots_5 = class(item_greater_travel_boots)
---item_travel_origin = class(item_greater_travel_boots)
+item_travel_boots_oaa = item_greater_travel_boots
+


### PR DESCRIPTION
* Completely removed vanilla Boots of Travel and replaced it with OAA Boots of Travel.
* Boots of Travel (without core) are no longer passive. They don't upgrade the Town Portal Scroll anymore.
* Boots of Travel now has an active like Greater Travel Boots but it can't target heroes. Active (teleport) doesn't share cooldown with Town Portal Scroll. But it does share cooldown with Greater Travel Boots.
* Boots of Travel bonus movement speed increased from 45 to 50.
* Fixed channeling Greater Travel Boots teleport not being interrupted/cancelled with roots.
* Fixed being able to use Greater Travel Boots teleport while rooted.

I did this because in Mistwoods update they added this: ''Upon equipping, automatically sells TP scrolls that you have, and grants you 1 charge. This also applies to Meepo clones.'' I don't know it they hardcoded something with TP scrolls and I don't want to know. With this, travels are 'normal' again and future updates will not break them.