### PR TITLE
Item Balance March 2021

### DIFF
--- a/game/resource/English/ability/items/tooltip_demon_stone.txt
+++ b/game/resource/English/ability/items/tooltip_demon_stone.txt
@@ -5,6 +5,6 @@
 "DOTA_Tooltip_ability_item_demon_stone_Lore"             "A weightless charm created by a demon with a powerful scorn for brute force."
 "DOTA_Tooltip_ability_item_demon_stone_Description"      "Increases experience income and mana, while reducing outgoing attack damage."
 "DOTA_Tooltip_Ability_item_demon_stone_Note0"            "Experience gain doesn't work in duels and on illusions or Spirit Bear."
-"DOTA_Tooltip_ability_item_demon_stone_bonus_xpm"        "+XPM BONUS"
+"DOTA_Tooltip_ability_item_demon_stone_bonus_xpm"        "+EXPERIENCE PER MINUTE BONUS"
 "DOTA_Tooltip_ability_item_demon_stone_bonus_mana"       "+$mana"
 "DOTA_Tooltip_ability_item_demon_stone_bonus_damage"     "-<font color='#e03e2e'>Attack Damage</font>"

--- a/game/scripts/npc/items/custom/item_devastator_3.txt
+++ b/game/scripts/npc/items/custom/item_devastator_3.txt
@@ -52,7 +52,7 @@
 
     "AbilityCastRange"                                    "800"
     "AbilityCastPoint"                                    "0"
-    "AbilityCooldown"                                     "10"
+    "AbilityCooldown"                                     "7"
     "AbilityManaCost"                                     "75"
 
     // Stats
@@ -88,7 +88,7 @@
         "var_type"                                        "FIELD_INTEGER"
         "corruption_armor"                                "-3 -5 -8 -12 -17"
       }
-      "03"
+      "03" // like Desolator
       {
         "var_type"                                        "FIELD_FLOAT"
         "corruption_duration"                             "7.0"
@@ -123,17 +123,17 @@
         "var_type"                                        "FIELD_INTEGER"
         "devastator_movespeed_reduction"                  "-10 -20 -30 -40 -50"
       }
-      "10" // like Solar Crest
+      "10" // like Desolator
       {
         "var_type"                                        "FIELD_FLOAT"
         "devastator_movespeed_reduction_duration"         "7.0"
       }
-      "11" // better than desolator, similar to solar crest
+      "11" // better than desolator
       {
         "var_type"                                        "FIELD_INTEGER"
         "devastator_armor_reduction"                      "-7 -10 -14 -19 -25"
       }
-      "12" // like Desolator and Solar Crest
+      "12" // like Desolator
       {
         "var_type"                                        "FIELD_FLOAT"
         "devastator_armor_reduction_duration"             "7.0"

--- a/game/scripts/npc/items/custom/item_devastator_4.txt
+++ b/game/scripts/npc/items/custom/item_devastator_4.txt
@@ -53,7 +53,7 @@
 
     "AbilityCastRange"                                    "800"
     "AbilityCastPoint"                                    "0"
-    "AbilityCooldown"                                     "10"
+    "AbilityCooldown"                                     "7"
     "AbilityManaCost"                                     "75"
 
     // Stats

--- a/game/scripts/npc/items/custom/item_devastator_5.txt
+++ b/game/scripts/npc/items/custom/item_devastator_5.txt
@@ -54,7 +54,7 @@
 
     "AbilityCastRange"                                    "800"
     "AbilityCastPoint"                                    "0"
-    "AbilityCooldown"                                     "10"
+    "AbilityCooldown"                                     "7"
     "AbilityManaCost"                                     "75"
 
     // Stats

--- a/game/scripts/npc/items/custom/item_pull_staff.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff.txt
@@ -103,7 +103,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 30 60 100 150"
+        "bonus_damage"                                    "10 30 70 130 210"
       }
       "03"
       {

--- a/game/scripts/npc/items/custom/item_pull_staff_2.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_2.txt
@@ -104,7 +104,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 30 60 100 150"
+        "bonus_damage"                                    "10 30 70 130 210"
       }
       "03"
       {

--- a/game/scripts/npc/items/custom/item_pull_staff_3.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_3.txt
@@ -104,7 +104,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 30 60 100 150"
+        "bonus_damage"                                    "10 30 70 130 210"
       }
       "03"
       {

--- a/game/scripts/npc/items/custom/item_pull_staff_4.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_4.txt
@@ -104,7 +104,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 30 60 100 150"
+        "bonus_damage"                                    "10 30 70 130 210"
       }
       "03"
       {

--- a/game/scripts/npc/items/custom/item_pull_staff_5.txt
+++ b/game/scripts/npc/items/custom/item_pull_staff_5.txt
@@ -104,7 +104,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 30 60 100 150"
+        "bonus_damage"                                    "10 30 70 130 210"
       }
       "03"
       {

--- a/game/scripts/npc/items/custom/item_regen_crystal_1.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_1.txt
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen"                                 "500"
+        "active_hp_regen"                                 "300 400 500"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_regen_crystal_2.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_2.txt
@@ -82,7 +82,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen"                                 "500"
+        "active_hp_regen"                                 "300 400 500"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_regen_crystal_3.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_3.txt
@@ -83,7 +83,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen"                                 "500"
+        "active_hp_regen"                                 "300 400 500"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_satanic_core.txt
+++ b/game/scripts/npc/items/custom/item_satanic_core.txt
@@ -87,12 +87,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "hero_spell_lifesteal"                            "35"
+        "hero_spell_lifesteal"                            "32 34 36"
       }
       "06"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "creep_spell_lifesteal"                           "15 20 25"
+        "creep_spell_lifesteal"                           "10 12 14"
       }
       "07"
       {

--- a/game/scripts/npc/items/custom/item_satanic_core_2.txt
+++ b/game/scripts/npc/items/custom/item_satanic_core_2.txt
@@ -88,12 +88,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "hero_spell_lifesteal"                            "35"
+        "hero_spell_lifesteal"                            "32 34 36"
       }
       "06"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "creep_spell_lifesteal"                           "15 20 25"
+        "creep_spell_lifesteal"                           "10 12 14"
       }
       "07"
       {

--- a/game/scripts/npc/items/custom/item_satanic_core_3.txt
+++ b/game/scripts/npc/items/custom/item_satanic_core_3.txt
@@ -87,12 +87,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "hero_spell_lifesteal"                            "35"
+        "hero_spell_lifesteal"                            "32 34 36"
       }
       "06"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "creep_spell_lifesteal"                           "15 20 25"
+        "creep_spell_lifesteal"                           "10 12 14"
       }
       "07"
       {

--- a/game/scripts/npc/items/custom/item_vampire.txt
+++ b/game/scripts/npc/items/custom/item_vampire.txt
@@ -71,10 +71,10 @@
         "var_type"                                        "FIELD_INTEGER"
         "bonus_strength"                                  "70 95"
       }
-      "02" // better than Satanic 4-5, worse than Mask of Madness 4-5
+      "02" // same as Mask of Madness 4-5
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "100 140"
+        "bonus_damage"                                    "130 210"
       }
       "03"
       {

--- a/game/scripts/npc/items/custom/item_vampire_2.txt
+++ b/game/scripts/npc/items/custom/item_vampire_2.txt
@@ -75,7 +75,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "100 140"
+        "bonus_damage"                                    "130 210"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_blade_mail.txt
+++ b/game/scripts/npc/items/item_blade_mail.txt
@@ -83,7 +83,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_reflection_constant"                     "20"
+        "passive_reflection_constant"                     "20 40 80 140 220"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_blade_mail_2.txt
+++ b/game/scripts/npc/items/item_blade_mail_2.txt
@@ -86,7 +86,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_reflection_constant"                     "20"
+        "passive_reflection_constant"                     "20 40 80 140 220"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_blade_mail_3.txt
+++ b/game/scripts/npc/items/item_blade_mail_3.txt
@@ -87,7 +87,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_reflection_constant"                     "20"
+        "passive_reflection_constant"                     "20 40 80 140 220"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_blade_mail_4.txt
+++ b/game/scripts/npc/items/item_blade_mail_4.txt
@@ -87,7 +87,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_reflection_constant"                     "20"
+        "passive_reflection_constant"                     "20 40 80 140 220"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_blade_mail_5.txt
+++ b/game/scripts/npc/items/item_blade_mail_5.txt
@@ -87,7 +87,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_reflection_constant"                     "20"
+        "passive_reflection_constant"                     "20 40 80 140 220"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_echo_sabre.txt
+++ b/game/scripts/npc/items/item_echo_sabre.txt
@@ -1,4 +1,4 @@
-	"DOTAAbilities"
+"DOTAAbilities"
 {
   //=================================================================================================================
   // Recipe: Echo Sabre
@@ -62,7 +62,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "15 35 65 105 155"
+        "bonus_damage"                                    "15 35 75 135 215"
       }
       "02"
       {
@@ -77,7 +77,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "10 15 20 25 30"
+        "bonus_attack_speed"                              "10 20 30 40 50"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_echo_sabre_2.txt
+++ b/game/scripts/npc/items/item_echo_sabre_2.txt
@@ -66,7 +66,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "15 35 65 105 155"
+        "bonus_damage"                                    "15 35 75 135 215"
       }
       "02"
       {
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "10 15 20 25 30"
+        "bonus_attack_speed"                              "10 20 30 40 50"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_echo_sabre_3.txt
+++ b/game/scripts/npc/items/item_echo_sabre_3.txt
@@ -66,7 +66,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "15 35 65 105 155"
+        "bonus_damage"                                    "15 35 75 135 215"
       }
       "02"
       {
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "10 15 20 25 30"
+        "bonus_attack_speed"                              "10 20 30 40 50"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_echo_sabre_4.txt
+++ b/game/scripts/npc/items/item_echo_sabre_4.txt
@@ -66,7 +66,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "15 35 65 105 155"
+        "bonus_damage"                                    "15 35 75 135 215"
       }
       "02"
       {
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "10 15 20 25 30"
+        "bonus_attack_speed"                              "10 20 30 40 50"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_echo_sabre_5.txt
+++ b/game/scripts/npc/items/item_echo_sabre_5.txt
@@ -66,7 +66,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "15 35 65 105 155"
+        "bonus_damage"                                    "15 35 75 135 215"
       }
       "02"
       {
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_attack_speed"                              "10 15 20 25 30"
+        "bonus_attack_speed"                              "10 20 30 40 50"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_havoc_hammer.txt
+++ b/game/scripts/npc/items/item_havoc_hammer.txt
@@ -66,7 +66,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "105 155"
+        "bonus_damage"                                    "135 215"
       }
       "02"
       {
@@ -81,7 +81,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "slow"                                            "50 75"
+        "slow"                                            "50 60"
       }
       "05"
       {
@@ -106,7 +106,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "nuke_base_dmg"                                   "550 650"
+        "nuke_base_dmg"                                   "550 750"
       }
       "10"
       {

--- a/game/scripts/npc/items/item_havoc_hammer_2.txt
+++ b/game/scripts/npc/items/item_havoc_hammer_2.txt
@@ -67,7 +67,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "105 155"
+        "bonus_damage"                                    "135 215"
       }
       "02"
       {
@@ -82,7 +82,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "slow"                                            "50 75"
+        "slow"                                            "50 60"
       }
       "05"
       {
@@ -107,7 +107,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "nuke_base_dmg"                                   "550 650"
+        "nuke_base_dmg"                                   "550 750"
       }
       "10"
       {

--- a/game/scripts/npc/items/item_mask_of_madness.txt
+++ b/game/scripts/npc/items/item_mask_of_madness.txt
@@ -57,7 +57,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 35 65 105 155"
+        "bonus_damage"                                    "10 30 70 130 210"
       }
       "02"
       {
@@ -72,7 +72,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 120 140 170 210"
+        "berserk_bonus_attack_speed"                      "100 110 130 160 200" //OAA
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness_2.txt
+++ b/game/scripts/npc/items/item_mask_of_madness_2.txt
@@ -60,7 +60,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 35 65 105 155"
+        "bonus_damage"                                    "10 30 70 130 210"
       }
       "02"
       {
@@ -75,7 +75,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 120 140 170 210"
+        "berserk_bonus_attack_speed"                      "100 110 130 160 200"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness_3.txt
+++ b/game/scripts/npc/items/item_mask_of_madness_3.txt
@@ -59,7 +59,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 35 65 105 155"
+        "bonus_damage"                                    "10 30 70 130 210"
       }
       "02"
       {
@@ -74,7 +74,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 120 140 170 210"
+        "berserk_bonus_attack_speed"                      "100 110 130 160 200"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness_4.txt
+++ b/game/scripts/npc/items/item_mask_of_madness_4.txt
@@ -59,7 +59,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 35 65 105 155"
+        "bonus_damage"                                    "10 30 70 130 210"
       }
       "02"
       {
@@ -74,7 +74,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 120 140 170 210"
+        "berserk_bonus_attack_speed"                      "100 110 130 160 200"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_mask_of_madness_5.txt
+++ b/game/scripts/npc/items/item_mask_of_madness_5.txt
@@ -60,7 +60,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "10 35 65 105 155"
+        "bonus_damage"                                    "10 30 70 130 210"
       }
       "02"
       {
@@ -75,7 +75,7 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "berserk_bonus_attack_speed"                      "110 120 140 170 210"
+        "berserk_bonus_attack_speed"                      "100 110 130 160 200"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_satanic.txt
+++ b/game/scripts/npc/items/item_satanic.txt
@@ -61,7 +61,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 35 55 85 125" //OAA
+        "bonus_damage"                                    "20 40 80 140 220" //OAA
       }
       "04"
       {

--- a/game/scripts/npc/items/item_satanic_2.txt
+++ b/game/scripts/npc/items/item_satanic_2.txt
@@ -63,7 +63,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 35 55 85 125"
+        "bonus_damage"                                    "20 40 80 140 220"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_satanic_3.txt
+++ b/game/scripts/npc/items/item_satanic_3.txt
@@ -64,7 +64,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 35 55 85 125"
+        "bonus_damage"                                    "20 40 80 140 220"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_satanic_4.txt
+++ b/game/scripts/npc/items/item_satanic_4.txt
@@ -64,7 +64,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 35 55 85 125"
+        "bonus_damage"                                    "20 40 80 140 220"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_satanic_5.txt
+++ b/game/scripts/npc/items/item_satanic_5.txt
@@ -64,7 +64,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "25 35 55 85 125"
+        "bonus_damage"                                    "20 40 80 140 220"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_sheepstick.txt
+++ b/game/scripts/npc/items/item_sheepstick.txt
@@ -60,10 +60,10 @@
         "var_type"                                        "FIELD_INTEGER"
         "bonus_agility"                                   "12 17 27 42 62" //OAA
       }
-      "03" // like Wind Waker
+      "03" // like Gleipnir
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "35 45 60 80 105" //OAA
+        "bonus_intellect"                                 "20 25 35 50 70" //OAA
       }
       "04" // first 3 values must be the same as Wind Waker, 4th value same as vanilla Sheepstick
       {
@@ -73,7 +73,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "sheep_duration"                                  "3.5 3.6 3.7 3.8 4.0"
+        "sheep_duration"                                  "2.5 2.75 3.0 3.25 3.5" //OAA
       }
       "06"
       {

--- a/game/scripts/npc/items/item_sheepstick_2.txt
+++ b/game/scripts/npc/items/item_sheepstick_2.txt
@@ -65,7 +65,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "35 45 60 80 105"
+        "bonus_intellect"                                 "20 25 35 50 70"
       }
       "04"
       {
@@ -75,7 +75,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "sheep_duration"                                  "3.5 3.6 3.7 3.8 4.0"
+        "sheep_duration"                                  "2.5 2.75 3.0 3.25 3.5"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_sheepstick_3.txt
+++ b/game/scripts/npc/items/item_sheepstick_3.txt
@@ -65,7 +65,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "35 45 60 80 105"
+        "bonus_intellect"                                 "20 25 35 50 70"
       }
       "04"
       {
@@ -75,7 +75,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "sheep_duration"                                  "3.5 3.6 3.7 3.8 4.0"
+        "sheep_duration"                                  "2.5 2.75 3.0 3.25 3.5"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_sheepstick_4.txt
+++ b/game/scripts/npc/items/item_sheepstick_4.txt
@@ -64,10 +64,10 @@
         "var_type"                                        "FIELD_INTEGER"
         "bonus_agility"                                   "12 17 27 42 62"
       }
-      "03" // like Wind Waker
+      "03" // like Gleipnir
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "35 45 60 80 105"
+        "bonus_intellect"                                 "20 25 35 50 70"
       }
       "04" // first 3 values must be the same as Wind Waker, 4th value same as vanilla Sheepstick
       {
@@ -77,7 +77,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "sheep_duration"                                  "3.5 3.6 3.7 3.8 4.0"
+        "sheep_duration"                                  "2.5 2.75 3.0 3.25 3.5"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_sheepstick_5.txt
+++ b/game/scripts/npc/items/item_sheepstick_5.txt
@@ -67,7 +67,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "35 45 60 80 105"
+        "bonus_intellect"                                 "20 25 35 50 70"
       }
       "04"
       {
@@ -77,7 +77,7 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "sheep_duration"                                  "3.5 3.6 3.7 3.8 4.0"
+        "sheep_duration"                                  "2.5 2.75 3.0 3.25 3.5"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_solar_crest.txt
+++ b/game/scripts/npc/items/item_solar_crest.txt
@@ -64,7 +64,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "5 8 12 17 23" //OAA
+        "bonus_armor"                                     "6 9 13 18 24" //OAA
       }
       "02"
       {

--- a/game/scripts/npc/items/item_solar_crest_2.txt
+++ b/game/scripts/npc/items/item_solar_crest_2.txt
@@ -66,7 +66,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "5 8 12 17 23" //OAA
+        "bonus_armor"                                     "6 9 13 18 24"
       }
       "02"
       {
@@ -91,7 +91,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "target_attack_speed"                             "50 60 70 80 90" //OAA
+        "target_attack_speed"                             "50 60 70 80 90"
       }
       "07"
       {

--- a/game/scripts/npc/items/item_solar_crest_3.txt
+++ b/game/scripts/npc/items/item_solar_crest_3.txt
@@ -66,7 +66,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "5 8 12 17 23" //OAA
+        "bonus_armor"                                     "6 9 13 18 24"
       }
       "02"
       {
@@ -91,7 +91,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "target_attack_speed"                             "50 60 70 80 90" //OAA
+        "target_attack_speed"                             "50 60 70 80 90"
       }
       "07"
       {

--- a/game/scripts/npc/items/item_solar_crest_4.txt
+++ b/game/scripts/npc/items/item_solar_crest_4.txt
@@ -66,7 +66,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "5 8 12 17 23" //OAA
+        "bonus_armor"                                     "6 9 13 18 24"
       }
       "02"
       {
@@ -91,7 +91,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "target_attack_speed"                             "50 60 70 80 90" //OAA
+        "target_attack_speed"                             "50 60 70 80 90"
       }
       "07"
       {

--- a/game/scripts/npc/items/item_solar_crest_5.txt
+++ b/game/scripts/npc/items/item_solar_crest_5.txt
@@ -66,7 +66,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "5 8 12 17 23" //OAA
+        "bonus_armor"                                     "6 9 13 18 24"
       }
       "02"
       {
@@ -91,7 +91,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "target_attack_speed"                             "50 60 70 80 90" //OAA
+        "target_attack_speed"                             "50 60 70 80 90"
       }
       "07"
       {

--- a/game/scripts/npc/items/neutral/item_demon_stone.txt
+++ b/game/scripts/npc/items/neutral/item_demon_stone.txt
@@ -30,7 +30,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_xpm"                                       "70"
+        "bonus_xpm"                                       "100"
       }
       "02"
       {
@@ -40,7 +40,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_damage"                                    "-300"
+        "bonus_damage"                                    "-100"
       }
     }
   }

--- a/game/scripts/npc/items/neutral/item_reflex_core.txt
+++ b/game/scripts/npc/items/neutral/item_reflex_core.txt
@@ -36,17 +36,17 @@
         "var_type"                                        "FIELD_INTEGER"
         "bonus_evasion"                                   "35"
       }
-	  "01"
+      "02"
       {
         "var_type"                                        "FIELD_INTEGER"
         "spell_dodge_chance"                              "15"
       }
-      "02"
+      "03"
       {
         "var_type"                                        "FIELD_INTEGER"
         "spell_dodge_cooldown"                            "8"
       }
-      "03"
+      "04"
       {
         "var_type"                                        "FIELD_FLOAT"
         "active_duration"                                 "1.0"

--- a/game/scripts/npc/items/neutral/item_stonework_pendant.txt
+++ b/game/scripts/npc/items/neutral/item_stonework_pendant.txt
@@ -30,7 +30,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_spell_lifesteal"                           "30"
+        "bonus_spell_lifesteal"                           "45"
       }
       "02"
       {

--- a/game/scripts/vscripts/items/neutral/demon_stone.lua
+++ b/game/scripts/vscripts/items/neutral/demon_stone.lua
@@ -66,7 +66,7 @@ end
 function modifier_item_demon_stone_passive:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_MANA_BONUS,
-	MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE,
+    MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE,
   }
 end
 

--- a/game/scripts/vscripts/items/neutral/reflex_core.lua
+++ b/game/scripts/vscripts/items/neutral/reflex_core.lua
@@ -49,7 +49,7 @@ end
 function modifier_item_reflex_core_passive:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_ABSORB_SPELL,
-	MODIFIER_PROPERTY_EVASION_CONSTANT,
+    MODIFIER_PROPERTY_EVASION_CONSTANT,
   }
 end
 

--- a/game/scripts/vscripts/items/neutral/stonework_pendant.lua
+++ b/game/scripts/vscripts/items/neutral/stonework_pendant.lua
@@ -168,9 +168,9 @@ function modifier_item_stonework_pendant_passive:OnTakeDamage(event)
     "modifier_item_kaya_and_sange",
   }
 
-  local custom_modifiers = {
-    "modifier_item_stoneskin",
-  }
+  -- local custom_modifiers = {
+    -- "modifier_item_stoneskin",
+  -- }
 
   local spell_lifesteal_amp = 0
 
@@ -185,16 +185,16 @@ function modifier_item_stonework_pendant_passive:OnTakeDamage(event)
     end
   end
 
-  for _, mod_name in pairs(custom_modifiers) do
-    local modifier = attacker:FindModifierByName(mod_name)
-    if modifier then
-      local ability = modifier:GetAbility()
-      if ability then
-        -- Spell Lifesteal Amp stacks multiplicatively
-        spell_lifesteal_amp = 1-(1-spell_lifesteal_amp)*(1-ability:GetSpecialValueFor("spell_lifesteal_amp"))
-      end
-    end
-  end
+  -- for _, mod_name in pairs(custom_modifiers) do
+    -- local modifier = attacker:FindModifierByName(mod_name)
+    -- if modifier then
+      -- local ability = modifier:GetAbility()
+      -- if ability then
+        -- -- Spell Lifesteal Amp stacks multiplicatively
+        -- spell_lifesteal_amp = 1-(1-spell_lifesteal_amp)*(1-ability:GetSpecialValueFor("spell_lifesteal_amp"))
+      -- end
+    -- end
+  -- end
 
   spell_lifesteal_percent = spell_lifesteal_percent * (1 + spell_lifesteal_amp/100)
 

--- a/game/scripts/vscripts/items/neutral/trusty_shovel.lua
+++ b/game/scripts/vscripts/items/neutral/trusty_shovel.lua
@@ -22,14 +22,7 @@ function item_trusty_shovel_oaa:OnSpellStart()
     self.rewards = {}
   end
 
-  if game_time <= 5*60 then
-    self.rewards = {
-      "kobold",
-      "flask",
-      "clarity",
-      "bottle",
-    }
-  elseif game_time > 5*60 and game_time <= 12*60 then
+  if game_time <= 12*60 then
     self.rewards = {
       "kobold",
       "flask",
@@ -46,14 +39,13 @@ function item_trusty_shovel_oaa:OnSpellStart()
     self.rewards = {
       "kobold_commander",
       "burst_elixir",
-      "bottle",
+      "hybrid_elixir",
     }
   elseif game_time > 36*60 and game_time <= 46*60 then
     self.rewards = {
       "ghost",
       "burst_elixir",
       "hybrid_elixir",
-      "bottle",
     }
   elseif game_time > 46*60 then
     self.rewards = {
@@ -61,7 +53,6 @@ function item_trusty_shovel_oaa:OnSpellStart()
       "burst_elixir",
       "hybrid_elixir",
       "sustain_elixir",
-      "bottle",
     }
   end
 
@@ -139,6 +130,7 @@ function item_trusty_shovel_oaa:DigOutItem(item_name, position)
   local item = CreateItem(item_name, nil, nil)
   item:SetSellable(false)
   item:SetShareability(ITEM_FULLY_SHAREABLE)
+  item:SetStacksWithOtherOwners(true)
   CreateItemOnPositionSync(position, item)
 end
 

--- a/game/scripts/vscripts/modifiers/modifier_item_spell_lifesteal_oaa.lua
+++ b/game/scripts/vscripts/modifiers/modifier_item_spell_lifesteal_oaa.lua
@@ -104,9 +104,9 @@ function modifier_item_spell_lifesteal_oaa:OnTakeDamage(params)
     "modifier_item_kaya_and_sange",
   }
 
-  local custom_modifiers = {
-    "modifier_item_stoneskin",
-  }
+  -- local custom_modifiers = {
+    -- "modifier_item_stoneskin",
+  -- }
 
   local spell_lifesteal_amp = 0
 
@@ -121,28 +121,28 @@ function modifier_item_spell_lifesteal_oaa:OnTakeDamage(params)
     end
   end
 
-  for _, mod_name in pairs(custom_modifiers) do
-    local modifier = attacker:FindModifierByName(mod_name)
-    if modifier then
-      local ability = modifier:GetAbility()
-      if ability then
-        -- Spell Lifesteal Amp stacks multiplicatively
-        spell_lifesteal_amp = 1-(1-spell_lifesteal_amp)*(1-ability:GetSpecialValueFor("spell_lifesteal_amp"))
-      end
-    end
-  end
+  -- for _, mod_name in pairs(custom_modifiers) do
+    -- local modifier = attacker:FindModifierByName(mod_name)
+    -- if modifier then
+      -- local ability = modifier:GetAbility()
+      -- if ability then
+        -- -- Spell Lifesteal Amp stacks multiplicatively
+        -- spell_lifesteal_amp = 1-(1-spell_lifesteal_amp)*(1-ability:GetSpecialValueFor("spell_lifesteal_amp"))
+      -- end
+    -- end
+  -- end
 
-  local paladin_sword_modifier = attacker:FindModifierByName("modifier_item_paladin_sword")
-  if paladin_sword_modifier then
-    local paladin_sword = paladin_sword_modifier:GetAbility()
-    if paladin_sword then
-      local bonus = paladin_sword:GetSpecialValueFor("bonus_amp")
-      if bonus then
-        -- Spell Lifesteal Amp stacks multiplicatively
-        spell_lifesteal_amp = 1-(1-spell_lifesteal_amp)*(1-bonus)
-      end
-    end
-  end
+  -- local paladin_sword_modifier = attacker:FindModifierByName("modifier_item_paladin_sword")
+  -- if paladin_sword_modifier then
+    -- local paladin_sword = paladin_sword_modifier:GetAbility()
+    -- if paladin_sword then
+      -- local bonus = paladin_sword:GetSpecialValueFor("bonus_amp")
+      -- if bonus then
+        -- -- Spell Lifesteal Amp stacks multiplicatively
+        -- spell_lifesteal_amp = 1-(1-spell_lifesteal_amp)*(1-bonus)
+      -- end
+    -- end
+  -- end
 
   nHeroHeal = nHeroHeal * (1 + spell_lifesteal_amp/100)
   nCreepHeal = nCreepHeal * (1 + spell_lifesteal_amp/100)


### PR DESCRIPTION
* Blade Mail buffed
* Echo Sabre buffed
* Havoc Hammer mostly buffed
* Solar Crest buffed
* Regen Crystal nerfed
* Scythe of Vyse (Sheepstick) nerfed
* Satanic mostly buffed
* Mask of Madness rebalanced
* Vampire Fang buffed
* Satanic Core nerfed
* Devastator small buff
* Pull Staff buffed
* Neutral items:
1) Demon Stone improvement
2) Stonework Pendant buffed
3) Trusty Shovel buffed