### PR TITLE
Meepo Update

### DIFF
--- a/game/resource/English/ability/units/tooltip_meepo_divided_we_stand_oaa.txt
+++ b/game/resource/English/ability/units/tooltip_meepo_divided_we_stand_oaa.txt
@@ -1,10 +1,13 @@
 "DOTA_Tooltip_ability_meepo_divided_we_stand_oaa"                               "#{DOTA_Tooltip_ability_meepo_divided_we_stand}"
-"DOTA_Tooltip_ability_meepo_divided_we_stand_oaa_Description"                   "Meepo summons an imperfect, semi-autonomous duplicates of himself, which can gain gold and experience as he does and shares his experience, attributes and abilities. However, the clones cannot wield any items (except some boots).  If any of the clones die, they all die.\n<font color='#FFA500'>Together We Stand: Each Meepo provides stacking damage reduction to other meepos when near each other.</font>"
+"DOTA_Tooltip_ability_meepo_divided_we_stand_oaa_Description"                   "Meepo summons an imperfect, semi-autonomous duplicates of himself, which can gain gold and experience as he does and shares his experience, attributes and abilities. However, the clones cannot wield any items (except some boots). If any of the clones die, they all die.\n<font color='#FFA500'>Together We Stand: Each Meepo provides stacking damage reduction to other meepos when near each other.</font>"
 "DOTA_Tooltip_ability_meepo_divided_we_stand_oaa_Lore"                          "#{DOTA_Tooltip_ability_meepo_divided_we_stand_Lore}"
 "DOTA_Tooltip_ability_meepo_divided_we_stand_oaa_Note0"                         ""
 "DOTA_Tooltip_ability_meepo_divided_we_stand_oaa_tooltip_clones"                "NUMBER OF MEEPOES:"
 "DOTA_Tooltip_ability_meepo_divided_we_stand_oaa_aura_radius"                   "RADIUS:"
 "DOTA_Tooltip_ability_meepo_divided_we_stand_oaa_bonus_dmg_reduction_pct"       "%DAMAGE REDUCTION PER MEEPO:"
 
+"DOTA_Tooltip_ability_meepo_divided_we_stand_Description"                       "#{DOTA_Tooltip_ability_meepo_divided_we_stand_oaa_Description}"
+"DOTA_Tooltip_ability_meepo_divided_we_stand_bonus_dmg_reduction_pct"           "#{DOTA_Tooltip_ability_meepo_divided_we_stand_oaa_bonus_dmg_reduction_pct}"
+
 "DOTA_Tooltip_modifier_meepo_divided_we_stand_oaa_bonus_buff"                   "Together We Stand"
-"DOTA_Tooltip_modifier_meepo_divided_we_stand_oaa_bonus_buff_description"       "Taking %dMODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE%%% less damage."
+"DOTA_Tooltip_modifier_meepo_divided_we_stand_oaa_bonus_buff_description"       "Taking %dMODIFIER_PROPERTY_TOOLTIP%%% less damage."

--- a/game/scripts/npc/abilities/meepo_divided_we_stand.txt
+++ b/game/scripts/npc/abilities/meepo_divided_we_stand.txt
@@ -46,6 +46,11 @@
         "var_type"                                        "FIELD_INTEGER"
         "tooltip_respawn"                                 "20"
       }
+      "06" //OAA, for picking screen tooltip
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_dmg_reduction_pct"                         "3 5 7 10 13"
+      }
     }
   }
 }

--- a/game/scripts/npc/abilities/meepo_divided_we_stand_oaa.txt
+++ b/game/scripts/npc/abilities/meepo_divided_we_stand_oaa.txt
@@ -31,7 +31,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_dmg_reduction_pct"                         "4 6 8 10 12"
+        "bonus_dmg_reduction_pct"                         "3 5 7 10 13"
       }
       "03"
       {

--- a/game/scripts/npc/heroes/meepo.txt
+++ b/game/scripts/npc/heroes/meepo.txt
@@ -12,6 +12,6 @@
     "Ability17"                                           "special_bonus_attack_speed_100" // replaces special_bonus_unique_meepo_5
 
     "AttributeBaseAgility"                                "24" // 17
-    "AttributeAgilityGain"                                "2.2" // 1.8
+    "AttributeAgilityGain"                                "1.9" // 1.8
   }
 }

--- a/game/scripts/vscripts/abilities/oaa_divided_we_stand.lua
+++ b/game/scripts/vscripts/abilities/oaa_divided_we_stand.lua
@@ -75,7 +75,7 @@ function meepo_divided_we_stand_oaa:RefreshMeepos(caster)
   if not IsServer() then
     return
   end
-  
+
   local ability = self
 
   Timers:CreateTimer(0.5, function()
@@ -404,7 +404,7 @@ end
 function modifier_meepo_divided_we_stand_oaa_bonus_buff:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE,
-    --MODIFIER_PROPERTY_TOOLTIP,
+    MODIFIER_PROPERTY_TOOLTIP,
   }
 end
 
@@ -412,6 +412,6 @@ function modifier_meepo_divided_we_stand_oaa_bonus_buff:GetModifierIncomingDamag
   return -self.total_dmg_reduction
 end
 
---function modifier_meepo_divided_we_stand_oaa_bonus_buff:OnTooltip()
-  --return self:GetStackCount()
---end
+function modifier_meepo_divided_we_stand_oaa_bonus_buff:OnTooltip()
+  return self:GetStackCount()
+end

--- a/game/scripts/vscripts/abilities/oaa_divided_we_stand.lua
+++ b/game/scripts/vscripts/abilities/oaa_divided_we_stand.lua
@@ -485,7 +485,15 @@ function modifier_meepo_divided_we_stand_oaa_bonus_buff:OnIntervalThink()
     end
   else
     for _, boots in pairs(custom_boots) do
-      parent:RemoveItemByName(boots)
+      for item_slot = DOTA_ITEM_SLOT_1, DOTA_ITEM_SLOT_6 do
+        local item = parent:GetItemInSlot(item_slot)
+        if item then
+          if item:GetAbilityName() == boots then
+            parent:RemoveItem(item)
+			break
+          end
+        end
+      end
     end
   end
 

--- a/game/scripts/vscripts/abilities/oaa_divided_we_stand.lua
+++ b/game/scripts/vscripts/abilities/oaa_divided_we_stand.lua
@@ -87,7 +87,7 @@ function meepo_divided_we_stand_oaa:RefreshMeepos(caster)
       FIND_UNITS_EVERYWHERE,
       DOTA_UNIT_TARGET_TEAM_FRIENDLY,
       DOTA_UNIT_TARGET_HERO,
-      DOTA_UNIT_TARGET_FLAG_NONE,
+      bit.bor(DOTA_UNIT_TARGET_FLAG_INVULNERABLE, DOTA_UNIT_TARGET_FLAG_OUT_OF_WORLD),
       FIND_ANY_ORDER,
       false
     )
@@ -108,7 +108,6 @@ function meepo_divided_we_stand_oaa:RefreshMeepos(caster)
         meepo:AddNewModifier(caster, ability, "modifier_meepo_divided_we_stand_oaa_bonus_buff", {})
       end
     end
-
   end)
 end
 
@@ -134,9 +133,7 @@ end
 
 function modifier_meepo_divided_we_stand_oaa:DeclareFunctions()
   return {
-    --MODIFIER_EVENT_ON_ORDER,
     MODIFIER_EVENT_ON_RESPAWN,
-    --MODIFIER_EVENT_ON_TAKEDAMAGE,
     MODIFIER_EVENT_ON_DEATH,
   }
 end
@@ -184,7 +181,7 @@ function modifier_meepo_divided_we_stand_oaa:OnDeath(event)
   end
 end
 
-function modifier_meepo_divided_we_stand_oaa:OnRespawn(keys)
+function modifier_meepo_divided_we_stand_oaa:OnRespawn(event)
   local parent = self:GetParent()
   local mainMeepo = self:GetCaster()
   for _, meepo in pairs(GetAllMeepos(mainMeepo)) do
@@ -335,8 +332,8 @@ function modifier_meepo_divided_we_stand_oaa_bonus_buff:OnCreated()
     self.dmg_reduction_per_meepo = ability:GetLevelSpecialValueFor("bonus_dmg_reduction_pct", ability:GetLevel()-1)
     self.radius = ability:GetSpecialValueFor("aura_radius")
   else
-    self.dmg_reduction_per_meepo = 4
-    self.radius = 600
+    self.dmg_reduction_per_meepo = 3
+    self.radius = 700
   end
   self:StartIntervalThink(0)
 end
@@ -352,8 +349,8 @@ function modifier_meepo_divided_we_stand_oaa_bonus_buff:OnRefresh()
     self.dmg_reduction_per_meepo = ability:GetLevelSpecialValueFor("bonus_dmg_reduction_pct", ability:GetLevel()-1)
     self.radius = ability:GetSpecialValueFor("aura_radius")
   else
-    self.dmg_reduction_per_meepo = 4
-    self.radius = 600
+    self.dmg_reduction_per_meepo = 3
+    self.radius = 700
   end
 end
 
@@ -399,6 +396,100 @@ function modifier_meepo_divided_we_stand_oaa_bonus_buff:OnIntervalThink()
   end
 
   self:SetStackCount(self.total_dmg_reduction)
+
+  local vanilla_boots = {
+    "item_phase_boots",
+    "item_power_treads",
+    "item_tranquil_boots",
+    "item_arcane_boots",
+    "item_guardian_greaves",
+  }
+
+  local custom_boots = {
+    "item_travel_boots_oaa",
+
+    "item_greater_guardian_greaves",
+    "item_greater_tranquil_boots",
+    "item_greater_travel_boots",
+    "item_greater_phase_boots",
+    "item_greater_power_treads",
+
+    "item_greater_guardian_greaves_2",
+    "item_greater_tranquil_boots_2",
+    "item_greater_travel_boots_2",
+    "item_greater_phase_boots_2",
+    "item_greater_power_treads_2",
+
+    "item_greater_guardian_greaves_3",
+    "item_greater_tranquil_boots_3",
+    "item_greater_travel_boots_3",
+    "item_greater_phase_boots_3",
+    "item_greater_power_treads_3",
+    "item_sonic",
+
+    "item_greater_guardian_greaves_4",
+    "item_greater_tranquil_boots_4",
+    "item_greater_travel_boots_4",
+    "item_greater_phase_boots_4",
+    "item_greater_power_treads_4",
+    "item_sonic_2",
+    "item_force_boots_1",
+  }
+
+  if not parent:IsClone() then
+    return
+  end
+
+  local meepo_prime = parent:GetCloneSource()
+  local found_boots = false
+  local has_vanilla_boots = false
+
+  for _, boots in pairs(vanilla_boots) do
+    if parent:HasItemInInventory(boots) then
+      has_vanilla_boots = true
+      break -- Breaks the for loop
+    end
+  end
+
+  -- If clone doesnt have vanilla boots check Meepo Prime for custom boots
+  if has_vanilla_boots == false then
+    for _, boots in pairs(custom_boots) do
+      for item_slot = DOTA_ITEM_SLOT_1, DOTA_ITEM_SLOT_6 do
+        local item = meepo_prime:GetItemInSlot(item_slot)
+        if item then
+          if item:GetAbilityName() == boots then
+            meepo_prime.main_boots = item
+            found_boots = true
+            break -- Breaks the for loop with item slots
+          end
+        end
+      end
+
+      if found_boots == true then
+        break -- Breaks the for loop with custom boots
+      end
+    end
+  end
+
+  -- If Meepo Prime has custom boots -> copy them to the clone
+  if found_boots == true then
+    local meepo_prime_boots = meepo_prime.main_boots
+    local boots_name = meepo_prime_boots:GetAbilityName()
+    -- Check if the clone has those boots
+    if not parent:HasItemInInventory(boots_name) then
+      self.cloned_boots = parent:AddItemByName(boots_name)
+      -- Check the slot of the cloned boots
+      if self.cloned_boots and parent:HasItemInInventory(boots_name) and self.cloned_boots:GetItemSlot() ~= meepo_prime_boots:GetItemSlot() then
+        parent:SwapItems(self.cloned_boots:GetItemSlot(), meepo_prime_boots:GetItemSlot())
+      end
+    end
+  else
+    for _, boots in pairs(custom_boots) do
+      parent:RemoveItemByName(boots)
+    end
+  end
+
+  parent:CalculateStatBonus(true)
 end
 
 function modifier_meepo_divided_we_stand_oaa_bonus_buff:DeclareFunctions()


### PR DESCRIPTION
* Divided We Stand damage reduction per meepo rescaled from 4/6/8/10/12% to 3/5/7/10/13%.
* Reduced AGI gain from 2.2 to 1.9 (vanilla is 1.8)
* Fixed tooltip of the Together We Stand buff not showing correct damage reduction.
* Fixed tooltip of Divided We Stand not mentioning damage reduction on the picking screen.
* Fixed Together We Stand buff not refreshing correctly on invulnerable or banished Meepo clones.
* Fixed custom boots not working on Meepo clones. Sonic and Force Boots Meepo is funny.