### PR TITLE
Chatterjee buffs

### DIFF
--- a/game/scripts/npc/abilities/electrician_energy_absorption_oaa.txt
+++ b/game/scripts/npc/abilities/electrician_energy_absorption_oaa.txt
@@ -40,7 +40,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "radius"                                          "300"
+        "radius"                                          "400"
       }
       "02"
       {
@@ -61,7 +61,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "speed_absorb_heroes"                             "10"
+        "speed_absorb_heroes"                             "10 15 20 25 30 35"
       }
       "06"
       {

--- a/game/scripts/npc/abilities/talents/electrician_talent5_oaa.txt
+++ b/game/scripts/npc/abilities/talents/electrician_talent5_oaa.txt
@@ -19,7 +19,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "value"                                           "50"
+        "value"                                           "100"
       }
     }
   }

--- a/game/scripts/npc/abilities/talents/electrician_talent6_oaa.txt
+++ b/game/scripts/npc/abilities/talents/electrician_talent6_oaa.txt
@@ -19,7 +19,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "value"                                           "3"
+        "value"                                           "4"
       }
     }
   }

--- a/game/scripts/npc/heroes/chatterjee.txt
+++ b/game/scripts/npc/heroes/chatterjee.txt
@@ -63,7 +63,7 @@
     "AttributeBaseAgility"      "13"
     "AttributeAgilityGain"      "2.0"
     "AttributeBaseIntelligence" "25"
-    "AttributeIntelligenceGain" "2.5"
+    "AttributeIntelligenceGain" "3.5"
 
     // Movement
     //-------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* INT gain increased from 2.5 to 3.5
* Energy Absorption effect radius increased from 300 to 400. (to match Electric Shield radius)
* Energy Absorption speed absorbtion from heroes and bosses increased from 10 to 10/15/20/25/30/35.
* Level 15 Talent +50 Electric Shield damage increased to +100.
* Level 20 Talent Energy Absorption cooldown reduction increased from 3 to 4.