### PR TITLE
Underlord Dark Abduction fix

### DIFF
--- a/game/resource/English/ability/units/tooltip_abyssal_underlord_cancel_dark_rift_oaa.txt
+++ b/game/resource/English/ability/units/tooltip_abyssal_underlord_cancel_dark_rift_oaa.txt
@@ -2,7 +2,7 @@
 // Underlord Dark Rift sub ability
 //=============================================================================
 "DOTA_Tooltip_ability_abyssal_underlord_cancel_dark_rift_oaa"                   "Dark Abduction"
-"DOTA_Tooltip_ability_abyssal_underlord_cancel_dark_rift_oaa_Description"       "Teleports Underlord and stunned enemies back to the inital Dark Rift cast location."
+"DOTA_Tooltip_ability_abyssal_underlord_cancel_dark_rift_oaa_Description"       "Teleports Underlord and stunned enemies back to the inital Dark Rift channel location. Doesn't teleport Underlord if there are no stunned enemies."
 "DOTA_Tooltip_ability_abyssal_underlord_cancel_dark_rift_oaa_Lore"              "You are coming with me."
 
 "DOTA_Tooltip_ability_abyssal_underlord_cancel_dark_rift"                       "#{DOTA_Tooltip_ability_abyssal_underlord_cancel_dark_rift_oaa}"

--- a/game/scripts/vscripts/abilities/oaa_cancel_dark_rift.lua
+++ b/game/scripts/vscripts/abilities/oaa_cancel_dark_rift.lua
@@ -18,26 +18,26 @@ function abyssal_underlord_cancel_dark_rift_oaa:OnSpellStart()
   local caster = self:GetCaster()
   local caster_location = caster:GetAbsOrigin()
   local should_teleport_caster = false
-  local destination = caster.original_cast_location
+  local start = caster.dark_rift_target
+  local destination = caster.dark_rift_origin
   local radius = self:GetSpecialValueFor("radius")
 
-  -- play modified gesture
+  -- play modified gesture (dancing)
   caster:StartGesture( ACT_DOTA_OVERRIDE_ABILITY_4 )
 
-  -- Destroy all trees around the caster and around the destination if destination exists
-  if destination then
-    GridNav:DestroyTreesAroundPoint(caster_location, radius, true)
-    GridNav:DestroyTreesAroundPoint(destination, radius, true)
+  -- Don't continue if there are no stored locations on the caster
+  if not start or not destination then
+    return
   end
 
   local targetTeam = self:GetAbilityTargetTeam()
   local targetType = self:GetAbilityTargetType()
   local targetFlags = self:GetAbilityTargetFlags()
 
-  local units_around_caster = FindUnitsInRadius(caster:GetTeamNumber(), caster_location, nil, radius, targetTeam, targetType, targetFlags, FIND_ANY_ORDER, false)
-  for _, unit in pairs(units_around_caster) do
+  local units = FindUnitsInRadius(caster:GetTeamNumber(), start, nil, radius, targetTeam, targetType, targetFlags, FIND_ANY_ORDER, false)
+  for _, unit in pairs(units) do
     -- Teleport only units that are stunned by Dark Rift
-    if unit.HasModifier and unit:HasModifier("modifier_underlord_dark_rift_oaa_stun") then
+    if unit and not unit:IsNull() and unit.HasModifier and unit:HasModifier("modifier_underlord_dark_rift_oaa_stun") then
       should_teleport_caster = true
       if destination then
         -- Teleport the unit
@@ -48,36 +48,47 @@ function abyssal_underlord_cancel_dark_rift_oaa:OnSpellStart()
         ProjectileManager:ProjectileDodge(unit)
 
         -- Teleportation particle
-        local part = ParticleManager:CreateParticle("particles/units/heroes/heroes_underlord/abbysal_underlord_darkrift_ambient_end.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster)
-        ParticleManager:SetParticleControl(part, 2, unit:GetAbsOrigin())
-        ParticleManager:SetParticleControl(part, 5, unit:GetAbsOrigin())
-        ParticleManager:ReleaseParticleIndex(part)
+        --local part = ParticleManager:CreateParticle("particles/units/heroes/heroes_underlord/abbysal_underlord_darkrift_ambient_end.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster)
+        --ParticleManager:SetParticleControl(part, 2, unit:GetAbsOrigin())
+        --ParticleManager:SetParticleControl(part, 5, unit:GetAbsOrigin())
+        --ParticleManager:ReleaseParticleIndex(part)
       end
     end
   end
 
   -- Teleport the caster if there are any stunned units by him and if destination exists
   if should_teleport_caster and destination then
+    -- Sound before teleport
+    caster:EmitSound("Hero_AbyssalUnderlord.DarkRift.Aftershock")
     -- Teleport the caster
     caster:SetAbsOrigin(destination)
     FindClearSpaceForUnit(caster, destination, true)
-    caster.original_cast_location = nil
+
+    -- Remove stored location
+    caster.dark_rift_origin = nil
+    caster.dark_rift_target = nil
 
     -- Disjoint disjointable/dodgeable projectiles
     ProjectileManager:ProjectileDodge(caster)
 
-    -- Teleportation particle
-    local part2 = ParticleManager:CreateParticle("particles/units/heroes/heroes_underlord/abbysal_underlord_darkrift_ambient_end.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster)
-    ParticleManager:SetParticleControl(part2, 2, caster:GetAbsOrigin())
-    ParticleManager:SetParticleControl(part2, 5, caster:GetAbsOrigin())
-    ParticleManager:ReleaseParticleIndex(part2)
+    -- Destroy all trees around the caster
+    GridNav:DestroyTreesAroundPoint(caster_location, radius, true)
 
-    -- play teleportation sounds
-    caster:EmitSound("Hero_AbyssalUnderlord.DarkRift.Aftershock")
+    -- Destroy all trees around destination
+    GridNav:DestroyTreesAroundPoint(destination, radius, true)
+
+    -- Teleportation particle
+    --local part2 = ParticleManager:CreateParticle("particles/units/heroes/heroes_underlord/abbysal_underlord_darkrift_ambient_end.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster)
+    --ParticleManager:SetParticleControl(part2, 2, caster:GetAbsOrigin())
+    --ParticleManager:SetParticleControl(part2, 5, caster:GetAbsOrigin())
+    --ParticleManager:ReleaseParticleIndex(part2)
+
+    -- Sound after teleport
     EmitSoundOnLocationWithCaster(destination, "Hero_AbyssalUnderlord.DarkRift.Aftershock", caster)
   end
 
 	-- Remove particles
+  --[[
   if caster.partPortal1 then
     ParticleManager:DestroyParticle(caster.partPortal1, false)
     ParticleManager:ReleaseParticleIndex(caster.partPortal1)
@@ -88,4 +99,5 @@ function abyssal_underlord_cancel_dark_rift_oaa:OnSpellStart()
     ParticleManager:ReleaseParticleIndex(caster.partPortal2)
     caster.partPortal2 = nil
   end
+  ]]
 end


### PR DESCRIPTION
* Fixed Dark Abduction destroying trees even when Dark Rift wasn't successful.
* Removed all particles from Dark Abduction - maybe this will stop client crashes.
* Made Dark Rift and Dark Abduction code more readable.