### PR TITLE
Greater Tranquil Boots tweaks

### DIFF
--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots.txt
@@ -49,7 +49,7 @@
     "AbilityCooldown"                                     "18"
     "AbilityManaCost"                                     "75"
     "AbilitySharedCooldown"                               "greater_tranquils"
-    "AbilityCastRange"                                    "500"
+    "AbilityCastRange"                                    "600 650 700 750"
     "AbilityCastPoint"                                    "0.0"
 
     // Item Info
@@ -110,12 +110,22 @@
       "07"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "tranquilize_duration"                            "3.0"
+        "slow_duration"                                   "2.5 3.0 3.5 4.0"
       }
       "08"
       {
+        "var_type"                                        "FIELD_FLOAT"
+        "sprout_duration"                                 "3.5 4.0 4.5 5.0"
+      }
+      "09"
+      {
         "var_type"                                        "FIELD_INTEGER"
         "hp_regen_amp"                                    "50"
+      }
+      "10"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "projectile_speed"                                "700"
       }
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_2.txt
@@ -49,7 +49,7 @@
     "AbilityCooldown"                                     "18"
     "AbilityManaCost"                                     "75"
     "AbilitySharedCooldown"                               "greater_tranquils"
-    "AbilityCastRange"                                    "500"
+    "AbilityCastRange"                                    "600 650 700 750"
     "AbilityCastPoint"                                    "0.0"
 
     // Item Info
@@ -110,12 +110,22 @@
       "07"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "tranquilize_duration"                            "3.0"
+        "slow_duration"                                   "2.5 3.0 3.5 4.0"
       }
       "08"
       {
+        "var_type"                                        "FIELD_FLOAT"
+        "sprout_duration"                                 "3.5 4.0 4.5 5.0"
+      }
+      "09"
+      {
         "var_type"                                        "FIELD_INTEGER"
         "hp_regen_amp"                                    "50"
+      }
+      "10"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "projectile_speed"                                "700"
       }
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_3.txt
@@ -49,7 +49,7 @@
     "AbilityCooldown"                                     "18"
     "AbilityManaCost"                                     "75"
     "AbilitySharedCooldown"                               "greater_tranquils"
-    "AbilityCastRange"                                    "500"
+    "AbilityCastRange"                                    "600 650 700 750"
     "AbilityCastPoint"                                    "0.0"
 
     // Item Info
@@ -110,12 +110,22 @@
       "07"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "tranquilize_duration"                            "3.0"
+        "slow_duration"                                   "2.5 3.0 3.5 4.0"
       }
       "08"
       {
+        "var_type"                                        "FIELD_FLOAT"
+        "sprout_duration"                                 "3.5 4.0 4.5 5.0"
+      }
+      "09"
+      {
         "var_type"                                        "FIELD_INTEGER"
         "hp_regen_amp"                                    "50"
+      }
+      "10"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "projectile_speed"                                "700"
       }
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_4.txt
@@ -50,7 +50,7 @@
     "AbilityCooldown"                                     "18"
     "AbilityManaCost"                                     "75"
     "AbilitySharedCooldown"                               "greater_tranquils"
-    "AbilityCastRange"                                    "500"
+    "AbilityCastRange"                                    "600 650 700 750"
     "AbilityCastPoint"                                    "0.0"
 
     // Item Info
@@ -111,12 +111,22 @@
       "07"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "tranquilize_duration"                            "3.0"
+        "slow_duration"                                   "2.5 3.0 3.5 4.0"
       }
       "08"
       {
+        "var_type"                                        "FIELD_FLOAT"
+        "sprout_duration"                                 "3.5 4.0 4.5 5.0"
+      }
+      "09"
+      {
         "var_type"                                        "FIELD_INTEGER"
         "hp_regen_amp"                                    "50"
+      }
+      "10"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "projectile_speed"                                "700"
       }
     }
   }

--- a/game/scripts/vscripts/items/farming/greater_tranquil_boots.lua
+++ b/game/scripts/vscripts/items/farming/greater_tranquil_boots.lua
@@ -55,7 +55,7 @@ function item_greater_tranquil_boots:OnSpellStart()
     bProvidesVision = true,
     bVisibleToEnemies = true,
     bReplaceExisting = false,
-    iMoveSpeed = 800,
+    iMoveSpeed = self:GetSpecialValueFor("projectile_speed"),
     iVisionRadius = 250,
     iVisionTeamNumber = caster:GetTeamNumber(),
   }
@@ -70,7 +70,8 @@ function item_greater_tranquil_boots:OnProjectileHit(target, location)
     return
   end
 
-  local duration = self:GetSpecialValueFor("tranquilize_duration")
+  local debuff_duration = self:GetSpecialValueFor("slow_duration")
+  local buff_duration = self:GetSpecialValueFor("sprout_duration")
 
   if target:GetTeam() ~= caster:GetTeam() then
     -- Don't do anything if target has Linken's effect
@@ -78,9 +79,9 @@ function item_greater_tranquil_boots:OnProjectileHit(target, location)
       return
     end
 
-    target:AddNewModifier(caster, self, "modifier_greater_tranquils_tranquilize_debuff", {duration = duration})
+    target:AddNewModifier(caster, self, "modifier_greater_tranquils_tranquilize_debuff", {duration = debuff_duration})
   else
-    target:AddNewModifier(caster, self, "modifier_greater_tranquils_tranquilize_buff", {duration = duration})
+    target:AddNewModifier(caster, self, "modifier_greater_tranquils_tranquilize_buff", {duration = buff_duration})
   end
 
   local target_loc = target:GetAbsOrigin()
@@ -95,7 +96,7 @@ function item_greater_tranquil_boots:OnProjectileHit(target, location)
   ParticleManager:ReleaseParticleIndex(nFXIndex)
 
   for i = 1,8 do
-    CreateTempTree(target_loc + Vector(x_offset[i], y_offset[i], 0.0), duration)
+    CreateTempTree(target_loc + Vector(x_offset[i], y_offset[i], 0.0), buff_duration)
   end
 
   for i = 1,8 do


### PR DESCRIPTION
* Attack speed slow duration rescaled from 3 to 2.5/3/3.5/4 seconds.
* Sprout duration increased from 3 to 3.5/4/4.5/5 seconds.
* Buff duration on allies is the same as sprout duration.
* Projectile speed reduced from 800 to 700.
* Cast range increased from 500 to 600/650/700/750.