### PR TITLE
Score limit and Point gaining changes

### DIFF
--- a/game/scripts/vscripts/components/boss/spawn.lua
+++ b/game/scripts/vscripts/components/boss/spawn.lua
@@ -194,11 +194,14 @@ function BossSpawner:SpawnBoss (pit, boss, bossTier, isProtected)
   bossAI.onDeath(function ()
     DebugPrint('Boss has died ' .. pit.killCount .. ' times')
     pit.killCount = pit.killCount + 1
+    -- Increasing the score limit with the first boss kill of the tier
+    --[[
     if not BossSpawner.hasKilledTiers[bossTier] then
       BossSpawner.hasKilledTiers[bossTier] = true
       local scoreLimitIncrease = PlayerResource:SafeGetTeamPlayerCount() * KILL_LIMIT_INCREASE
       PointsManager:IncreaseLimit(scoreLimitIncrease)
     end
+    ]]
     Timers:CreateTimer(BOSS_RESPAWN_TIMER, function()
       BossSpawner:SpawnBossAtPit(pit, bossTier)
     end)

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -144,7 +144,8 @@ function Duels:CountPlayerDeath (player)
       winningTeamId = DOTA_TEAM_GOODGUYS
     end
 
-    PointsManager:AddPoints(winningTeamId, 1)
+    -- Gaining a point for winning a duel -> not intuitive
+    --PointsManager:AddPoints(winningTeamId, 1)
 
     self:AllPlayers(self.currentDuel, function (otherPlayer)
       if player.duelNumber ~= otherPlayer.duelNumber then

--- a/game/scripts/vscripts/components/gold/hero_kills.lua
+++ b/game/scripts/vscripts/components/gold/hero_kills.lua
@@ -80,10 +80,6 @@ function HeroKillGold:GoldFilter (keys)
 end
 
 function HeroKillGold:HeroDeathHandler (keys)
-  -- points code for reference
-  -- if keys.killer:GetTeam() ~= keys.killed:GetTeam() and not keys.killed:IsReincarnating() and keys.killed:GetTeam() ~= DOTA_TEAM_NEUTRALS then
-  --   self:AddPoints(keys.killer:GetTeam())
-  -- end
   if not keys.killer or not keys.killed then
     return
   end

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -34,9 +34,9 @@ ABANDON_DIFF_NEEDED = 2                   -- how many more abandons you need on 
 ABANDON_NEEDED = 3                        -- how many total abandons you need before auto win conditions can trigger
 
 -- kill limits
-NORMAL_KILL_LIMIT = 3                     -- Starting KILL_LIMIT = NORMAL_KILL_LIMIT x number of players + 10 (5v5 - 40; 4v4 - 34; 3v3 - 28; 2v2 - 22; 1v1 - 16)
-TEN_V_TEN_KILL_LIMIT = 2
-KILL_LIMIT_INCREASE = 1                   -- Actual KILL_LIMIT_INCREASE is equal to number of players (for 10v10 map its 1/2 of the number of players)
+NORMAL_KILL_LIMIT = 5                     -- Starting KILL_LIMIT = (NORMAL_KILL_LIMIT + KILL_LIMIT_INCREASE) x number of players: 5v5 - 40 (60); 4v4 - 34 (48); 3v3 - 28 (36); 2v2 - 22 (24); 1v1 - 16 (12);
+TEN_V_TEN_KILL_LIMIT = 4                  -- Starting KILL_LIMIT = (TEN_V_TEN_KILL_LIMIT + KILL_LIMIT_INCREASE) x number of players: 6v6 - 60; 8v8 - 80; 10v10 - 100;
+KILL_LIMIT_INCREASE = 1                   -- Actual KILL_LIMIT_INCREASE is equal to number of players
 
 -- poop wards
 POOP_WARD_DURATION = 360


### PR DESCRIPTION
* Score limit no longer increases with boss kills.
* Winning a duel no longer gives 1 point.
* Starting score limit temporarily changed from 3*N+10 to 6*N where N is the number of players. (Starting score limit for 5v5 is now 60, for 3v3 its 36, for 2v2 its 24 etc.)
* Score limit will now decrease if a player abandoned and only if that player abandoned after first 3 minutes of the game. Abandons before 3 minutes will not be considered.
* Score limit will now update/refresh itself when a player reconnected at the game start (if there were no points gained). (This will maybe fix the score limit if someone disconnects during hero selection).
* Keep in mind that if a player disconnected during hero selection and it reconnected after first duel or sometime later, score limit will still be reduced (it will be like that player really abandoned).
* Starting score limit for the 10v10 map changed from 2*N+5 to 5*N where N is the number of players. (Starting score limit for 6v6 is now 60, for 8v8 its 80 and for 10v10 its 100.)
* Score limit decrease caused by a player abandon now also scales with the remaining number of players.