### PR TITLE
Boss damage reduction update

### DIFF
--- a/game/scripts/npc/abilities/necrolyte_reapers_scythe.txt
+++ b/game/scripts/npc/abilities/necrolyte_reapers_scythe.txt
@@ -12,7 +12,7 @@
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO"
-    "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_NOT_ANCIENTS" // OAA, not ancient flag to disable casting on bosses
+    //"AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_NOT_ANCIENTS" // OAA, not ancient flag to disable casting on bosses
     "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_NO"
     "SpellDispellableType"                                "SPELL_DISPELLABLE_NO"
     "AbilityUnitDamageType"                               "DAMAGE_TYPE_MAGICAL"

--- a/game/scripts/vscripts/abilities/boss_regen.lua
+++ b/game/scripts/vscripts/abilities/boss_regen.lua
@@ -134,8 +134,6 @@ if IsServer() then
     local spell = self:GetAbility()
 
     local inflictor = event.inflictor
-    print("[BOSS REGEN ONTAKEDAMAGE] Ability that dealt damage is:")
-    print(inflictor)
     if inflictor then
       local damagingByAccident = {
         item_radiance = true,
@@ -146,7 +144,6 @@ if IsServer() then
         item_cloak_of_flames = true,
       }
       local name = inflictor:GetAbilityName()
-      print("[BOSS REGEN ONTAKEDAMAGE] Name of the ability that is being checked: "..name)
       -- Don't react to damage if it was accidental, we check this by checking boss hp percentage
       if damagingByAccident[name] and parent:GetHealth()/parent:GetMaxHealth() > 90/100 then
         return

--- a/game/scripts/vscripts/abilities/boss_regen.lua
+++ b/game/scripts/vscripts/abilities/boss_regen.lua
@@ -133,6 +133,23 @@ if IsServer() then
 
     local spell = self:GetAbility()
 
+    local inflictor = event.inflictor
+    if inflictor then
+      local damagingByAccident = {
+        item_radiance = true,
+        item_radiance_2 = true,
+        item_radiance_3 = true,
+        item_radiance_4 = true,
+        item_radiance_5 = true,
+        item_cloak_of_flames = true,
+      }
+      local name = inflictor:GetAbilityName()
+      -- Don't react to damage if it was accidental, we check this by checking boss hp percentage
+      if damagingByAccident[name] and parent:GetHealth()/parent:GetMaxHealth() > 90/100 then
+        return
+      end
+    end
+
     -- Don't trigger bleeding when damage is below min aggro dmg (tier * BOSS_AGRO_FACTOR)
     if event.damage > damage_threshold then
       parent:AddNewModifier( parent, spell, "modifier_boss_regen_degen", {duration = spell:GetSpecialValueFor( "degen_duration" )} )

--- a/game/scripts/vscripts/abilities/boss_regen.lua
+++ b/game/scripts/vscripts/abilities/boss_regen.lua
@@ -134,6 +134,8 @@ if IsServer() then
     local spell = self:GetAbility()
 
     local inflictor = event.inflictor
+    print("[BOSS REGEN ONTAKEDAMAGE] Ability that dealt damage is:")
+    print(inflictor)
     if inflictor then
       local damagingByAccident = {
         item_radiance = true,
@@ -144,6 +146,7 @@ if IsServer() then
         item_cloak_of_flames = true,
       }
       local name = inflictor:GetAbilityName()
+      print("[BOSS REGEN ONTAKEDAMAGE] Name of the ability that is being checked: "..name)
       -- Don't react to damage if it was accidental, we check this by checking boss hp percentage
       if damagingByAccident[name] and parent:GetHealth()/parent:GetMaxHealth() > 90/100 then
         return

--- a/game/scripts/vscripts/abilities/boss_resistance.lua
+++ b/game/scripts/vscripts/abilities/boss_resistance.lua
@@ -35,6 +35,27 @@ function modifier_boss_resistance:GetModifierTotal_ConstantBlock(keys)
   if keys.attacker == parent then -- boss degen nonsense
     return 0
   end
+
+  local inflictor = keys.inflictor
+  print("[BOSS RESISTANCE BLOCK] Ability that dealt damage:")
+  print(inflictor)
+  if inflictor and IsServer() then
+    local damagingByAccident = {
+      item_radiance = true,
+      item_radiance_2 = true,
+      item_radiance_3 = true,
+      item_radiance_4 = true,
+      item_radiance_5 = true,
+      item_cloak_of_flames = true,
+    }
+    local name = inflictor:GetAbilityName()
+    print("[BOSS RESISTANCE BLOCK] Name of the ability that is being blocked: "..name)
+    -- Block damage if it was accidental, we check this by checking boss hp percentage
+    if damagingByAccident[name] and parent:GetHealth()/parent:GetMaxHealth() > 90/100 then
+      return keys.damage
+    end
+  end
+
   return keys.damage * damageReduction / 100
 end
 
@@ -165,9 +186,13 @@ function modifier_boss_resistance:GetModifierIncomingDamage_Percentage(keys)
     return 0
   end
 
+  print("[BOSS RESISTANCE REDUCTION] Ability that dealt damage:")
+  print(inflictor)
+
   local name = inflictor:GetAbilityName()
+  print("[BOSS RESISTANCE REDUCTION] Name of the ability that is being reduced: "..name)
   if percentDamageSpells[name] then
-    return -damageReduction
+    --return -damageReduction
   end
 
   -- Leshrac Diabolic Edict bonus damage

--- a/game/scripts/vscripts/abilities/boss_resistance.lua
+++ b/game/scripts/vscripts/abilities/boss_resistance.lua
@@ -29,8 +29,10 @@ function modifier_boss_resistance:DeclareFunctions()
 end
 
 function modifier_boss_resistance:GetModifierTotal_ConstantBlock(keys)
+  local parent = self:GetParent()
   local damageReduction = self:GetAbility():GetSpecialValueFor("percent_damage_reduce")
-  if keys.attacker == self:GetParent() then -- boss degen nonsense
+
+  if keys.attacker == parent then -- boss degen nonsense
     return 0
   end
   return keys.damage * damageReduction / 100
@@ -109,13 +111,18 @@ function modifier_boss_resistance:GetModifierIncomingDamage_Percentage(keys)
 -- [   VScript              ]: mkb_tested: false
 
   local percentDamageSpells = {
+    bloodseeker_bloodrage = true,
     death_prophet_spirit_siphon = true,
     doom_bringer_infernal_blade = true,
     huskar_life_break = true,
+    jakiro_liquid_ice = true,
+    necrolyte_reapers_scythe = true,
+    phantom_assassin_fan_of_knives = true,
+    tinker_shrink_ray = true,
     winter_wyvern_arctic_burn = true
-    --life_stealer_feast = true
   }
 
+  local damageReduction = self:GetAbility():GetSpecialValueFor("percent_damage_reduce")
   local attacker = keys.attacker
   local inflictor = keys.inflictor
 
@@ -160,7 +167,7 @@ function modifier_boss_resistance:GetModifierIncomingDamage_Percentage(keys)
 
   local name = inflictor:GetAbilityName()
   if percentDamageSpells[name] then
-    return -100
+    return -damageReduction
   end
 
   -- Leshrac Diabolic Edict bonus damage
@@ -174,7 +181,6 @@ function modifier_boss_resistance:GetModifierIncomingDamage_Percentage(keys)
     end
   end
 
---   local damageReduction = self:GetAbility():GetSpecialValueFor("percent_damage_reduce")
 --   local parent = self:GetParent()
 --   -- List of modifiers with all damage amplification that need to stack multiplicatively with Boss Resistance
 --   local damageAmpModifiers = {

--- a/game/scripts/vscripts/abilities/shielder/modifier_boss_shielder_shielded.lua
+++ b/game/scripts/vscripts/abilities/shielder/modifier_boss_shielder_shielded.lua
@@ -1,9 +1,9 @@
 modifier_boss_shielder_shielded_buff = class(ModifierBaseClass)
 
 function modifier_boss_shielder_shielded_buff:DeclareFunctions()
-  return
-  {
-    MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE,
+  return {
+    MODIFIER_PROPERTY_TOTAL_CONSTANT_BLOCK,
+    --MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE,
     MODIFIER_EVENT_ON_DEATH
   }
 end
@@ -61,37 +61,51 @@ function modifier_boss_shielder_shielded_buff:IsPurgable()
   return false
 end
 
+function modifier_boss_shielder_shielded_buff:GetModifierTotal_ConstantBlock(keys)
+  local parent = self:GetParent()
+  local ability = self:GetAbility()
+
+  local attacker = keys.attacker
+  local damage = keys.damage
+  local damage_type = keys.damage_type
+  local damage_flags = keys.damage_flags
+
+  if attacker == parent then -- boss degen
+    return 0
+  end
+
+  local attackOrigin = attacker:GetAbsOrigin()
+  local parentOrigin = parent:GetAbsOrigin()
+  local attackDirection = (attackOrigin - parentOrigin):Normalized()
+  local parentFacing = (parent:GetForwardVector()):Normalized()
+  local angleCos = parentFacing:Dot(attackDirection)
+
+  if angleCos > ability:GetSpecialValueFor("shield_width") then
+    -- Return Damage
+    local damage_return = damage * (ability:GetSpecialValueFor("damage_return_pct")) / 100
+    local damage_return_flags = bit.bor(damage_flags, DOTA_DAMAGE_FLAG_REFLECTION)
+    ApplyDamage({
+      victim = attacker,
+      attacker = parent,
+      damage = damage_return,
+      damage_type = damage_type,
+      damage_flags = damage_return_flags,
+      ability = ability
+    })
+
+    local particle = ParticleManager:CreateParticle("particles/units/heroes/hero_spectre/spectre_desolate.vpcf", PATTACH_ABSORIGIN_FOLLOW, parent)
+    ParticleManager:SetParticleControl(particle, 0, parent:GetAbsOrigin())
+    ParticleManager:SetParticleControl(particle, 1, Vector(nil, 0, 0))
+    ParticleManager:ReleaseParticleIndex(particle)
+
+    return damage * (ability:GetSpecialValueFor("damage_reduction_pct")) / 100
+  end
+
+  return 0
+end
+
+--[[
 function modifier_boss_shielder_shielded_buff:GetModifierIncomingDamage_Percentage(keys)
- --[[
-process_procs: true
-order_type: 0
-issuer_player_index: 1982289334
-fail_type: 0
-damage_category: 0
-reincarnate: false
-distance: 0
-gain: 98.332176208496
-attacker: hScript
-ranged_attack: false
-record: 5
-activity: -1
-do_not_consume: false
-damage_type: 4
-heart_regen_applied: false
-diffusal_applied: false
-no_attack_cooldown: false
-cost: 0
-inflictor: hScript
-damage_flags: 0
-original_damage: 650
-ignore_invis: false
-damage: 650
-basher_tested: false
-target: hScript
-]]
---  for k,v in pairs(keys) do
---    print(k .. ': ' .. tostring(v))
---  end
   local parent = self:GetParent()
   local attacker = keys.attacker
   local damage = keys.damage
@@ -99,17 +113,13 @@ target: hScript
   local damage_flags = keys.damage_flags
   local ability = self:GetAbility()
 
-  --if hero and hero:IsRealHero and hero:IsRealHero() then
   local attackOrigin = attacker:GetAbsOrigin()
   local parentOrigin = parent:GetAbsOrigin()
   local attackDirection = (attackOrigin - parentOrigin):Normalized()
   local parentFacing = (parent:GetForwardVector()):Normalized()
   local angleCos = parentFacing:Dot(attackDirection)
-  --end
-  --DebugPrint(angleCos .. ' : ' .. self:GetAbility():GetSpecialValueFor("sheild_width"))
-  if (angleCos > (self:GetAbility():GetSpecialValueFor("shield_width"))) then
-    -- Return Damage
 
+  if (angleCos > (ability:GetSpecialValueFor("shield_width"))) then
     if not bit.band(damage_flags, DOTA_DAMAGE_FLAG_REFLECTION) == DOTA_DAMAGE_FLAG_REFLECTION then
       local damage_return = damage * (ability:GetSpecialValueFor("damage_return_pct"))
       damage_flags = bit.bor(damage_flags, DOTA_DAMAGE_FLAG_REFLECTION)
@@ -133,3 +143,4 @@ target: hScript
 
   return 0
 end
+]]

--- a/game/scripts/vscripts/components/boss/boss_protection.lua
+++ b/game/scripts/vscripts/components/boss/boss_protection.lua
@@ -62,7 +62,7 @@ if not BossProtectionFilter then
     monkey_king_boundless_strike = true,
     morphling_adaptive_strike_str = true,
     naga_siren_song_of_the_siren = true,
-    necrolyte_reapers_scythe = true,
+    --necrolyte_reapers_scythe = true,
     nyx_assassin_spiked_carapace = true,
     nyx_assassin_impale = true,
     obsidian_destroyer_astral_imprisonment = true,
@@ -98,10 +98,13 @@ if not BossProtectionFilter then
   }
 
   BossProtectionFilter.ProblematicSpells = {
-    death_prophet_spirit_siphon = true,
-    doom_bringer_infernal_blade = true,
-    huskar_life_break = true,
-    winter_wyvern_arctic_burn = true
+    death_prophet_spirit_siphon = false,
+    doom_bringer_infernal_blade = false,
+    huskar_life_break = false,
+    jakiro_liquid_ice = false,
+    necrolyte_reapers_scythe = false,
+    tinker_shrink_ray = false,
+    winter_wyvern_arctic_burn = false
   }
 
 end


### PR DESCRIPTION
* Most bosses should ignore accidental Radiance damage now. Bosses that have bad AI still don't ignore it.
* Necrophos Reaper's Scythe can now be used on bosses but the damage is reduced by 97.75%.
* Boss damage reduction for the following spells have been decreased from 100% to 97.75%:
1) Death Prophet Spirit Siphon
2) Doom Infernal Blade
3) Huskar Life Break
4) Winter Wyvern Arctic Burn
* Boss damage reduction for the following spells have been increased from 85% to 97.75%:
1) Bloodseeker Blood Rage (with Shard)
2) Tinker Laser (with Scepter)
* Interaction of Veil of Discord debuff and boss base damage reduction stays the same as before.
* General rule: If a spell does hp percentage based dmg and doesn't work on vanilla Roshan, it will either not work on OAA bosses or the dmg will be reduced by 97.75%. This reduction can be partially mitigated with Veil of Discord debuff.
* Fixed being able to damage Shielder through the shield if he has Veil of Discord debuff.
* Fixed being able to damage Shielder through the shield with abilities that deal bonus damage to bosses.
* Fixed Shielder's damage return not working when attacked from shielded sides.