### PR TITLE
Alchemist nerfs

### DIFF
--- a/game/scripts/npc/abilities/alchemist_chemical_rage.txt
+++ b/game/scripts/npc/abilities/alchemist_chemical_rage.txt
@@ -48,7 +48,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "base_attack_time"                                "1.2 1.1 1.0 0.9 0.8"
+        "base_attack_time"                                "1.2 1.15 1.1 1.05 1.0" //OAA
         "LinkedSpecialBonus"                              "special_bonus_unique_alchemist_3"
       }
       "04"

--- a/game/scripts/npc/abilities/alchemist_goblins_greed.txt
+++ b/game/scripts/npc/abilities/alchemist_goblins_greed.txt
@@ -26,17 +26,17 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_gold"                                      "3"
+        "bonus_gold"                                      "3 4 5 6 8 14" //OAA
       }
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_bonus_gold"                                "3 4 5 6 8 11" //OAA
+        "bonus_bonus_gold"                                "3 4 5 6 8 14" //OAA
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_gold_cap"                                  "1000"  //OAA
+        "bonus_gold_cap"                                  "36 42 48 54 66 102" //OAA
       }
       "05"
       {

--- a/game/scripts/npc/abilities/talents/alchemist_talent4.txt
+++ b/game/scripts/npc/abilities/talents/alchemist_talent4.txt
@@ -7,9 +7,9 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"					"7054"														// unique ID number for this ability.  Do not change this once established or it will invalidate collected stats.
-    "AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
-    "AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+    "ID"                                                  "7054"
+    "AbilityType"                                         "DOTA_ABILITY_TYPE_ATTRIBUTES"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------
@@ -17,9 +17,9 @@
     {
       "01"
       {
-        "var_type"					"FIELD_INTEGER"
-        "value"				"80" //OAA
-        "ad_linked_ability"			"alchemist_chemical_rage"
+        "var_type"                                        "FIELD_INTEGER"
+        "value"                                           "50"
+        "ad_linked_ability"                               "alchemist_chemical_rage"
       }
     }
   }


### PR DESCRIPTION
Nerfing bullshit things about OAA Alchemist so he is less overwhelming.
* Chemical rage BAT increased from 1.2/1.1/1/0.9/0.8 to 1.2/1.15/1.1/1.05/1.
* Greevil's Greed Base Gold Bonus and Extra Gold Bonus per Stack are now the same: 3/4/5/6/8/14
* Greevil's Greed Gold Bonus Cap reduced from 1000 to 36/42/48/54/66/102.
* Level 25 talent +80 Chemical Rage hp regen reduced to +50.