### PR TITLE
Ghost Creep changes

### DIFF
--- a/game/resource/English/ability/units/tooltip_ghost_frostburn_oaa.txt
+++ b/game/resource/English/ability/units/tooltip_ghost_frostburn_oaa.txt
@@ -1,5 +1,5 @@
 "DOTA_Tooltip_ability_ghost_frostburn_oaa"                                  "Frostburn"
-"DOTA_Tooltip_ability_ghost_frostburn_oaa_Description"                      "Ghost's attacks reduce hp regeneration and healing by %heal_prevent_percent%%% for %heal_prevent_duration% seconds."
+"DOTA_Tooltip_ability_ghost_frostburn_oaa_Description"                      "Ghost's attacks reduce hp regeneration, lifesteal, healing and spell lifesteal by %heal_prevent_percent%%% and attack speed by %attack_speed_slow% for %heal_prevent_duration% seconds."
 
 "DOTA_Tooltip_modifier_frostburn_oaa_effect"                                "Frostburn"
-"DOTA_Tooltip_modifier_frostburn_oaa_effect_Description"                    "Reduced healing."
+"DOTA_Tooltip_modifier_frostburn_oaa_effect_Description"                    "Reduced healing and attack speed."

--- a/game/scripts/npc/abilities/neutrals/ghost_frostburn_oaa.txt
+++ b/game/scripts/npc/abilities/neutrals/ghost_frostburn_oaa.txt
@@ -28,6 +28,11 @@
       }
       "02"
       {
+        "var_type"                                        "FIELD_INTEGER"
+        "attack_speed_slow"                               "-35"
+      }
+      "03"
+      {
         "var_type"                                        "FIELD_FLOAT"
         "heal_prevent_duration"                           "5.0"
       }

--- a/game/scripts/npc/abilities/neutrals/ghost_frostburn_oaa.txt
+++ b/game/scripts/npc/abilities/neutrals/ghost_frostburn_oaa.txt
@@ -24,12 +24,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "heal_prevent_percent"                            "-35"
+        "heal_prevent_percent"                            "-25"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "attack_speed_slow"                               "-35"
+        "attack_speed_slow"                               "-25"
       }
       "03"
       {

--- a/game/scripts/vscripts/abilities/neutrals/oaa_ghost_frostburn.lua
+++ b/game/scripts/vscripts/abilities/neutrals/oaa_ghost_frostburn.lua
@@ -77,8 +77,8 @@ function modifier_frostburn_oaa_effect:OnCreated()
     self.heal_prevent_percent = ability:GetSpecialValueFor("heal_prevent_percent")
     self.attack_slow = ability:GetSpecialValueFor("attack_speed_slow")
   else
-    self.heal_prevent_percent = -35
-    self.attack_slow = -35
+    self.heal_prevent_percent = -25
+    self.attack_slow = -25
   end
   --self.duration = self:GetDuration()
   --self.health_fraction = 0
@@ -90,8 +90,8 @@ function modifier_frostburn_oaa_effect:OnRefresh()
     self.heal_prevent_percent = ability:GetSpecialValueFor("heal_prevent_percent")
     self.attack_slow = ability:GetSpecialValueFor("attack_speed_slow")
   else
-    self.heal_prevent_percent = -35
-    self.attack_slow = -35
+    self.heal_prevent_percent = -25
+    self.attack_slow = -25
   end
 end
 

--- a/game/scripts/vscripts/abilities/neutrals/oaa_ghost_frostburn.lua
+++ b/game/scripts/vscripts/abilities/neutrals/oaa_ghost_frostburn.lua
@@ -72,25 +72,66 @@ function modifier_frostburn_oaa_effect:IsPurgable()
 end
 
 function modifier_frostburn_oaa_effect:OnCreated()
-  if IsServer() then
-    local ability = self:GetAbility()
-    if ability then
-      self.heal_prevent_percent = ability:GetSpecialValueFor("heal_prevent_percent")
-    else
-      self.heal_prevent_percent = 35
-    end
-    self.duration = self:GetDuration()
-    self.health_fraction = 0
+  local ability = self:GetAbility()
+  if ability then
+    self.heal_prevent_percent = ability:GetSpecialValueFor("heal_prevent_percent")
+    self.attack_slow = ability:GetSpecialValueFor("attack_speed_slow")
+  else
+    self.heal_prevent_percent = -35
+    self.attack_slow = -35
   end
+  --self.duration = self:GetDuration()
+  --self.health_fraction = 0
+end
+
+function modifier_frostburn_oaa_effect:OnRefresh()
+  local ability = self:GetAbility()
+  if ability then
+    self.heal_prevent_percent = ability:GetSpecialValueFor("heal_prevent_percent")
+    self.attack_slow = ability:GetSpecialValueFor("attack_speed_slow")
+  else
+    self.heal_prevent_percent = -35
+    self.attack_slow = -35
+  end
+end
+
+function modifier_frostburn_oaa_effect:GetEffectName()
+  return "particles/items4_fx/spirit_vessel_damage.vpcf"
 end
 
 function modifier_frostburn_oaa_effect:DeclareFunctions()
   local funcs = {
-    MODIFIER_EVENT_ON_HEALTH_GAINED
+    MODIFIER_PROPERTY_HEAL_AMPLIFY_PERCENTAGE_TARGET,
+    MODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE,
+    MODIFIER_PROPERTY_LIFESTEAL_AMPLIFY_PERCENTAGE,
+    MODIFIER_PROPERTY_SPELL_LIFESTEAL_AMPLIFY_PERCENTAGE,
+    MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT,
+    --MODIFIER_EVENT_ON_HEALTH_GAINED
   }
   return funcs
 end
 
+function modifier_frostburn_oaa_effect:GetModifierHealAmplify_PercentageTarget()
+  return self.heal_prevent_percent
+end
+
+function modifier_frostburn_oaa_effect:GetModifierHPRegenAmplify_Percentage()
+  return self.heal_prevent_percent
+end
+
+function modifier_frostburn_oaa_effect:GetModifierLifestealRegenAmplify_Percentage()
+  return self.heal_prevent_percent
+end
+
+function modifier_frostburn_oaa_effect:GetModifierSpellLifestealRegenAmplify_Percentage()
+  return self.heal_prevent_percent
+end
+
+function modifier_frostburn_oaa_effect:GetModifierAttackSpeedBonus_Constant()
+  return self.attack_slow
+end
+
+--[[
 function modifier_frostburn_oaa_effect:OnHealthGained(event)
   if IsServer() then
     -- Check that event is being called for the unit that self is attached to
@@ -107,3 +148,4 @@ function modifier_frostburn_oaa_effect:OnHealthGained(event)
     end
   end
 end
+]]

--- a/game/scripts/vscripts/components/creeps/creep_types.lua
+++ b/game/scripts/vscripts/components/creeps/creep_types.lua
@@ -31,8 +31,8 @@ CreepTypes = {
     -- 3 "hard camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_custom_ghost",             800,    0,  40,   1.5,   45,  60}, -- expected gold is 90 and XP 120
-      {"npc_dota_neutral_custom_ghost",             800,    0,  40,   1.5,   45,  60}
+      {"npc_dota_neutral_custom_ghost",             800,    0,  35,   1.5,   45,  60}, -- expected gold is 90 and XP 120
+      {"npc_dota_neutral_custom_ghost",             800,    0,  35,   1.5,   45,  60}
     },
     {
       {"npc_dota_neutral_custom_centaur_khan",      800,  300,  50,   1.5,   45,  60},


### PR DESCRIPTION
* Ghost starting attack damage reduced from 40 to 35.
* Frostburn now properly reduces all healing instead of reducing health when health is gained.
* Frostburn healing reduction reduced from 35% to 25%.
* Frostburn now also reduces attack speed by 25.