### PR TITLE
Wanderer tweaks

### DIFF
--- a/game/scripts/npc/abilities/wanderer/wanderer_aoe_cleanse.txt
+++ b/game/scripts/npc/abilities/wanderer/wanderer_aoe_cleanse.txt
@@ -34,7 +34,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "radius"                                          "500"
+        "radius"                                          "450"
       }
       "02"
       {

--- a/game/scripts/npc/abilities/wanderer/wanderer_net.txt
+++ b/game/scripts/npc/abilities/wanderer/wanderer_net.txt
@@ -35,7 +35,7 @@
       "01"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "duration"                                        "4.0"
+        "duration"                                        "3.5"
       }
       "02"
       {

--- a/game/scripts/npc/abilities/wanderer/wanderer_point_aversion.txt
+++ b/game/scripts/npc/abilities/wanderer/wanderer_point_aversion.txt
@@ -25,7 +25,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage_per_point_difference"                     "75"
+        "damage_per_point_difference"                     "100"
       }
     }
   }

--- a/game/scripts/vscripts/abilities/wanderer/oaa_wanderer_aoe_cleanse.lua
+++ b/game/scripts/vscripts/abilities/wanderer/oaa_wanderer_aoe_cleanse.lua
@@ -9,10 +9,11 @@ end
 function wanderer_aoe_cleanse:OnAbilityPhaseStart()
   if IsServer() then
     local caster = self:GetCaster()
+    local radius = self:GetSpecialValueFor("radius")
     self.nPreviewFX = ParticleManager:CreateParticle("particles/darkmoon_creep_warning.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster)
     ParticleManager:SetParticleControlEnt(self.nPreviewFX, 0, caster, PATTACH_ABSORIGIN_FOLLOW, nil, caster:GetOrigin(), true)
-    ParticleManager:SetParticleControl(self.nPreviewFX, 1, Vector(self:GetSpecialValueFor("radius"), self:GetSpecialValueFor("radius"), 175))
-    ParticleManager:SetParticleControl(self.nPreviewFX, 15, Vector(255, 140, 0))
+    ParticleManager:SetParticleControl(self.nPreviewFX, 1, Vector(radius, radius, radius))
+    ParticleManager:SetParticleControl(self.nPreviewFX, 15, Vector(255, 26, 26))
   end
   return true
 end

--- a/game/scripts/vscripts/abilities/wanderer/oaa_wanderer_point_aversion.lua
+++ b/game/scripts/vscripts/abilities/wanderer/oaa_wanderer_point_aversion.lua
@@ -27,7 +27,7 @@ function modifier_wanderer_point_aversion_passive:OnCreated()
   if ability and not ability:IsNull() then
     self.damage = ability:GetSpecialValueFor("damage_per_point_difference")
   else
-    self.damage = 25
+    self.damage = 100
   end
 end
 

--- a/game/scripts/vscripts/abilities/wanderer/oaa_wanderer_sticky_blood.lua
+++ b/game/scripts/vscripts/abilities/wanderer/oaa_wanderer_sticky_blood.lua
@@ -103,9 +103,7 @@ function modifier_wanderer_sticky_blood_passive:OnTakeDamage(event)
     end
 
     if attacker:IsHero() then
-      if not attacker:IsMagicImmune() then
-        self:ProcStickyBlood(caster, ability, attacker)
-      end
+      self:ProcStickyBlood(caster, ability, attacker)
     else
       if attacker.GetPlayerOwner then
         local player = attacker:GetPlayerOwner()
@@ -117,9 +115,7 @@ function modifier_wanderer_sticky_blood_passive:OnTakeDamage(event)
           hero_owner = PlayerResource:GetSelectedHeroEntity(UnitVarToPlayerID(attacker))
         end
         if hero_owner then
-          if not hero_owner:IsMagicImmune() then
-            self:ProcStickyBlood(caster, ability, hero_owner)
-          end
+          self:ProcStickyBlood(caster, ability, hero_owner)
         end
       end
     end
@@ -127,6 +123,11 @@ function modifier_wanderer_sticky_blood_passive:OnTakeDamage(event)
 end
 
 function modifier_wanderer_sticky_blood_passive:ProcStickyBlood(caster, ability, unit)
+  -- If unit is dead, spell immune or in a duel, don't do anything
+  if not unit:IsAlive() or unit:IsMagicImmune() or Duels:IsActive() then
+    return
+  end
+
   -- Proc Sound
   caster:EmitSound("Hero_Batrider.StickyNapalm.Cast")
 


### PR DESCRIPTION
* Wanderer's AoE Cleanse radius reduced from 500 to 450.
* Tried to fix particle of Wanderer's Aoe Cleanse.
* Wanderer's Net duration reduced from 4 to 3.5 seconds.
* Wanderer's Point Aversion damage per point difference increased from 75 to 100.
* Fixed Wanderer's Sticky Blood proc-ing on dead heroes and heroes in duel arenas.