### PR TITLE
Tier 2 bosses update

### DIFF
--- a/content/particles/warning/generic_marker.vpcf
+++ b/content/particles/warning/generic_marker.vpcf
@@ -1,0 +1,26 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_nMaxParticles = 0
+	m_Children = 
+	[
+		{
+			m_ChildRef = resource:"particles/generic/generic_marker_model.vpcf"
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/particles/warning/generic_marker_model.vpcf
+++ b/content/particles/warning/generic_marker_model.vpcf
@@ -1,0 +1,102 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 1
+	m_flConstantRadius = 1.0
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_hTexture = resource:"materials/particle/arrow_down.vtex"
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_OscillateScalarSimple"
+			m_flOscAdd = 0.0
+			m_Frequency = 0.0
+			m_Rate = 1.0
+			m_nField = 3
+		},
+		{
+			_class = "C_OP_PositionLock"
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_flEndScale = 0.25
+			m_nOpEndCapState = 0
+			m_flStartScale = 0.0
+			m_flBias = 0.0
+			m_flEndTime = 0.25
+		},
+		{
+			_class = "C_OP_BasicMovement"
+		},
+		{
+			_class = "C_OP_ClampScalar"
+			m_flOutputMax = 50.0
+			m_flOutputMin = 0.5
+		},
+		{
+			_class = "C_OP_LerpEndCapScalar"
+			m_nFieldOutput = 16
+			m_flOutput = 0.0
+			m_flLerpTime = 0.5
+		},
+		{
+			_class = "C_OP_Decay"
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomScalar"
+			m_nFieldOutput = 20
+			m_flMax = 1.2
+			m_flMin = 1.2
+		},
+		{
+			_class = "C_INIT_CreateWithinSphere"
+		},
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMin = 1.5
+			m_fLifetimeMax = 1.5
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMin = 273.061
+			m_flRadiusMax = 278.258
+		},
+		{
+			_class = "C_INIT_PositionOffset"
+			m_OffsetMin = [ 0.0, 0.0, 100.0 ]
+			m_OffsetMax = [ 0.0, 0.0, 100.0 ]
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_InstantaneousEmitter"
+			m_nParticlesToEmit = 1
+		},
+	]
+	m_ConstantColor = [ 255, 0, 0, 255 ]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+}

--- a/content/particles/warning/generic_marker_model_glow.vpcf
+++ b/content/particles/warning/generic_marker_model_glow.vpcf
@@ -1,0 +1,73 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 8
+	m_flConstantRadius = 2.5
+	m_ConstantColor = [ 255, 250, 202, 255 ]
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderSprites"
+			m_nSequenceCombineMode = "SEQUENCE_COMBINE_MODE_USE_SEQUENCE_0"
+			m_hTexture = resource:"materials/particle/particle_glow_03.vtex"
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_PositionLock"
+		},
+		{
+			_class = "C_OP_BasicMovement"
+		},
+		{
+			_class = "C_OP_ColorInterpolate"
+			m_ColorFade = [ 255, 205, 85, 255 ]
+		},
+		{
+			_class = "C_OP_FadeOutSimple"
+		},
+		{
+			_class = "C_OP_Decay"
+		},
+		{
+			_class = "C_OP_InterpolateRadius"
+			m_flStartScale = 0.5
+			m_flEndScale = 1.5
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_CreateWithinSphere"
+		},
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMax = 1.0
+			m_fLifetimeMin = 1.0
+		},
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMin = 32.0
+			m_flRadiusMax = 50.0
+		},
+		{
+			_class = "C_INIT_PositionOffset"
+			m_OffsetMin = [ 0.0, 10.0, 10.0 ]
+			m_OffsetMax = [ 0.0, 10.0, 10.0 ]
+		},
+		{
+			_class = "C_INIT_RandomAlpha"
+			m_nAlphaMin = 50
+			m_nAlphaMax = 100
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_ContinuousEmitter"
+			m_flEmitRate = 3.0
+		},
+	]
+}

--- a/content/particles/warning/warning_particle_cone.vpcf
+++ b/content/particles/warning/warning_particle_cone.vpcf
@@ -1,0 +1,65 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:vpcf25:version{7bca2d8d-3a14-4a76-bd41-f483fdf78d50} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 0
+	m_flConstantRadius = 15.0
+	m_ConstantColor = [ 255, 0, 0, 255 ]
+	m_Children = 
+	[
+		{
+			m_ChildRef = resource:"particles/ui_mouseactions/warning_particle_cone_body.vpcf"
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 1
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 2
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 3
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 1.0, 1.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 4
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 255.0, 255.0, 255.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 6
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 1.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+	m_nBehaviorVersion = 10
+}

--- a/content/particles/warning/warning_particle_cone_body.vpcf
+++ b/content/particles/warning/warning_particle_cone_body.vpcf
@@ -1,0 +1,189 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:vpcf25:version{7bca2d8d-3a14-4a76-bd41-f483fdf78d50} -->
+{
+	_class = "CParticleSystemDefinition"
+	m_bShouldHitboxesFallbackToRenderBounds = false
+	m_nMaxParticles = 48
+	m_flConstantRadius = 15.0
+	m_Renderers = 
+	[
+		{
+			_class = "C_OP_RenderRopes"
+			m_bAdditive = true
+			m_nOrientationType = 3
+			m_hTexture = resource:"materials/particle/pangolier/pangolier_range_gradient.vtex"
+			m_flTextureVWorldSize = 1500.0
+			m_nMaxTesselation = 5
+			m_nMinTesselation = 5
+			m_flDepthBias = 15.0
+			m_flTextureVOffset = 10.0
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_BasicMovement"
+		},
+		{
+			_class = "C_OP_Decay"
+		},
+		{
+			_class = "C_OP_MaintainSequentialPath"
+			m_flTolerance = 2.0
+			m_flNumToAssign = 48.0
+			m_PathParams = 
+			{
+				m_nEndControlPointNumber = 2
+				m_nStartControlPointNumber = 1
+			}
+		},
+		{
+			_class = "C_OP_MovementPlaceOnGround"
+			m_CollisionGroupName = "DEBRIS"
+			m_flTraceOffset = 128.0
+			m_flMaxTraceLength = 512.0
+			m_flTolerance = 2.0
+			m_nRefCP2 = 1
+			m_nRefCP1 = 2
+			m_flOffset = 16.0
+		},
+		{
+			_class = "C_OP_PercentageBetweenCPLerpCPs"
+			m_bRadialCheck = false
+			m_nOutputEndCP = 3
+			m_nOutputStartField = 1
+			m_nOutputStartCP = 3
+			m_nEndCP = 2
+			m_nStartCP = 1
+			m_nSetMethod = "PARTICLE_SET_SCALE_INITIAL_VALUE"
+		},
+		{
+			_class = "C_OP_RemapCPtoVector"
+			m_nCPInput = 4
+			m_nFieldOutput = "6"
+			m_vInputMax = [ 255.0, 255.0, 255.0 ]
+			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+			m_flOpStrength = 
+			{
+				m_nType = "PF_TYPE_CONTROL_POINT_COMPONENT"
+				m_nControlPoint = 6
+				m_nVectorComponent = 0
+				m_nMapType = "PF_MAP_TYPE_REMAP"
+				m_flInput0 = 0.0
+				m_flInput1 = 1.0
+				m_flOutput0 = 0.0
+				m_flOutput1 = 1.0
+			}
+		},
+		{
+			_class = "C_OP_FadeOutSimple"
+		},
+		{
+			_class = "C_OP_FadeInSimple"
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_RandomRadius"
+			m_flRadiusMax = 0.9
+			m_flRadiusMin = 0.9
+		},
+		{
+			_class = "C_INIT_CreateSequentialPath"
+			m_flNumToAssign = 48.0
+			m_PathParams = 
+			{
+				m_nStartControlPointNumber = 1
+			}
+		},
+		{
+			_class = "C_INIT_RandomColor"
+			m_ColorMin = [ 255, 255, 0, 255 ]
+			m_ColorMax = [ 255, 255, 0, 255 ]
+		},
+		{
+			_class = "C_INIT_RandomAlpha"
+			m_nAlphaMin = 150
+			m_nAlphaMax = 150
+		},
+		{
+			_class = "C_INIT_RandomLifeTime"
+			m_fLifetimeMin = 1.5
+			m_fLifetimeMax = 1.5
+		},
+		{
+			_class = "C_INIT_RemapCPtoVector"
+			m_nCPInput = 4
+			m_nFieldOutput = "6"
+			m_vInputMax = [ 255.0, 255.0, 255.0 ]
+			m_vOutputMax = [ 1.0, 1.0, 1.0 ]
+			m_flOpStrength = 
+			{
+				m_nType = "PF_TYPE_CONTROL_POINT_COMPONENT"
+				m_nControlPoint = 6
+				m_nVectorComponent = 0
+				m_nMapType = "PF_MAP_TYPE_REMAP"
+				m_flInput0 = 0.0
+				m_flInput1 = 1.0
+				m_flOutput0 = 0.0
+				m_flOutput1 = 1.0
+			}
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_InstantaneousEmitter"
+			m_nParticlesToEmit = 
+			{
+				m_nType = "PF_TYPE_LITERAL"
+				m_flLiteralValue = 48.0
+			}
+		},
+	]
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+			m_drivers = 
+			[
+				{
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 1
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 2
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 0.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 4
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 255.0, 255.0, 255.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+				{
+					m_iControlPoint = 6
+					m_iAttachType = "PATTACH_WORLDORIGIN"
+					m_vecOffset = [ 1.0, 0.0, 0.0 ]
+					m_angOffset = [ null, null, null ]
+					m_entityName = "self"
+				},
+			]
+		},
+	]
+	m_nBehaviorVersion = 5
+	m_nFirstMultipleOverride_BackwardCompat = 5
+}

--- a/game/resource/English/ability/units/boss/tooltip_boss_earthshock.txt
+++ b/game/resource/English/ability/units/boss/tooltip_boss_earthshock.txt
@@ -1,0 +1,16 @@
+//=============================================================================
+// Bear Boss Earthshock
+//=============================================================================
+"DOTA_Tooltip_ability_bear_boss_earthshock"                               "Earthshock"
+"DOTA_Tooltip_ability_bear_boss_earthshock_Lore"                          ""
+"DOTA_Tooltip_ability_bear_boss_earthshock_Description"                   "Angry bear applies knockback, damage and slow to enemies around him."
+"DOTA_Tooltip_ability_bear_boss_earthshock_radius"                        "RADIUS:"
+"DOTA_Tooltip_ability_bear_boss_earthshock_damage"                        "DAMAGE:"
+"DOTA_Tooltip_ability_bear_boss_earthshock_move_speed_slow"               "%MOVE SPEED SLOW:"
+"DOTA_Tooltip_ability_bear_boss_earthshock_attack_speed_slow"             "%ATTACK SPEED SLOW:"
+"DOTA_Tooltip_ability_bear_boss_earthshock_slow_duration"                 "SLOW DURATION:"
+
+"Dota_Tooltip_modifier_bear_boss_earthshock_debuff"                             "Bear Earthshock Slow"
+"Dota_Tooltip_modifier_bear_boss_earthshock_debuff_description"                 "Movement speed reduced by %dMODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE%%%, attack speed reduced by %dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%."
+
+

--- a/game/scripts/npc/abilities/boss/bear_boss_earthshock.txt
+++ b/game/scripts/npc/abilities/boss/bear_boss_earthshock.txt
@@ -20,7 +20,7 @@
 
     "AbilityCastRange"                                    "450"
     "AbilityCastPoint"                                    "1.8"
-    "AbilityCastAnimation"                                "ACT_DOTA_DIE"
+    "AbilityCastAnimation"                                "ACT_DOTA_IDLE_RARE"
 
     "AbilityCooldown"                                     "8.0"
 

--- a/game/scripts/npc/abilities/boss/bear_boss_earthshock.txt
+++ b/game/scripts/npc/abilities/boss/bear_boss_earthshock.txt
@@ -1,0 +1,61 @@
+"DOTAAbilities"
+{
+  //=================================================================================================================
+  // Bear Boss: Earthshock - AoE damage, slow and knockback
+  // Notes: Doesn't pierce spell immunity;
+  //=================================================================================================================
+  "bear_boss_earthshock"
+  {
+    "ID"                                                  "3588"
+    "BaseClass"                                           "ability_lua"
+    "ScriptFile"                                          "abilities/bear_boss_earthshock.lua"
+    "AbilityTextureName"                                  "ursa_earthshock"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+    "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
+    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+    "AbilityUnitDamageType"                               "DAMAGE_TYPE_PHYSICAL"
+    "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_NO"
+
+    "MaxLevel"                                            "1"
+
+    "AbilityCastRange"                                    "450"
+    "AbilityCastPoint"                                    "1.8"
+    "AbilityCastAnimation"                                "ACT_DOTA_DIE"
+
+    "AbilityCooldown"                                     "8.0"
+
+    "AbilityManaCost"                                     "0"
+    "AbilityProcsMagicStick"                              "1"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "radius"                                          "450"
+      }
+      "02"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "damage"                                          "6000"
+      }
+      "03"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "move_speed_slow"                                 "-50"
+      }
+      "04"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "attack_speed_slow"                               "-350"
+      }
+      "05"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "slow_duration"                                   "3.5"
+      }
+    }
+  }
+}

--- a/game/scripts/npc/abilities/carapace/boss_carapace_headbutt.txt
+++ b/game/scripts/npc/abilities/carapace/boss_carapace_headbutt.txt
@@ -59,7 +59,7 @@
       "05" // length of the rectangle
       {
         "var_type"                  "FIELD_INTEGER"
-        "damage_range"              "200"
+        "damage_range"              "300"
       }
       "06"
       {
@@ -76,15 +76,6 @@
         "var_type"                  "FIELD_INTEGER"
         "range"                     "150"
       }
-    }
-
-    "precache"
-    {
-      "soundfile"                   "soundevents/game_sounds_heroes/game_sounds_juggernaut.vsndevts"
-      "soundfile"                   "soundevents/game_sounds_heroes/game_sounds_ursa.vsndevts"
-      "particle"                    "particles/econ/items/antimage/antimage_ti7_golden/antimage_blink_start_ti7_golden_smoke.vpcf"
-      "particle"                    "particles/econ/items/pudge/pudge_ti6_immortal/pudge_meathook_witness_impact_ti6.vpcf"
-      "particle"                    "particles/warning/warning_particle_cone.vpcf"
     }
   }
 }

--- a/game/scripts/npc/abilities/carapace/boss_carapace_headbutt.txt
+++ b/game/scripts/npc/abilities/carapace/boss_carapace_headbutt.txt
@@ -64,7 +64,7 @@
       "06"
       {
         "var_type"                  "FIELD_INTEGER"
-        "damage"                    "1500"
+        "damage"                    "2000"
       }
       "07" // width of the rectangle
       {
@@ -84,6 +84,7 @@
       "soundfile"                   "soundevents/game_sounds_heroes/game_sounds_ursa.vsndevts"
       "particle"                    "particles/econ/items/antimage/antimage_ti7_golden/antimage_blink_start_ti7_golden_smoke.vpcf"
       "particle"                    "particles/econ/items/pudge/pudge_ti6_immortal/pudge_meathook_witness_impact_ti6.vpcf"
+      "particle"                    "particles/warning/warning_particle_cone.vpcf"
     }
   }
 }

--- a/game/scripts/npc/abilities/charger/boss_charger_charge.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_charge.txt
@@ -1,6 +1,7 @@
-
-"DOTAAbilities" {
-  "boss_charger_charge" {
+"DOTAAbilities"
+{
+  "boss_charger_charge"
+  {
     "ID"                                                  "9901"
     "BaseClass"                                           "ability_lua"
     "ScriptFile"                                          "abilities/charger/boss_charger_charge.lua"
@@ -64,22 +65,22 @@
       "08"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_damage"                                  "500 750 1000"
+        "glancing_damage"                                 "500 750 1000"
       }
       "09"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_slow"                                    "10 30 50"
+        "glancing_slow"                                   "10 30 50"
       }
       "10"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_duration"                                "1 2 3"
+        "glancing_duration"                               "1 2 3"
       }
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_knockback"                               "200 250 300"
+        "glancing_knockback"                              "200 250 300"
       }
     }
   }

--- a/game/scripts/npc/abilities/charger/boss_charger_charge_tier5.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_charge_tier5.txt
@@ -1,6 +1,7 @@
-
-"DOTAAbilities" {
-  "boss_charger_charge_tier5" {
+"DOTAAbilities"
+{
+  "boss_charger_charge_tier5"
+  {
     "ID"                                                  "8574"
     "BaseClass"                                           "ability_lua"
     "ScriptFile"                                          "abilities/charger/boss_charger_charge_tier5.lua"
@@ -64,22 +65,22 @@
       "08"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_damage"                                  "2000 2500 3000"
+        "glancing_damage"                                 "2000 2500 3000"
       }
       "09"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_slow"                                    "10 30 50"
+        "glancing_slow"                                   "10 30 50"
       }
       "10"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_duration"                                "1 2 3"
+        "glancing_duration"                               "1 2 3"
       }
       "11"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "glancing_knockback"                               "200 250 300"
+        "glancing_knockback"                              "200 250 300"
       }
     }
   }

--- a/game/scripts/npc/abilities/charger/boss_charger_summon_pillar.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_summon_pillar.txt
@@ -1,6 +1,7 @@
-
-"DOTAAbilities" {
-  "boss_charger_summon_pillar" {
+"DOTAAbilities"
+{
+  "boss_charger_summon_pillar"
+  {
     "ID"                                                  "9902"
     "BaseClass"                                           "ability_lua"
     "ScriptFile"                                          "abilities/charger/boss_charger_summon_pillar.lua"

--- a/game/scripts/npc/abilities/charger/boss_charger_super_armor.txt
+++ b/game/scripts/npc/abilities/charger/boss_charger_super_armor.txt
@@ -1,6 +1,7 @@
-
-"DOTAAbilities" {
-  "boss_charger_super_armor" {
+"DOTAAbilities"
+{
+  "boss_charger_super_armor"
+  {
     "ID"                                                  "8581"
     "BaseClass"                                           "ability_lua"
     "ScriptFile"                                          "abilities/charger/boss_charger_super_armor.lua"

--- a/game/scripts/npc/abilities/shielder/boss_shielder_shield.txt
+++ b/game/scripts/npc/abilities/shielder/boss_shielder_shield.txt
@@ -1,23 +1,20 @@
 "DOTAAbilities"
 {
   //=================================================================================================================
-  // Generic boss resistance for % based damage
+  // Damage reduction and damage return for all damage dealt from the front; shield size increases
   //=================================================================================================================
   "boss_shielder_shield"
   {
-
     "ID"                                                  "9904"
     "BaseClass"                                           "ability_lua"
     "ScriptFile"                                          "abilities/shielder/boss_shielder_shield.lua"
-    "AbilityTextureName"                                  "tidehunter_kraken_shell"
+    "AbilityTextureName"                                  "mars_bulwark"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
     "AbilityType"                                         "DOTA_ABILITY_TYPE_ULTIMATE"
-
 
     "MaxLevel"                                            "3"
     "RequiredLevel"                                       "1"
     "LevelsBetweenUpgrades"                               "1"
-
 
     "AbilitySpecial"
     {

--- a/game/scripts/npc/abilities/slime/boss_slime_jump.txt
+++ b/game/scripts/npc/abilities/slime/boss_slime_jump.txt
@@ -9,7 +9,7 @@
     // General
     //-------------------------------------------------------------------------------------------------------------
     "BaseClass"                     "ability_lua"
-    "AbilityTextureName"            "bloodseeker_bloodrage"
+    "AbilityTextureName"            "techies_suicide"
     "ScriptFile"                    "abilities/slime/boss_slime_jump.lua"
     "AbilityCastAnimation"          "ACT_DOTA_CAST_ABILITY_1"
     "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
@@ -53,7 +53,7 @@
       "04"
       {
         "var_type"                  "FIELD_INTEGER"
-        "damage"                    "3000"
+        "damage"                    "2000"
       }
       "05"
       {

--- a/game/scripts/npc/abilities/slime/boss_slime_jump.txt
+++ b/game/scripts/npc/abilities/slime/boss_slime_jump.txt
@@ -1,86 +1,80 @@
 "DOTAAbilities"
 {
-    //=================================================================================================================
-    // Slime Boss: Jump
-    //=================================================================================================================
-    "boss_slime_jump"
+  //=================================================================================================================
+  // Slime Boss: Jump
+  //=================================================================================================================
+  "boss_slime_jump"
+  {
+    "ID"                            "8483"
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "BaseClass"                     "ability_lua"
+    "AbilityTextureName"            "bloodseeker_bloodrage"
+    "ScriptFile"                    "abilities/slime/boss_slime_jump.lua"
+    "AbilityCastAnimation"          "ACT_DOTA_CAST_ABILITY_1"
+    "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
+    "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
+    "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
+    "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+    "AbilityUnitDamageType"         "DAMAGE_TYPE_PURE"
+
+    // Casting
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCastRange"              "800"
+    "AbilityCastPoint"              "2.0"
+
+    // Time
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCooldown"               "10"
+
+    // Cost
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityManaCost"               "0"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
     {
-        "ID"                            "8483"
-        // General
-        //-------------------------------------------------------------------------------------------------------------
-        "BaseClass"                     "ability_lua"
-        "AbilityTextureName"            "bloodseeker_bloodrage"
-        "ScriptFile"                    "abilities/slime/boss_slime_jump.lua"
-        "AbilityCastAnimation"          "ACT_DOTA_CAST_ABILITY_1"
-        "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
-        "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
-        "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
-        "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
-        "AbilityUnitDamageType"         "DAMAGE_TYPE_PURE"
-
-        // Casting
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCastRange"              "800"
-        "AbilityCastPoint"              "2.0"
-
-        // Time
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "10"
-
-        // Cost
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityManaCost"               "0"
-
-        // Special
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilitySpecial"
-        {
-            "01"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "target_max_range"          "800"
-            }
-            "02"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "target_min_range"          "300"
-            }
-            "03"
-            {
-                "var_type"                  "FIELD_FLOAT"
-                "movement_speed"            "0.02"
-            }
-            "04"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "damage"                    "3000"
-            }
-            "05"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "knockback"                 "200"
-            }
-            "06"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "slow"                      "-80"
-            }
-            "07"
-            {
-                "var_type"                  "FIELD_FLOAT"
-                "slow_duration"             "1.5"
-            }
-            "08"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "radius"                    "300"
-            }
-        }
-
-        "precache"
-        {
-            "particle"  "particles/econ/items/invoker/invoker_ti6/invoker_deafening_blast_glyphs_shadow_ti6.vpcf"
-            "soundfile" "soundevents/game_sounds_heroes/game_sounds_techies.vsndevts"
-        }
+      "01"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "target_max_range"          "800"
+      }
+      "02"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "target_min_range"          "300"
+      }
+      "03"
+      {
+        "var_type"                  "FIELD_FLOAT"
+        "movement_speed"            "0.02"
+      }
+      "04"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "damage"                    "3000"
+      }
+      "05"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "knockback"                 "200"
+      }
+      "06"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "slow"                      "-80"
+      }
+      "07"
+      {
+        "var_type"                  "FIELD_FLOAT"
+        "slow_duration"             "1.5"
+      }
+      "08"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "radius"                    "300"
+      }
     }
+  }
 }

--- a/game/scripts/npc/abilities/slime/boss_slime_shake.txt
+++ b/game/scripts/npc/abilities/slime/boss_slime_shake.txt
@@ -1,85 +1,85 @@
 "DOTAAbilities"
 {
-    //=================================================================================================================
-    // Slime Boss: Shake
-    //=================================================================================================================
-    "boss_slime_shake"
+  //=================================================================================================================
+  // Slime Boss: Shake
+  //=================================================================================================================
+  "boss_slime_shake"
+  {
+    "ID"                            "8482"
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "BaseClass"                     "ability_lua"
+    "AbilityTextureName"            "abyssal_underlord_firestorm"
+    "ScriptFile"                    "abilities/slime/boss_slime_shake.lua"
+    "AbilityCastAnimation"          "ACT_DOTA_IDLE"
+    "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_CHANNELLED"
+    "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
+    "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
+    "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+    "AbilityUnitDamageType"         "DAMAGE_TYPE_PURE"
+
+    // Casting
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCastRange"              "700"
+    "AbilityCastPoint"              "0.5"
+    "AbilityChannelTime"            "6.0"
+    // Time
+    //-------------------------------------------------------------------------------------------------------------
+    // "AbilityCooldown"               "10"
+
+    // Cost
+    //-------------------------------------------------------------------------------------------------------------
+    // "AbilityManaCost"               "0"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
     {
-        "ID"                            "8482"
-        // General
-        //-------------------------------------------------------------------------------------------------------------
-        "BaseClass"                     "ability_lua"
-        "AbilityTextureName"            "bloodseeker_bloodrage"
-        "ScriptFile"                    "abilities/slime/boss_slime_shake.lua"
-        "AbilityCastAnimation"          "ACT_DOTA_IDLE"
-        "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_CHANNELLED"
-        "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
-        "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
-        "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
-        "AbilityUnitDamageType"         "DAMAGE_TYPE_PURE"
-
-        // Casting
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCastRange"              "700"
-        "AbilityCastPoint"              "0.5"
-        "AbilityChannelTime"            "6.0"
-        // Time
-        //-------------------------------------------------------------------------------------------------------------
-        // "AbilityCooldown"               "10"
-
-        // Cost
-        //-------------------------------------------------------------------------------------------------------------
-        // "AbilityManaCost"               "0"
-
-        // Special
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilitySpecial"
-        {
-            "01"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "chance"                    "50"
-            }
-            "02"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "radius"                    "700"
-            }
-            "03"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "projectile_min_size"       "64"
-            }
-            "04"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "projectile_max_size"       "128"
-            }
-            "05"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "damage"                    "500"
-            }
-            "06"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "slow"                      "-50"
-            }
-            "07"
-            {
-                "var_type"                  "FIELD_FLOAT"
-                "slow_duration"             "5.0"
-            }
-            "08"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "projectile_count"          "24"
-            }
-            "09"
-            {
-                "var_type"                  "FIELD_FLOAT"
-                "delay"                     "1.25"
-            }
-        }
+      "01"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "chance"                    "50"
+      }
+      "02"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "radius"                    "700"
+      }
+      "03"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "projectile_min_size"       "64"
+      }
+      "04"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "projectile_max_size"       "128"
+      }
+      "05"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "damage"                    "1000"
+      }
+      "06"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "slow"                      "-50"
+      }
+      "07"
+      {
+        "var_type"                  "FIELD_FLOAT"
+        "slow_duration"             "5.0"
+      }
+      "08"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "projectile_count"          "24"
+      }
+      "09"
+      {
+        "var_type"                  "FIELD_FLOAT"
+        "delay"                     "1.25"
+      }
     }
+  }
 }

--- a/game/scripts/npc/abilities/slime/boss_slime_slam.txt
+++ b/game/scripts/npc/abilities/slime/boss_slime_slam.txt
@@ -1,77 +1,70 @@
 "DOTAAbilities"
 {
-    //=================================================================================================================
-    // Slime Boss: Slam
-    //=================================================================================================================
-    "boss_slime_slam"
+  //=================================================================================================================
+  // Slime Boss: Slam
+  //=================================================================================================================
+  "boss_slime_slam"
+  {
+    "ID"                            "8575"
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "BaseClass"                     "ability_lua"
+    "AbilityTextureName"            "bloodseeker_bloodrage"
+    "ScriptFile"                    "abilities/slime/boss_slime_slam.lua"
+    "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
+    "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
+    "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
+    "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
+    "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+    "AbilityUnitDamageType"         "DAMAGE_TYPE_PURE"
+
+    // Casting
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCastRange"              "700"
+    "AbilityCastPoint"              "2.0"
+
+    // Time
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCooldown"               "10"
+
+    // Cost
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityManaCost"               "0"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
     {
-        "ID"                            "8575"
-        // General
-        //-------------------------------------------------------------------------------------------------------------
-        "BaseClass"                     "ability_lua"
-        "AbilityTextureName"            "bloodseeker_bloodrage"
-        "ScriptFile"                    "abilities/slime/boss_slime_slam.lua"
-        "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
-        "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
-        "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
-        "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
-        "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
-        "AbilityUnitDamageType"         "DAMAGE_TYPE_PURE"
-
-        // Casting
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCastRange"              "700"
-        "AbilityCastPoint"              "2.0"
-
-        // Time
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "10"
-
-        // Cost
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityManaCost"               "0"
-
-        // Special
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilitySpecial"
-        {
-            "01"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "damage"                    "2000"
-            }
-            "02"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "knockback"                 "150"
-            }
-            "03"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "slow"                      "-80"
-            }
-            "04"
-            {
-                "var_type"                  "FIELD_FLOAT"
-                "slow_duration"             "1.5"
-            }
-            "05"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "width"                     "100"
-            }
-            "06"
-            {
-                "var_type"                  "FIELD_FLOAT"
-                "self_stun"                 "2.5"
-            }
-        }
-
-        "precache"
-        {
-            "particle" "particles/units/heroes/hero_earthshaker/earthshaker_fissure.vpcf"
-            "particle"  "particles/econ/items/pudge/pudge_ti6_immortal/pudge_meathook_witness_impact_ti6.vpcf"
-            "soundfile" "soundevents/game_sounds_heroes/game_sounds_juggernaut.vsndevts"
-        }
+      "01"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "damage"                    "2000"
+      }
+      "02"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "knockback"                 "150"
+      }
+      "03"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "slow"                      "-80"
+      }
+      "04"
+      {
+        "var_type"                  "FIELD_FLOAT"
+        "slow_duration"             "1.5"
+      }
+      "05"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "width"                     "100"
+      }
+      "06"
+      {
+        "var_type"                  "FIELD_FLOAT"
+        "self_stun"                 "2.5"
+      }
     }
+  }
 }

--- a/game/scripts/npc/abilities/slime/boss_slime_slam.txt
+++ b/game/scripts/npc/abilities/slime/boss_slime_slam.txt
@@ -9,7 +9,7 @@
     // General
     //-------------------------------------------------------------------------------------------------------------
     "BaseClass"                     "ability_lua"
-    "AbilityTextureName"            "bloodseeker_bloodrage"
+    "AbilityTextureName"            "earthshaker_fissure"
     "ScriptFile"                    "abilities/slime/boss_slime_slam.lua"
     "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
     "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"

--- a/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
@@ -1,53 +1,59 @@
 "DOTAAbilities"
 {
-    //=================================================================================================================
-    // Swiper Boss: Backswipe
-    //=================================================================================================================
-    "boss_swiper_backswipe"
+  //=================================================================================================================
+  // Swiper Boss: Backswipe
+  //=================================================================================================================
+  "boss_swiper_backswipe"
+  {
+    "ID"                            "8577"
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "BaseClass"                     "ability_lua"
+    "AbilityTextureName"            "bloodseeker_bloodrage"
+    "ScriptFile"                    "abilities/swiper/boss_swiper_backswipe.lua"
+    "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
+    "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+    "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
+    "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
+    "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+    "AbilityUnitDamageType"         "DAMAGE_TYPE_PHYSICAL"
+    "AnimationIgnoresModelScale"    "1"
+
+    // Casting
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCastRange"              "300"
+    "AbilityCastPoint"              "2"
+
+    // Time
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCooldown"               "0.5"
+
+    // Cost
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityManaCost"               "0"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
     {
-        "ID"                            "8577"
-        // General
-        //-------------------------------------------------------------------------------------------------------------
-        "BaseClass"                     "ability_lua"
-        "AbilityTextureName"            "bloodseeker_bloodrage"
-        "ScriptFile"                    "abilities/swiper/boss_swiper_backswipe.lua"
-        "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
-        "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_NO_TARGET"
-        "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
-        "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
-        "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
-        "AbilityUnitDamageType"         "DAMAGE_TYPE_PHYSICAL"
-        "AnimationIgnoresModelScale"     "1"
-
-        // Casting
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCastRange"              "300"
-        "AbilityCastPoint"              "2"
-        // "Radius"                        "200"
-
-        // Time
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "0.5"
-
-        // Cost
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityManaCost"               "0"
-
-        // Special
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilitySpecial"
-        {
-            "01"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "damage"                    "6500"
-            }
-        }
-
-        "precache"
-        {
-            "particle" "particles/bosses/swiper/swiper_backswipe_base.vpcf"
-            "soundfile" "soundevents/game_sounds_heroes/game_sounds_juggernaut.vsndevts"
-        }
+      "01"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "damage"                    "6500"
+      }
+      "02"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "delay"                     "2"
+      }
     }
+
+    "precache"
+    {
+      "particle"                                          "particles/bosses/swiper/swiper_backswipe_base.vpcf"
+      "particle"                                          "particles/warning/warning_particle_cone.vpcf"
+      "particle"                                          "particles/econ/items/pudge/pudge_ti6_immortal/pudge_meathook_witness_impact_ti6.vpcf"
+      "soundfile"                                         "soundevents/game_sounds_heroes/game_sounds_juggernaut.vsndevts"
+    }
+  }
 }

--- a/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_backswipe.txt
@@ -9,7 +9,7 @@
     // General
     //-------------------------------------------------------------------------------------------------------------
     "BaseClass"                     "ability_lua"
-    "AbilityTextureName"            "bloodseeker_bloodrage"
+    "AbilityTextureName"            "sven_great_cleave"
     "ScriptFile"                    "abilities/swiper/boss_swiper_backswipe.lua"
     "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
     "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_NO_TARGET"
@@ -39,7 +39,7 @@
       "01"
       {
         "var_type"                  "FIELD_INTEGER"
-        "damage"                    "6500"
+        "damage"                    "6000"
       }
       "02"
       {

--- a/game/scripts/npc/abilities/swiper/boss_swiper_frontswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_frontswipe.txt
@@ -1,58 +1,64 @@
 "DOTAAbilities"
 {
-    //=================================================================================================================
-    // Swiper Boss: Frontswipe
-    //=================================================================================================================
-    "boss_swiper_frontswipe"
+  //=================================================================================================================
+  // Swiper Boss: Frontswipe
+  //=================================================================================================================
+  "boss_swiper_frontswipe"
+  {
+    "ID"                            "8578"
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "BaseClass"                     "ability_lua"
+    "AbilityTextureName"            "bloodseeker_bloodrage"
+    "ScriptFile"                    "abilities/swiper/boss_swiper_frontswipe.lua"
+    "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
+    "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
+    "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
+    "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
+    "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+    "AbilityUnitDamageType"         "DAMAGE_TYPE_PHYSICAL"
+    "AnimationIgnoresModelScale"    "1"
+
+    // Casting
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCastRange"              "300"
+    "AbilityCastPoint"              "2"
+
+    // Time
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCooldown"               "0.5"
+
+    // Cost
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityManaCost"               "0"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
     {
-        "ID"                            "8578"
-        // General
-        //-------------------------------------------------------------------------------------------------------------
-        "BaseClass"                     "ability_lua"
-        "AbilityTextureName"            "bloodseeker_bloodrage"
-        "ScriptFile"                    "abilities/swiper/boss_swiper_frontswipe.lua"
-        "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
-        "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
-        "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
-        "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
-        "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
-        "AbilityUnitDamageType"         "DAMAGE_TYPE_PHYSICAL"
-        "AnimationIgnoresModelScale"     "1"
-
-        // Casting
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCastRange"              "300"
-        "AbilityCastPoint"              "2"
-        // "Radius"                        "200"
-
-        // Time
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "0.5"
-
-        // Cost
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityManaCost"               "0"
-
-        // Special
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilitySpecial"
-        {
-            "01"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "damage"                    "6500"
-            }
-            "02"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "min_targets"               "1"
-            }
-        }
-
-        "precache"
-        {
-            "particle" "particles/bosses/swiper/swiper_frontswipe_base.vpcf"
-            "soundfile" "soundevents/game_sounds_heroes/game_sounds_juggernaut.vsndevts"
-        }
+      "01"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "damage"                    "6500"
+      }
+      "02"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "min_targets"               "1"
+      }
+      "03"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "delay"                     "2"
+      }
     }
+
+    "precache"
+    {
+      "particle"                                          "particles/bosses/swiper/swiper_frontswipe_base.vpcf"
+      "particle"                                          "particles/warning/warning_particle_cone.vpcf"
+      "particle"                                          "particles/econ/items/pudge/pudge_ti6_immortal/pudge_meathook_witness_impact_ti6.vpcf"
+      "soundfile"                                         "soundevents/game_sounds_heroes/game_sounds_juggernaut.vsndevts"
+    }
+  }
 }

--- a/game/scripts/npc/abilities/swiper/boss_swiper_frontswipe.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_frontswipe.txt
@@ -9,7 +9,7 @@
     // General
     //-------------------------------------------------------------------------------------------------------------
     "BaseClass"                     "ability_lua"
-    "AbilityTextureName"            "bloodseeker_bloodrage"
+    "AbilityTextureName"            "sven_great_cleave"
     "ScriptFile"                    "abilities/swiper/boss_swiper_frontswipe.lua"
     "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
     "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
@@ -39,7 +39,7 @@
       "01"
       {
         "var_type"                  "FIELD_INTEGER"
-        "damage"                    "6500"
+        "damage"                    "6000"
       }
       "02"
       {

--- a/game/scripts/npc/abilities/swiper/boss_swiper_reapers_rush.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_reapers_rush.txt
@@ -1,101 +1,91 @@
 "DOTAAbilities"
 {
-    //=================================================================================================================
-    // Swiper Boss: Reaper's Rush
-    //=================================================================================================================
-    "boss_swiper_reapers_rush"
+  //=================================================================================================================
+  // Swiper Boss: Reaper's Rush
+  //=================================================================================================================
+  "boss_swiper_reapers_rush"
+  {
+    "ID"                            "8579"
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "BaseClass"                     "ability_lua"
+    "AbilityTextureName"            "sven_warcry"
+    "ScriptFile"                    "abilities/swiper/boss_swiper_reapers_rush.lua"
+    "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
+    "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
+    "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
+    "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
+    "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+    "AbilityUnitDamageType"         "DAMAGE_TYPE_PHYSICAL"
+    "AnimationIgnoresModelScale"    "1"
+
+    // Casting
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCastRange"              "1200"
+    "AbilityCastPoint"              "2.0"
+
+    // Time
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCooldown"               "0.5"
+
+    // Cost
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityManaCost"               "0"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
     {
-        "ID"                            "8579"
-        // General
-        //-------------------------------------------------------------------------------------------------------------
-        "BaseClass"                     "ability_lua"
-        "AbilityTextureName"            "bloodseeker_bloodrage"
-        "ScriptFile"                    "abilities/swiper/boss_swiper_reapers_rush.lua"
-        "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
-        "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
-        "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
-        "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
-        "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
-        "AbilityUnitDamageType"         "DAMAGE_TYPE_PHYSICAL"
-        "AnimationIgnoresModelScale"     "1"
-
-        // Casting
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCastRange"              "1200"
-        "AbilityCastPoint"              "2.0"
-
-        // Time
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "0.5"
-
-        // Cost
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityManaCost"               "0"
-
-        // Special
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilitySpecial"
-        {
-            "01"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "speed"                     "1200"
-            }
-            "02"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "max_range"                 "1200"
-            }
-            "03"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "min_range"                 "400"
-            }
-            "04"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "min_targets"               "2"
-            }
-            "05"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "push_length"               "25"
-            }
-            "06"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "slow"                      "-20"
-            }
-            "07"
-            {
-                "var_type"                  "FIELD_FLOAT"
-                "slow_duration"             "1.25"
-            }
-            "08"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "max_damage"                "7000"
-            }
-            "09"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "min_damage"                "2000"
-            }
-            "10"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "radius"                    "200"
-            }
-        //     "11"
-        //     {
-        //         "var_type"                  "FIELD_FLOAT"
-        //         "start_angle"               "1.0"
-        //     }
-        //     "12"
-        //     {
-        //         "var_type"                  "FIELD_FLOAT"
-        //         "end_angle"                 "1.0"
-        //     }
-        }
+      "01"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "speed"                     "1200"
+      }
+      "02"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "max_range"                 "1200"
+      }
+      "03"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "min_range"                 "400"
+      }
+      "04"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "min_targets"               "2"
+      }
+      "05"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "push_length"               "25"
+      }
+      "06"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "slow"                      "-20"
+      }
+      "07"
+      {
+        "var_type"                  "FIELD_FLOAT"
+        "slow_duration"             "1.25"
+      }
+      "08"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "max_damage"                "7000"
+      }
+      "09"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "min_damage"                "2000"
+      }
+      "10"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "radius"                    "200"
+      }
     }
+  }
 }

--- a/game/scripts/npc/abilities/swiper/boss_swiper_thrust.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_thrust.txt
@@ -9,7 +9,7 @@
     // General
     //-------------------------------------------------------------------------------------------------------------
     "BaseClass"                     "ability_lua"
-    "AbilityTextureName"            "bloodseeker_bloodrage"
+    "AbilityTextureName"            "nyx_assassin_impale"
     "ScriptFile"                    "abilities/swiper/boss_swiper_thrust.lua"
     "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
     "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
@@ -54,7 +54,7 @@
       "04"
       {
         "var_type"                  "FIELD_INTEGER"
-        "damage"                    "6500"
+        "damage"                    "6000"
       }
     }
   }

--- a/game/scripts/npc/abilities/swiper/boss_swiper_thrust.txt
+++ b/game/scripts/npc/abilities/swiper/boss_swiper_thrust.txt
@@ -1,66 +1,61 @@
 "DOTAAbilities"
 {
-    //=================================================================================================================
-    // Swiper Boss: Thrust
-    //=================================================================================================================
-    "boss_swiper_thrust"
+  //=================================================================================================================
+  // Swiper Boss: Thrust
+  //=================================================================================================================
+  "boss_swiper_thrust"
+  {
+    "ID"                            "8580"
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "BaseClass"                     "ability_lua"
+    "AbilityTextureName"            "bloodseeker_bloodrage"
+    "ScriptFile"                    "abilities/swiper/boss_swiper_thrust.lua"
+    "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
+    "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
+    "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
+    "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
+    "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+    "AbilityUnitDamageType"         "DAMAGE_TYPE_PHYSICAL"
+    "AnimationIgnoresModelScale"    "1"
+
+    // Casting
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCastRange"              "700"
+    "AbilityCastPoint"              "2.0"
+
+    // Time
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCooldown"               "0.5"
+
+    // Cost
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityManaCost"               "0"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
     {
-        "ID"                            "8580"
-        // General
-        //-------------------------------------------------------------------------------------------------------------
-        "BaseClass"                     "ability_lua"
-        "AbilityTextureName"            "bloodseeker_bloodrage"
-        "ScriptFile"                    "abilities/swiper/boss_swiper_thrust.lua"
-        "AbilityCastAnimation"          "ACT_DOTA_ATTACK"
-        "AbilityBehavior"               "DOTA_ABILITY_BEHAVIOR_POINT"
-        "AbilityUnitTargetTeam"         "DOTA_UNIT_TARGET_TEAM_ENEMY"
-        "AbilityUnitTargetType"         "DOTA_UNIT_TARGET_HERO"
-        "AbilityUnitTargetFlags"        "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
-        "AbilityUnitDamageType"         "DAMAGE_TYPE_PHYSICAL"
-        "AnimationIgnoresModelScale"     "1"
-
-        // Casting
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCastRange"              "700"
-        "AbilityCastPoint"              "2.0"
-
-        // Time
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "0.5"
-
-        // Cost
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilityManaCost"               "0"
-
-        // Special
-        //-------------------------------------------------------------------------------------------------------------
-        "AbilitySpecial"
-        {
-            "01"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "range"                     "700"
-            }
-            "02"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "width"                     "200"
-            }
-            "03"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "target_min_range"          "500"
-            }
-            "04"
-            {
-                "var_type"                  "FIELD_INTEGER"
-                "damage"                    "6500"
-            }
-        }
-
-        "precache"
-        {
-            "soundfile" "soundevents/game_sounds_heroes/game_sounds_ursa.vsndevts"
-        }
+      "01"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "range"                     "700"
+      }
+      "02"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "width"                     "200"
+      }
+      "03"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "target_min_range"          "500"
+      }
+      "04"
+      {
+        "var_type"                  "FIELD_INTEGER"
+        "damage"                    "6500"
+      }
     }
+  }
 }

--- a/game/scripts/npc/abilities/twin/boss_twin_twin_empathy.txt
+++ b/game/scripts/npc/abilities/twin/boss_twin_twin_empathy.txt
@@ -1,11 +1,10 @@
 "DOTAAbilities"
 {
   //=================================================================================================================
-  // Generic boss resistance for % based damage
+  // Equalizing hp with the twin after a timer; both twins have this
   //=================================================================================================================
   "boss_twin_twin_empathy"
   {
-
     "ID"                                                  "9903"
     "BaseClass"                                           "ability_lua"
     "ScriptFile"                                          "abilities/twin/boss_twin_twin_empathy.lua"
@@ -13,11 +12,9 @@
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
     "AbilityType"                                         "DOTA_ABILITY_TYPE_ULTIMATE"
 
-
     "MaxLevel"                                            "3"
     "RequiredLevel"                                       "1"
     "LevelsBetweenUpgrades"                               "1"
-
 
     "AbilitySpecial"
     {

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -71,6 +71,7 @@
 #base "abilities/boss/boss_fury_swipes.txt"
 #base "abilities/boss/boss_cliffwalk.txt"
 #base "abilities/boss/boss_unslowable_attack_speed.txt"
+#base "abilities/boss/bear_boss_earthshock.txt"
 #base "abilities/siltbreaker/siltbreaker_boss_protection.txt"
 
 #base "abilities/spiders/boss_spiders_spider_cold_combustion.txt"

--- a/game/scripts/npc/units/boss/npc_dota_boss_simple_2.txt
+++ b/game/scripts/npc/units/boss/npc_dota_boss_simple_2.txt
@@ -9,7 +9,7 @@
     //
     "BaseClass"                                           "npc_dota_creature" // Class of entity of link to.
     "Model"                                               "models/creeps/forest_bear/forest_bear.vmdl"  // Model.
-    "vscripts"                                            "units/ai_simple.lua"
+    "vscripts"                                            "units/ai_bear_boss.lua"
     "SoundSet"                                            "Roshan"          // Name of sound set.
     "ModelScale"                                          "2"
     "Level"                                               "30"
@@ -20,9 +20,10 @@
     // Abilities
     //----------------------------------------------------------------
     "Ability1"                                            "boss_fury_swipes"
-    "Ability2"                                            "boss_resistance"
-    "Ability3"                                            "boss_cliffwalk"
-    "Ability4"                                            "boss_regen"
+    "Ability2"                                            "bear_boss_earthshock"
+    "Ability3"                                            "boss_resistance"
+    "Ability4"                                            "boss_cliffwalk"
+    "Ability5"                                            "boss_regen"
 
     // Armor
     //----------------------------------------------------------------

--- a/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_2_tier5.txt
+++ b/game/scripts/npc/units/boss/tier5_bosses/npc_dota_boss_simple_2_tier5.txt
@@ -9,7 +9,7 @@
     //
     "BaseClass"                                           "npc_dota_creature" // Class of entity of link to.
     "Model"                                               "models/creeps/forest_bear/forest_bear.vmdl"  // Model.
-    "vscripts"                                            "units/ai_simple.lua"
+    "vscripts"                                            "units/ai_bear_boss.lua"
     "SoundSet"                                            "Roshan"          // Name of sound set.
     "ModelScale"                                          "2"
     "Level"                                               "30"
@@ -20,9 +20,10 @@
     // Abilities
     //----------------------------------------------------------------
     "Ability1"                                            "boss_fury_swipes"
-    "Ability2"                                            "boss_resistance"
-    "Ability3"                                            "boss_cliffwalk"
-    "Ability4"                                            "boss_regen"
+    "Ability2"                                            "bear_boss_earthshock"
+    "Ability3"                                            "boss_resistance"
+    "Ability4"                                            "boss_cliffwalk"
+    "Ability5"                                            "boss_regen"
 
     // Armor
     //----------------------------------------------------------------

--- a/game/scripts/vscripts/abilities/bear_boss_earthshock.lua
+++ b/game/scripts/vscripts/abilities/bear_boss_earthshock.lua
@@ -1,0 +1,141 @@
+LinkLuaModifier("modifier_bear_boss_earthshock_debuff", "abilities/bear_boss_earthshock.lua", LUA_MODIFIER_MOTION_NONE)
+
+bear_boss_earthshock = class(AbilityBaseClass)
+
+function bear_boss_earthshock:Precache(context)
+  PrecacheResource("particle", "particles/darkmoon_creep_warning.vpcf", context)
+  PrecacheResource("particle", "particles/units/heroes/hero_ursa/ursa_earthshock.vpcf", context)
+  PrecacheResource("particle", "particles/units/heroes/hero_ursa/ursa_earthshock_modifier.vpcf", context)
+  PrecacheResource("soundfile", "soundevents/game_sounds_heroes/game_sounds_ursa.vsndevts", context)
+end
+
+function bear_boss_earthshock:OnAbilityPhaseStart()
+  if IsServer() then
+    local caster = self:GetCaster()
+    local radius = self:GetSpecialValueFor("radius")
+    local indicator = ParticleManager:CreateParticle("particles/darkmoon_creep_warning.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster)
+    ParticleManager:SetParticleControlEnt(indicator, 0, caster, PATTACH_ABSORIGIN_FOLLOW, nil, caster:GetOrigin(), true)
+    ParticleManager:SetParticleControl(indicator, 1, Vector(radius, radius, radius))
+    ParticleManager:SetParticleControl(indicator, 15, Vector(255, 26, 26))
+    self.nPreviewFX = indicator
+  end
+  return true
+end
+
+function bear_boss_earthshock:OnAbilityPhaseInterrupted()
+  if IsServer() then
+    if self.nPreviewFX then
+      ParticleManager:DestroyParticle(self.nPreviewFX, true)
+      ParticleManager:ReleaseParticleIndex(self.nPreviewFX)
+      self.nPreviewFX = nil
+    end
+  end
+end
+
+function bear_boss_earthshock:OnSpellStart()
+  -- Remove ability phase (cast) particle
+  if self.nPreviewFX then
+    ParticleManager:DestroyParticle(self.nPreviewFX, true)
+    ParticleManager:ReleaseParticleIndex(self.nPreviewFX)
+    self.nPreviewFX = nil
+  end
+
+  local caster = self:GetCaster()
+  local radius = self:GetSpecialValueFor("radius")
+  local damage = self:GetSpecialValueFor("damage")
+
+  local caster_location = caster:GetAbsOrigin()
+
+  local knockback_table = {
+    should_stun = 1,
+    knockback_duration = 0.5,
+    duration = 0.5,
+    knockback_distance = radius/2,
+    knockback_height = 100,
+    center_x = caster_location.x,
+    center_y = caster_location.y,
+    center_z = caster_location.z
+  }
+
+  -- Find enemies in a radius
+  local enemies = FindUnitsInRadius(
+    caster:GetTeamNumber(),
+    caster_location,
+    nil,
+    radius,
+    DOTA_UNIT_TARGET_TEAM_ENEMY,
+    bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC),
+    DOTA_UNIT_TARGET_FLAG_NONE,
+    FIND_ANY_ORDER,
+    false
+  )
+
+  -- Damage table constants
+  local damage_table = {}
+  damage_table.attacker = caster
+  damage_table.damage_type = DAMAGE_TYPE_PHYSICAL
+  damage_table.damage_flags = DOTA_DAMAGE_FLAG_BYPASSES_BLOCK
+  damage_table.ability = self
+  damage_table.damage = damage
+
+  for _, enemy in pairs(enemies) do
+    if enemy and not enemy:IsNull() and not enemy:IsMagicImmune() and not enemy:IsInvulnerable() then
+      -- Apply knockback
+      enemy:AddNewModifier(caster, self, "modifier_knockback", knockback_table)
+      -- Apply Slow
+      enemy:AddNewModifier(caster, self, "modifier_bear_boss_earthshock_debuff", {duration = self:GetSpecialValueFor("slow_duration")})
+      -- Damage table variables
+      damage_table.victim = enemy
+      -- Apply Damage
+      ApplyDamage(damage_table)
+    end
+  end
+
+  -- Destroy Trees
+  GridNav:DestroyTreesAroundPoint(caster_location, radius, true)
+
+  -- Sound
+  EmitSoundOnLocationWithCaster(caster_location, "Hero_Ursa.Earthshock", caster)
+
+  -- Particle
+  local particle = ParticleManager:CreateParticle("particles/units/heroes/hero_ursa/ursa_earthshock.vpcf", PATTACH_WORLDORIGIN, nil)
+  ParticleManager:SetParticleControl(particle, 0, caster_location)
+  ParticleManager:SetParticleControlForward(particle, 0, caster:GetForwardVector())
+  ParticleManager:SetParticleControl(particle, 1, Vector(radius/2, radius/2, radius/2))
+  ParticleManager:ReleaseParticleIndex(particle)
+end
+
+---------------------------------------------------------------------------------------------------
+
+modifier_bear_boss_earthshock_debuff = class(ModifierBaseClass)
+
+function modifier_bear_boss_earthshock_debuff:IsDebuff()
+  return true
+end
+
+function modifier_bear_boss_earthshock_debuff:IsPurgable()
+  return true
+end
+
+function modifier_bear_boss_earthshock_debuff:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE,
+    MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT
+  }
+end
+
+function modifier_bear_boss_earthshock_debuff:GetModifierMoveSpeedBonus_Percentage()
+  return self:GetAbility():GetSpecialValueFor("move_speed_slow")
+end
+
+function modifier_bear_boss_earthshock_debuff:GetModifierAttackSpeedBonus_Constant()
+  return self:GetAbility():GetSpecialValueFor("attack_speed_slow")
+end
+
+function modifier_bear_boss_earthshock_debuff:GetEffectName()
+  return "particles/units/heroes/hero_ursa/ursa_earthshock_modifier.vpcf"
+end
+
+function modifier_bear_boss_earthshock_debuff:GetEffectAttachType()
+  return PATTACH_ABSORIGIN_FOLLOW
+end

--- a/game/scripts/vscripts/abilities/carapace/boss_carapace_headbutt.lua
+++ b/game/scripts/vscripts/abilities/carapace/boss_carapace_headbutt.lua
@@ -12,17 +12,26 @@ end
 
 --------------------------------------------------------------------------------
 
-if IsServer() then
-	function boss_carapace_headbutt:OnAbilityPhaseStart()
-		local caster = self:GetCaster()
-		local width = self:GetSpecialValueFor("width")
-		local damage_range = self:GetSpecialValueFor("damage_range")
-		local castTime = self:GetCastPoint()
-		local direction = caster:GetForwardVector()
 
-		DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width,0), Vector(damage_range*2,width,50), direction, Vector(255,0,0), 1, castTime)
-		return true
-	end
+function boss_carapace_headbutt:OnAbilityPhaseStart()
+  if IsServer() then
+    local caster = self:GetCaster()
+    local width = self:GetSpecialValueFor("width")
+    local distance = self:GetSpecialValueFor("damage_range")
+    local castTime = self:GetCastPoint()
+    local direction = caster:GetForwardVector()
+
+    -- Warning particle
+    local FX = ParticleManager:CreateParticle("particles/warning/warning_particle_cone.vpcf", PATTACH_WORLDORIGIN, nil)
+    ParticleManager:SetParticleControl(FX, 1, caster:GetAbsOrigin())
+    ParticleManager:SetParticleControl(FX, 2, caster:GetAbsOrigin() + direction*distance)
+    ParticleManager:SetParticleControl(FX, 3, Vector(width, width, width))
+    ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
+    ParticleManager:ReleaseParticleIndex(FX)
+
+    DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width,0), Vector(distance*2,width,50), direction, Vector(255,0,0), 1, castTime)
+  end
+  return true
 end
 
 --------------------------------------------------------------------------------

--- a/game/scripts/vscripts/abilities/carapace/boss_carapace_headbutt.lua
+++ b/game/scripts/vscripts/abilities/carapace/boss_carapace_headbutt.lua
@@ -6,8 +6,16 @@ boss_carapace_headbutt = class(AbilityBaseClass)
 
 --------------------------------------------------------------------------------
 
+function boss_carapace_headbutt:Precache(context)
+  PrecacheResource("particle", "particles/warning/warning_particle_cone.vpcf", context)
+  PrecacheResource("particle", "particles/econ/items/antimage/antimage_ti7_golden/antimage_blink_start_ti7_golden_smoke.vpcf", context)
+  PrecacheResource("particle", "particles/econ/items/pudge/pudge_ti6_immortal/pudge_meathook_witness_impact_ti6.vpcf", context)
+  PrecacheResource("soundfile", "soundevents/game_sounds_heroes/game_sounds_ursa.vsndevts", context)
+  PrecacheResource("soundfile", "soundevents/game_sounds_heroes/game_sounds_juggernaut.vsndevts", context)
+end
+
 function boss_carapace_headbutt:GetPlaybackRateOverride()
-	return 0.25
+  return 0.25
 end
 
 --------------------------------------------------------------------------------
@@ -22,14 +30,14 @@ function boss_carapace_headbutt:OnAbilityPhaseStart()
     local direction = caster:GetForwardVector()
 
     -- Warning particle
-    local FX = ParticleManager:CreateParticle("particles/warning/warning_particle_cone.vpcf", PATTACH_WORLDORIGIN, nil)
+    local FX = ParticleManager:CreateParticle("particles/warning/warning_particle_cone.vpcf", PATTACH_WORLDORIGIN, caster)
     ParticleManager:SetParticleControl(FX, 1, caster:GetAbsOrigin())
-    ParticleManager:SetParticleControl(FX, 2, caster:GetAbsOrigin() + direction*distance)
+    ParticleManager:SetParticleControl(FX, 2, caster:GetAbsOrigin() + direction*(distance+width) + Vector(0, 0, 50))
     ParticleManager:SetParticleControl(FX, 3, Vector(width, width, width))
-    ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
+    ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 255))
     ParticleManager:ReleaseParticleIndex(FX)
 
-    DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width,0), Vector(distance*2,width,50), direction, Vector(255,0,0), 1, castTime)
+    --DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width,0), Vector(distance*2,width,50), direction, Vector(255,0,0), 1, castTime)
   end
   return true
 end
@@ -42,7 +50,7 @@ if IsServer() then
 		local damage_range = self:GetSpecialValueFor("damage_range")
 
 		local startPoint = caster:GetAbsOrigin()
-		local endPoint = caster:GetAbsOrigin() + (caster:GetForwardVector() * damage_range)
+		local endPoint = startPoint + (caster:GetForwardVector() * damage_range)
 
 		local enemies = FindUnitsInLine(
 			caster:GetTeamNumber(),

--- a/game/scripts/vscripts/abilities/shielder/modifier_boss_shielder_shielded.lua
+++ b/game/scripts/vscripts/abilities/shielder/modifier_boss_shielder_shielded.lua
@@ -74,6 +74,14 @@ function modifier_boss_shielder_shielded_buff:GetModifierTotal_ConstantBlock(key
     return 0
   end
 
+  if keys.inflictor then
+    local damaging_ability = keys.inflictor
+    -- Prevent Shielder returning damage to another Shielder
+    if damaging_ability:GetAbilityName() == ability:GetAbilityName() then
+      return 0
+    end
+  end
+
   local attackOrigin = attacker:GetAbsOrigin()
   local parentOrigin = parent:GetAbsOrigin()
   local attackDirection = (attackOrigin - parentOrigin):Normalized()

--- a/game/scripts/vscripts/abilities/slime/boss_slime_jump.lua
+++ b/game/scripts/vscripts/abilities/slime/boss_slime_jump.lua
@@ -12,7 +12,8 @@ function boss_slime_jump:GetPlaybackRateOverride()
 end
 
 function boss_slime_jump:Precache(context)
-  PrecacheResource("particle", "particles/econ/items/invoker/invoker_ti6/invoker_deafening_blast_glyphs_shadow_ti6.vpcf", context)
+  --PrecacheResource("particle", "particles/econ/items/invoker/invoker_ti6/invoker_deafening_blast_glyphs_shadow_ti6.vpcf", context)
+  PrecacheResource("particle", "particles/darkmoon_creep_warning.vpcf", context)
   PrecacheResource("particle", "particles/units/heroes/hero_techies/techies_blast_off_fire_smallmoketrail.vpcf", context)
   PrecacheResource("particle", "particles/econ/items/techies/techies_arcana/techies_suicide_arcana.vpcf", context)
   PrecacheResource("soundfile", "soundevents/game_sounds_heroes/game_sounds_techies.vsndevts", context)
@@ -59,8 +60,13 @@ function boss_slime_jump:OnSpellStart(keys)
 	local origin = caster:GetAbsOrigin()
 	local radius = self:GetSpecialValueFor("radius")
 
-	local indicator = ParticleManager:CreateParticle("particles/econ/items/invoker/invoker_ti6/invoker_deafening_blast_glyphs_shadow_ti6.vpcf", PATTACH_CUSTOMORIGIN, caster)
-	ParticleManager:SetParticleControl(indicator, 3, target + Vector(0,0,16))
+	-- Warning particle (while Slime is flying)
+  --local indicator = ParticleManager:CreateParticle("particles/econ/items/invoker/invoker_ti6/invoker_deafening_blast_glyphs_shadow_ti6.vpcf", PATTACH_CUSTOMORIGIN, caster)
+	--ParticleManager:SetParticleControl(indicator, 3, target + Vector(0,0,16))
+  local indicator = ParticleManager:CreateParticle("particles/darkmoon_creep_warning.vpcf", PATTACH_CUSTOMORIGIN, caster)
+  ParticleManager:SetParticleControl(indicator, 0, target)
+  ParticleManager:SetParticleControl(indicator, 1, Vector(radius, radius, radius))
+  ParticleManager:SetParticleControl(indicator, 15, Vector(255, 26, 26))
 
 	local projectileModifier = caster:AddNewModifier(caster, self, "modifier_generic_projectile", {})
 	local projectileTable = {
@@ -78,6 +84,7 @@ function boss_slime_jump:OnSpellStart(keys)
 			ParticleManager:ReleaseParticleIndex(smoke)
 
 			ParticleManager:DestroyParticle(indicator, true)
+      ParticleManager:ReleaseParticleIndex(indicator)
 
 			local units = self:FindTargets()
 

--- a/game/scripts/vscripts/abilities/slime/boss_slime_jump.lua
+++ b/game/scripts/vscripts/abilities/slime/boss_slime_jump.lua
@@ -12,7 +12,6 @@ function boss_slime_jump:GetPlaybackRateOverride()
 end
 
 function boss_slime_jump:Precache(context)
-  --PrecacheResource("particle", "particles/econ/items/invoker/invoker_ti6/invoker_deafening_blast_glyphs_shadow_ti6.vpcf", context)
   PrecacheResource("particle", "particles/darkmoon_creep_warning.vpcf", context)
   PrecacheResource("particle", "particles/units/heroes/hero_techies/techies_blast_off_fire_smallmoketrail.vpcf", context)
   PrecacheResource("particle", "particles/econ/items/techies/techies_arcana/techies_suicide_arcana.vpcf", context)
@@ -48,7 +47,7 @@ function boss_slime_jump:OnAbilityPhaseStart()
 	local origin = caster:GetAbsOrigin()
 	local radius = self:GetSpecialValueFor("radius")
 
-	DebugDrawCircle(target + Vector(0,0,32), Vector(255,0,0), 55, radius, false, self:GetCastPoint())
+	--DebugDrawCircle(target + Vector(0,0,32), Vector(255,0,0), 55, radius, false, self:GetCastPoint())
 	return true
 end
 
@@ -60,9 +59,7 @@ function boss_slime_jump:OnSpellStart(keys)
 	local origin = caster:GetAbsOrigin()
 	local radius = self:GetSpecialValueFor("radius")
 
-	-- Warning particle (while Slime is flying)
-  --local indicator = ParticleManager:CreateParticle("particles/econ/items/invoker/invoker_ti6/invoker_deafening_blast_glyphs_shadow_ti6.vpcf", PATTACH_CUSTOMORIGIN, caster)
-	--ParticleManager:SetParticleControl(indicator, 3, target + Vector(0,0,16))
+  -- Warning particle (while Slime is flying)
   local indicator = ParticleManager:CreateParticle("particles/darkmoon_creep_warning.vpcf", PATTACH_CUSTOMORIGIN, caster)
   ParticleManager:SetParticleControl(indicator, 0, target)
   ParticleManager:SetParticleControl(indicator, 1, Vector(radius, radius, radius))
@@ -83,8 +80,9 @@ function boss_slime_jump:OnSpellStart(keys)
 			local smoke = ParticleManager:CreateParticle("particles/units/heroes/hero_techies/techies_blast_off_fire_smallmoketrail.vpcf", PATTACH_POINT, caster)
 			ParticleManager:ReleaseParticleIndex(smoke)
 
+            -- Remove warning particle
 			ParticleManager:DestroyParticle(indicator, true)
-      ParticleManager:ReleaseParticleIndex(indicator)
+            ParticleManager:ReleaseParticleIndex(indicator)
 
 			local units = self:FindTargets()
 

--- a/game/scripts/vscripts/abilities/slime/boss_slime_slam.lua
+++ b/game/scripts/vscripts/abilities/slime/boss_slime_slam.lua
@@ -30,7 +30,7 @@ function boss_slime_slam:OnAbilityPhaseStart()
     ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
     ParticleManager:ReleaseParticleIndex(FX)
 
-		--DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width,0), Vector(distance,width,50), direction, Vector(255,0,0), 1, castTime)
+		DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width,0), Vector(distance,width,50), direction, Vector(255,0,0), 1, castTime)
 	end
 	return true
 end

--- a/game/scripts/vscripts/abilities/slime/boss_slime_slam.lua
+++ b/game/scripts/vscripts/abilities/slime/boss_slime_slam.lua
@@ -25,12 +25,12 @@ function boss_slime_slam:OnAbilityPhaseStart()
     -- Warning particle
     local FX = ParticleManager:CreateParticle("particles/warning/warning_particle_cone.vpcf", PATTACH_WORLDORIGIN, nil)
     ParticleManager:SetParticleControl(FX, 1, caster:GetAbsOrigin())
-    ParticleManager:SetParticleControl(FX, 2, target)
+    ParticleManager:SetParticleControl(FX, 2, caster:GetAbsOrigin() + direction*distance)
     ParticleManager:SetParticleControl(FX, 3, Vector(width, width, width))
     ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
     ParticleManager:ReleaseParticleIndex(FX)
 
-		DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width,0), Vector(distance,width,50), direction, Vector(255,0,0), 1, castTime)
+		--DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width,0), Vector(distance,width,50), direction, Vector(255,0,0), 1, castTime)
 	end
 	return true
 end
@@ -98,7 +98,7 @@ function boss_slime_slam:OnSpellStart()
 		local units = self:FindTargets()
 
 		for k,v in pairs(units) do
-			DebugDrawSphere(v:GetAbsOrigin(), Vector(255,0,255), 255, 64, true, 0.3)
+			--DebugDrawSphere(v:GetAbsOrigin(), Vector(255,0,255), 255, 64, true, 0.3)
 
 			v:EmitSound("hero_ursa.attack")
 

--- a/game/scripts/vscripts/abilities/slime/boss_slime_slam.lua
+++ b/game/scripts/vscripts/abilities/slime/boss_slime_slam.lua
@@ -14,25 +14,25 @@ function boss_slime_slam:Precache(context)
 end
 
 function boss_slime_slam:OnAbilityPhaseStart()
-	if IsServer() then
-		local caster = self:GetCaster()
-		local width = self:GetSpecialValueFor("width")
-		local target = GetGroundPosition(self:GetCursorPosition(), caster)
-		local distance = self:GetCastRange(target, caster)
-		local castTime = self:GetCastPoint()
-		local direction = (target - caster:GetAbsOrigin()):Normalized()
+  if IsServer() then
+    local caster = self:GetCaster()
+    local width = self:GetSpecialValueFor("width")
+    local target = GetGroundPosition(self:GetCursorPosition(), caster)
+    local distance = self:GetCastRange(target, caster)
+    local castTime = self:GetCastPoint()
+    local direction = (target - caster:GetAbsOrigin()):Normalized()
 
     -- Warning particle
     local FX = ParticleManager:CreateParticle("particles/warning/warning_particle_cone.vpcf", PATTACH_WORLDORIGIN, nil)
     ParticleManager:SetParticleControl(FX, 1, caster:GetAbsOrigin())
-    ParticleManager:SetParticleControl(FX, 2, caster:GetAbsOrigin() + direction*distance)
+    ParticleManager:SetParticleControl(FX, 2, caster:GetAbsOrigin() + direction*(distance+width))
     ParticleManager:SetParticleControl(FX, 3, Vector(width, width, width))
     ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
     ParticleManager:ReleaseParticleIndex(FX)
 
-		DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width,0), Vector(distance,width,50), direction, Vector(255,0,0), 1, castTime)
-	end
-	return true
+    --DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width,0), Vector(distance,width,50), direction, Vector(255,0,0), 1, castTime)
+  end
+  return true
 end
 
 --------------------------------------------------------------------------------

--- a/game/scripts/vscripts/abilities/slime/boss_slime_slam.lua
+++ b/game/scripts/vscripts/abilities/slime/boss_slime_slam.lua
@@ -9,6 +9,7 @@ boss_slime_slam = class(AbilityBaseClass)
 function boss_slime_slam:Precache(context)
   PrecacheResource("particle", "particles/units/heroes/hero_earthshaker/earthshaker_fissure.vpcf", context)
   PrecacheResource("particle", "particles/econ/items/pudge/pudge_ti6_immortal/pudge_meathook_witness_impact_ti6.vpcf", context)
+  PrecacheResource("particle", "particles/warning/warning_particle_cone.vpcf", context)
   PrecacheResource("soundfile", "soundevents/game_sounds_heroes/game_sounds_juggernaut.vsndevts", context)
 end
 
@@ -20,6 +21,14 @@ function boss_slime_slam:OnAbilityPhaseStart()
 		local distance = self:GetCastRange(target, caster)
 		local castTime = self:GetCastPoint()
 		local direction = (target - caster:GetAbsOrigin()):Normalized()
+
+    -- Warning particle
+    local FX = ParticleManager:CreateParticle("particles/warning/warning_particle_cone.vpcf", PATTACH_WORLDORIGIN, nil)
+    ParticleManager:SetParticleControl(FX, 1, caster:GetAbsOrigin())
+    ParticleManager:SetParticleControl(FX, 2, target)
+    ParticleManager:SetParticleControl(FX, 3, Vector(width, width, width))
+    ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
+    ParticleManager:ReleaseParticleIndex(FX)
 
 		DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width,0), Vector(distance,width,50), direction, Vector(255,0,0), 1, castTime)
 	end

--- a/game/scripts/vscripts/abilities/swiper/boss_swiper_reapers_rush.lua
+++ b/game/scripts/vscripts/abilities/swiper/boss_swiper_reapers_rush.lua
@@ -22,9 +22,9 @@ function boss_swiper_reapers_rush:OnAbilityPhaseStart()
     local direction = (target - caster:GetAbsOrigin()):Normalized()
 
     -- Warning particle
-    local FX = ParticleManager:CreateParticle("particles/warning/warning_particle_cone.vpcf", PATTACH_WORLDORIGIN, nil)
+    local FX = ParticleManager:CreateParticle("particles/warning/warning_particle_cone.vpcf", PATTACH_WORLDORIGIN, caster)
     ParticleManager:SetParticleControl(FX, 1, caster:GetAbsOrigin())
-    ParticleManager:SetParticleControl(FX, 2, caster:GetAbsOrigin() + direction*distance)
+    ParticleManager:SetParticleControl(FX, 2, caster:GetAbsOrigin() + direction*(distance+width))
     ParticleManager:SetParticleControl(FX, 3, Vector(width, width, width))
     ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
     ParticleManager:ReleaseParticleIndex(FX)
@@ -32,13 +32,13 @@ function boss_swiper_reapers_rush:OnAbilityPhaseStart()
     -- Destination indicator particle
     local indicator = ParticleManager:CreateParticle("particles/darkmoon_creep_warning.vpcf", PATTACH_CUSTOMORIGIN, caster)
     ParticleManager:SetParticleControl(indicator, 0, target)
-    ParticleManager:SetParticleControl(indicator, 1, Vector(radius, radius, radius))
+    ParticleManager:SetParticleControl(indicator, 1, Vector(width, width, width))
     ParticleManager:SetParticleControl(indicator, 15, Vector(255, 26, 26))
 
-    self.indicator = indicator
+	self.indicator = indicator
 
-    DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width / 2,0), Vector(distance,width / 2,50), direction, Vector(255,0,0), 1, castTime)
-    DebugDrawCircle(target + Vector(0,0,32), Vector(255,0,0), 128, width, false, castTime + 2.0)
+    --DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width / 2,0), Vector(distance,width / 2,50), direction, Vector(255,0,0), 1, castTime)
+    --DebugDrawCircle(target + Vector(0,0,32), Vector(255,0,0), 128, width, false, castTime + 2.0)
   end
   return true
 end

--- a/game/scripts/vscripts/abilities/swiper/boss_swiper_reapers_rush.lua
+++ b/game/scripts/vscripts/abilities/swiper/boss_swiper_reapers_rush.lua
@@ -4,19 +4,53 @@ boss_swiper_reapers_rush = class(AbilityBaseClass)
 
 --------------------------------------------------------------------------------
 
-function boss_swiper_reapers_rush:OnAbilityPhaseStart()
-	if IsServer() then
-		local caster = self:GetCaster()
-		local width = self:GetSpecialValueFor("radius")
-		local target = self:GetCursorPosition()
-		local distance = (target - caster:GetAbsOrigin()):Length2D()
-		local castTime = self:GetCastPoint()
-		local direction = (target - caster:GetAbsOrigin()):Normalized()
+function boss_swiper_reapers_rush:Precache(context)
+  PrecacheResource("particle", "particles/warning/warning_particle_cone.vpcf", context)
+  PrecacheResource("particle", "particles/darkmoon_creep_warning.vpcf", context)
+  PrecacheResource("particle", "particles/econ/items/bloodseeker/bloodseeker_eztzhok_weapon/bloodseeker_bloodbath_eztzhok_burst.vpcf", context)
+  PrecacheResource("particle", "particles/econ/items/lich/frozen_chains_ti6/lich_frozenchains_frostnova_swipe.vpcf", context)
+  PrecacheResource("soundfile", "soundevents/game_sounds_heroes/game_sounds_ursa.vsndevts", context)
+end
 
-		DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width / 2,0), Vector(distance,width / 2,50), direction, Vector(255,0,0), 1, castTime)
-		DebugDrawCircle(target + Vector(0,0,32), Vector(255,0,0), 128, width, false, castTime + 2.0)
-	end
-	return true
+function boss_swiper_reapers_rush:OnAbilityPhaseStart()
+  if IsServer() then
+    local caster = self:GetCaster()
+    local width = self:GetSpecialValueFor("radius")
+    local target = self:GetCursorPosition()
+    local distance = (target - caster:GetAbsOrigin()):Length2D()
+    local castTime = self:GetCastPoint()
+    local direction = (target - caster:GetAbsOrigin()):Normalized()
+
+    -- Warning particle
+    local FX = ParticleManager:CreateParticle("particles/warning/warning_particle_cone.vpcf", PATTACH_WORLDORIGIN, nil)
+    ParticleManager:SetParticleControl(FX, 1, caster:GetAbsOrigin())
+    ParticleManager:SetParticleControl(FX, 2, caster:GetAbsOrigin() + direction*distance)
+    ParticleManager:SetParticleControl(FX, 3, Vector(width, width, width))
+    ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
+    ParticleManager:ReleaseParticleIndex(FX)
+
+    -- Destination indicator particle
+    local indicator = ParticleManager:CreateParticle("particles/darkmoon_creep_warning.vpcf", PATTACH_CUSTOMORIGIN, caster)
+    ParticleManager:SetParticleControl(indicator, 0, target)
+    ParticleManager:SetParticleControl(indicator, 1, Vector(radius, radius, radius))
+    ParticleManager:SetParticleControl(indicator, 15, Vector(255, 26, 26))
+
+    self.indicator = indicator
+
+    DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width / 2,0), Vector(distance,width / 2,50), direction, Vector(255,0,0), 1, castTime)
+    DebugDrawCircle(target + Vector(0,0,32), Vector(255,0,0), 128, width, false, castTime + 2.0)
+  end
+  return true
+end
+
+function boss_swiper_reapers_rush:OnAbilityPhaseInterrupted()
+  if IsServer() then
+    if self.indicator then
+      ParticleManager:DestroyParticle(self.indicator, true)
+      ParticleManager:ReleaseParticleIndex(self.indicator)
+      self.indicator = nil
+    end
+  end
 end
 
 --------------------------------------------------------------------------------
@@ -28,19 +62,24 @@ end
 --------------------------------------------------------------------------------
 
 function boss_swiper_reapers_rush:OnSpellStart()
-	if IsServer() then
-		local caster = self:GetCaster()
-		local target = self:GetCursorPosition()
-		local distance = (target - caster:GetAbsOrigin()):Length2D()
-		local direction = (target - caster:GetAbsOrigin()):Normalized()
+  -- Remove ability phase (indicator) particle
+  if self.indicator then
+    ParticleManager:DestroyParticle(self.indicator, true)
+    ParticleManager:ReleaseParticleIndex(self.indicator)
+    self.indicator = nil
+  end
 
-		caster:Stop()
+  local caster = self:GetCaster()
+  local target = self:GetCursorPosition()
+  local distance = (target - caster:GetAbsOrigin()):Length2D()
+  local direction = (target - caster:GetAbsOrigin()):Normalized()
 
-		local modifierTable = {}
-		modifierTable.speed = self:GetSpecialValueFor("speed")
-		modifierTable.distance = distance
-		caster:AddNewModifier(caster, self, "modifier_boss_swiper_reapers_rush_active", modifierTable)
-	end
+  caster:Stop()
+
+  local modifierTable = {}
+  modifierTable.speed = self:GetSpecialValueFor("speed")
+  modifierTable.distance = distance
+  caster:AddNewModifier(caster, self, "modifier_boss_swiper_reapers_rush_active", modifierTable)
 end
 
 ------------------------------------------------------------------------------------
@@ -56,53 +95,52 @@ end
 ------------------------------------------------------------------------------------
 
 function modifier_boss_swiper_reapers_rush_active:GetActivityTranslationModifiers()
-    return "haste"
+  return "haste"
 end
 
 --------------------------------------------------------------------------------
 
 function modifier_boss_swiper_reapers_rush_active:GetOverrideAnimationRate()
-	return 2.0
+  return 2.0
 end
 
 ------------------------------------------------------------------------------------
 
 function modifier_boss_swiper_reapers_rush_active:GetOverrideAnimation()
-	return ACT_DOTA_RUN
+  return ACT_DOTA_RUN
 end
 
 ------------------------------------------------------------------------------------
 
 function modifier_boss_swiper_reapers_rush_active:GetOverrideAnimationWeight(params)
-    return 1.0
+  return 1.0
 end
 
 ------------------------------------------------------------------------------------
 
 function modifier_boss_swiper_reapers_rush_active:DeclareFunctions()
-	local funcs = {
-        MODIFIER_PROPERTY_OVERRIDE_ANIMATION,
-        MODIFIER_PROPERTY_OVERRIDE_ANIMATION_WEIGHT,
-        MODIFIER_PROPERTY_OVERRIDE_ANIMATION_RATE,
-		MODIFIER_PROPERTY_TRANSLATE_ACTIVITY_MODIFIERS
-	}
+  local funcs = {
+    MODIFIER_PROPERTY_OVERRIDE_ANIMATION,
+    MODIFIER_PROPERTY_OVERRIDE_ANIMATION_WEIGHT,
+    MODIFIER_PROPERTY_OVERRIDE_ANIMATION_RATE,
+    MODIFIER_PROPERTY_TRANSLATE_ACTIVITY_MODIFIERS
+  }
 
-	return funcs
+  return funcs
 end
 
 ------------------------------------------------------------------------------------
 
 function modifier_boss_swiper_reapers_rush_active:CheckState()
-    local state = {
-        [MODIFIER_STATE_COMMAND_RESTRICTED] = true,
-        [MODIFIER_STATE_NO_UNIT_COLLISION] = true,
-        [MODIFIER_STATE_FLYING_FOR_PATHING_PURPOSES_ONLY] = true,
-        [MODIFIER_STATE_STUNNED] = true,
-        [MODIFIER_STATE_MAGIC_IMMUNE] = true,
-        -- [MODIFIER_STATE_INVULNERABLE] = true,
-    }
+  local state = {
+    [MODIFIER_STATE_COMMAND_RESTRICTED] = true,
+    [MODIFIER_STATE_NO_UNIT_COLLISION] = true,
+    [MODIFIER_STATE_FLYING_FOR_PATHING_PURPOSES_ONLY] = true,
+    [MODIFIER_STATE_STUNNED] = true,
+    [MODIFIER_STATE_MAGIC_IMMUNE] = true,
+  }
 
-    return state
+  return state
 end
 
 ------------------------------------------------------------------------------------

--- a/game/scripts/vscripts/abilities/swiper/boss_swiper_swipe.lua
+++ b/game/scripts/vscripts/abilities/swiper/boss_swiper_swipe.lua
@@ -58,32 +58,24 @@ function boss_swiper_backswipe_base:OnAbilityPhaseStart()
 
     caster:AddNewModifier(caster, self, "modifier_boss_swiper_anti_stun", {duration = self:GetCastPoint()})
 
-    self:DebugRange(caster, range)
+    --self:DebugRange(caster, range)
 
     local delay = self:GetSpecialValueFor("delay") --self:GetCastPoint()
 
     local position2 = caster_loc + (caster:GetForwardVector() * range)
-    local position1 = RotatePosition(caster_loc, QAngle(0,45,0), position2)
-    local position3 = RotatePosition(caster_loc, QAngle(0,-45,0), position2)
+    local position1 = RotatePosition(caster_loc, QAngle(0, 45, 0), position2)
+    local position3 = RotatePosition(caster_loc, QAngle(0, -45, 0), position2)
     local forward1 = (position1 - caster_loc):Normalized()
     local forward3 = (position3 - caster_loc):Normalized()
     local width = (position2 - position1):Length2D() / 2
 
-    -- Warning particle
-    local FX = ParticleManager:CreateParticle("particles/warning/warning_particle_cone.vpcf", PATTACH_WORLDORIGIN, nil)
-    ParticleManager:SetParticleControl(FX, 1, GetGroundPosition(caster_loc, nil)
-    ParticleManager:SetParticleControl(FX, 2, GetGroundPosition(position2, nil)
-    ParticleManager:SetParticleControl(FX, 3, Vector(3*width, 100, 3*width))
-    ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
-    ParticleManager:ReleaseParticleIndex(FX)
-
-    -- Hit particle
-    Timers:CreateTimer(delay, function()
+    -- Particle
+	Timers:CreateTimer(delay/2, function()
       local swipe = ParticleManager:CreateParticle(self.particleName, PATTACH_CUSTOMORIGIN, caster)
-      ParticleManager:SetParticleControl(swipe, 0, caster_loc + (caster:GetForwardVector() * 50) + Vector(0,0,100))
-      ParticleManager:SetParticleControl(swipe, 1, caster_loc + (caster:GetForwardVector() * 100) + Vector(0,0,100))
-      ParticleManager:SetParticleControl(swipe, 2, Vector(1.25,0,0))
-      ParticleManager:SetParticleControl(swipe, 3, Vector(0.8,0,0))
+      ParticleManager:SetParticleControl(swipe, 0, caster_loc + (caster:GetForwardVector() * 50) + Vector(0, 0, 100))
+      ParticleManager:SetParticleControl(swipe, 1, caster_loc + (caster:GetForwardVector() * 100) + Vector(0, 0, 100))
+      ParticleManager:SetParticleControl(swipe, 2, Vector(1.25, 0, 0))
+      ParticleManager:SetParticleControl(swipe, 3, Vector(0.8, 0, 0))
       ParticleManager:ReleaseParticleIndex(swipe)
     end)
 
@@ -114,7 +106,7 @@ function boss_swiper_backswipe_base:OnAbilityPhaseStart()
 		end
 
 		for k, direction in pairs(directions) do
-			Timers:CreateTimer(delay + (delay * math.abs(k - modifier))/6, function()
+			Timers:CreateTimer(delay/2 + (delay * math.abs(k - modifier))/12, function()
 				local units = self:FindUnitsInCone(
 					caster_loc,
 					direction,

--- a/game/scripts/vscripts/abilities/swiper/boss_swiper_thrust.lua
+++ b/game/scripts/vscripts/abilities/swiper/boss_swiper_thrust.lua
@@ -28,7 +28,7 @@ function boss_swiper_thrust:OnAbilityPhaseStart()
     ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
     ParticleManager:ReleaseParticleIndex(FX)
 
-		DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width / 2,0), Vector(distance,width / 2,50), direction, Vector(255,0,0), 1, castTime)
+    --DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width / 2,0), Vector(distance,width / 2,50), direction, Vector(255,0,0), 1, castTime)
 	end
 	return true
 end
@@ -70,7 +70,7 @@ end
 function boss_swiper_thrust:OnProjectileHit( target, location )
 	if IsServer() then
 		if target ~= nil then
-			DebugDrawSphere(target:GetAbsOrigin(), Vector(255,0,255), 255, 64, true, 0.3)
+			--DebugDrawSphere(target:GetAbsOrigin(), Vector(255,0,255), 255, 64, true, 0.3)
 
 			target:EmitSound("hero_ursa.attack")
 

--- a/game/scripts/vscripts/abilities/swiper/boss_swiper_thrust.lua
+++ b/game/scripts/vscripts/abilities/swiper/boss_swiper_thrust.lua
@@ -4,6 +4,13 @@ boss_swiper_thrust = class(AbilityBaseClass)
 
 --------------------------------------------------------------------------------
 
+function boss_swiper_thrust:Precache(context)
+  PrecacheResource("particle", "particles/units/heroes/hero_nyx_assassin/nyx_assassin_impale.vpcf", context)
+  PrecacheResource("particle", "particles/econ/items/bloodseeker/bloodseeker_eztzhok_weapon/bloodseeker_bloodbath_eztzhok_burst.vpcf", context)
+  PrecacheResource("particle", "particles/warning/warning_particle_cone.vpcf", context)
+  PrecacheResource("soundfile", "soundevents/game_sounds_heroes/game_sounds_ursa.vsndevts", context)
+end
+
 function boss_swiper_thrust:OnAbilityPhaseStart()
 	if IsServer() then
 		local caster = self:GetCaster()
@@ -12,6 +19,14 @@ function boss_swiper_thrust:OnAbilityPhaseStart()
 		local distance = (target - caster:GetAbsOrigin()):Length()
 		local castTime = self:GetCastPoint()
 		local direction = (target - caster:GetAbsOrigin()):Normalized()
+
+    -- Warning particle
+    local FX = ParticleManager:CreateParticle("particles/warning/warning_particle_cone.vpcf", PATTACH_WORLDORIGIN, nil)
+    ParticleManager:SetParticleControl(FX, 1, caster:GetAbsOrigin())
+    ParticleManager:SetParticleControl(FX, 2, target)
+    ParticleManager:SetParticleControl(FX, 3, Vector(width, width, width))
+    ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
+    ParticleManager:ReleaseParticleIndex(FX)
 
 		DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width / 2,0), Vector(distance,width / 2,50), direction, Vector(255,0,0), 1, castTime)
 	end

--- a/game/scripts/vscripts/abilities/swiper/boss_swiper_thrust.lua
+++ b/game/scripts/vscripts/abilities/swiper/boss_swiper_thrust.lua
@@ -12,25 +12,25 @@ function boss_swiper_thrust:Precache(context)
 end
 
 function boss_swiper_thrust:OnAbilityPhaseStart()
-	if IsServer() then
-		local caster = self:GetCaster()
-		local width = self:GetSpecialValueFor("width")
-		local target = GetGroundPosition(self:GetCursorPosition(), caster)
-		local distance = (target - caster:GetAbsOrigin()):Length2D()
-		local castTime = self:GetCastPoint()
-		local direction = (target - caster:GetAbsOrigin()):Normalized()
+  if IsServer() then
+    local caster = self:GetCaster()
+    local width = self:GetSpecialValueFor("width")
+    local target = GetGroundPosition(self:GetCursorPosition(), caster)
+    local distance = (target - caster:GetAbsOrigin()):Length2D()
+    local castTime = self:GetCastPoint()
+    local direction = (target - caster:GetAbsOrigin()):Normalized()
 
     -- Warning particle
     local FX = ParticleManager:CreateParticle("particles/warning/warning_particle_cone.vpcf", PATTACH_WORLDORIGIN, nil)
     ParticleManager:SetParticleControl(FX, 1, caster:GetAbsOrigin())
-    ParticleManager:SetParticleControl(FX, 2, target)
+    ParticleManager:SetParticleControl(FX, 2, caster:GetAbsOrigin() + direction*(distance+width))
     ParticleManager:SetParticleControl(FX, 3, Vector(width, width, width))
     ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
     ParticleManager:ReleaseParticleIndex(FX)
 
-    DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width / 2,0), Vector(distance,width / 2,50), direction, Vector(255,0,0), 1, castTime)
-	end
-	return true
+    --DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width / 2,0), Vector(distance,width / 2,50), direction, Vector(255,0,0), 1, castTime)
+  end
+  return true
 end
 
 --------------------------------------------------------------------------------

--- a/game/scripts/vscripts/abilities/swiper/boss_swiper_thrust.lua
+++ b/game/scripts/vscripts/abilities/swiper/boss_swiper_thrust.lua
@@ -16,7 +16,7 @@ function boss_swiper_thrust:OnAbilityPhaseStart()
 		local caster = self:GetCaster()
 		local width = self:GetSpecialValueFor("width")
 		local target = GetGroundPosition(self:GetCursorPosition(), caster)
-		local distance = (target - caster:GetAbsOrigin()):Length()
+		local distance = (target - caster:GetAbsOrigin()):Length2D()
 		local castTime = self:GetCastPoint()
 		local direction = (target - caster:GetAbsOrigin()):Normalized()
 
@@ -28,7 +28,7 @@ function boss_swiper_thrust:OnAbilityPhaseStart()
     ParticleManager:SetParticleControl(FX, 4, Vector(255, 0, 0))
     ParticleManager:ReleaseParticleIndex(FX)
 
-    --DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width / 2,0), Vector(distance,width / 2,50), direction, Vector(255,0,0), 1, castTime)
+    DebugDrawBoxDirection(caster:GetAbsOrigin(), Vector(0,-width / 2,0), Vector(distance,width / 2,50), direction, Vector(255,0,0), 1, castTime)
 	end
 	return true
 end

--- a/game/scripts/vscripts/units/ai_bear_boss.lua
+++ b/game/scripts/vscripts/units/ai_bear_boss.lua
@@ -1,0 +1,181 @@
+local SIMPLE_AI_STATE_IDLE = 0
+local SIMPLE_AI_STATE_AGGRO = 1
+local SIMPLE_AI_STATE_LEASH = 2
+
+local SIMPLE_BOSS_LEASH_SIZE = BOSS_LEASH_SIZE or 1200
+local SIMPLE_BOSS_AGGRO_HP_PERCENT = 99
+
+function Spawn( entityKeyValues )
+  if not thisEntity or not IsServer() then
+    return
+  end
+  thisEntity.slam_ability = thisEntity:FindAbilityByName("bear_boss_earthshock")
+  thisEntity:SetContextThink("BearBossThink", BearBossThink, 1)
+end
+
+function BearBossThink()
+  if GameRules:IsGamePaused() == true or GameRules:State_Get() == DOTA_GAMERULES_STATE_POST_GAME or thisEntity:IsAlive() == false then
+    return 1
+  end
+
+  if Duels:IsActive() then
+    thisEntity.aggro_target = nil
+  end
+
+  if not thisEntity.initialized then
+    thisEntity.spawn_position = thisEntity:GetAbsOrigin()
+    thisEntity.state = SIMPLE_AI_STATE_IDLE
+    thisEntity.aggro_target = nil
+    thisEntity:SetIdleAcquire(false)
+    thisEntity:SetAcquisitionRange(0)
+    thisEntity.initialized = true
+  end
+
+  local function FindNearestAttackableUnit(thisEntity)
+    local nearby_enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, bit.bor(DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE), FIND_CLOSEST, false)
+    if #nearby_enemies ~= 0 then
+      for i = 1, #nearby_enemies do
+        local enemy = nearby_enemies[i]
+        if enemy and not enemy:IsNull() then
+          if enemy:IsAlive() and not enemy:IsAttackImmune() and not enemy:IsInvulnerable() and not enemy:IsOutOfGame() and not enemy:HasModifier("modifier_item_buff_ward") and not enemy:IsCourier() then
+            return enemy
+          end
+        end
+      end
+    end
+    nearby_enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity.spawn_position, nil, 3*SIMPLE_BOSS_LEASH_SIZE, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_CLOSEST, false)
+    if #nearby_enemies ~= 0 then
+      for i = 1, #nearby_enemies do
+        local enemy = nearby_enemies[i]
+        if enemy and not enemy:IsNull() then
+          if enemy:IsAlive() and not enemy:IsAttackImmune() and not enemy:IsInvulnerable() and not enemy:IsOutOfGame() and not enemy:HasModifier("modifier_item_buff_ward") and not enemy:IsCourier() and enemy:GetAttackRange() > SIMPLE_BOSS_LEASH_SIZE and (enemy:GetAbsOrigin() - thisEntity.spawn_position):Length2D() < 2*SIMPLE_BOSS_LEASH_SIZE then
+            return enemy
+          end
+        end
+      end
+    end
+    return nil
+  end
+
+  local function AttackNearestTarget(thisEntity)
+    local nearest_enemy = FindNearestAttackableUnit(thisEntity)
+    if nearest_enemy then
+      ExecuteOrderFromTable({
+        UnitIndex = thisEntity:entindex(),
+        OrderType = DOTA_UNIT_ORDER_ATTACK_MOVE,
+        Position = nearest_enemy:GetAbsOrigin(),
+        Queue = false,
+      })
+    end
+    thisEntity.aggro_target = nearest_enemy
+  end
+
+  local function StartLeashing(thisEntity)
+    thisEntity.aggro_target = nil
+    thisEntity.state = SIMPLE_AI_STATE_LEASH
+    return 1
+  end
+
+  if thisEntity.state == SIMPLE_AI_STATE_IDLE then
+    local current_hp_pct = thisEntity:GetHealth()/thisEntity:GetMaxHealth()
+    local aggro_hp_pct = SIMPLE_BOSS_AGGRO_HP_PERCENT/100
+    if current_hp_pct < aggro_hp_pct then
+      -- Issue an attack-move command towards the nearast unit that is attackable and assign it as aggro_target.
+      -- Because of attack priorities (wards have the lowest attack priority) aggro_target will not always be
+      -- the same as true aggro target (unit that is boss actually attacking at the moment)
+      AttackNearestTarget(thisEntity)
+      thisEntity.state = SIMPLE_AI_STATE_AGGRO
+    else
+      -- Check if the boss was messed around with displacing abilities (Force Staff for example)
+      if (thisEntity.spawn_position - thisEntity:GetAbsOrigin()):Length2D() > 10 then
+        thisEntity:MoveToPosition(thisEntity.spawn_position)
+        thisEntity.state = SIMPLE_AI_STATE_LEASH
+      end
+    end
+  elseif thisEntity.state == SIMPLE_AI_STATE_AGGRO then
+    -- Check how far did the boss go from the spawn position
+    if (thisEntity:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > SIMPLE_BOSS_LEASH_SIZE then
+      -- Check for actual aggro target
+      if thisEntity:GetAggroTarget() and not thisEntity:GetAggroTarget():IsNull() then
+        local true_aggro_target = thisEntity:GetAggroTarget()
+        -- Prevent bosses chasing Snipers all over the map (its funny though)
+        if (true_aggro_target:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > 2*SIMPLE_BOSS_LEASH_SIZE then
+          return StartLeashing(thisEntity)
+        elseif (true_aggro_target:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > SIMPLE_BOSS_LEASH_SIZE then
+          -- Check attack range of true aggro target, if its less than leash/aggro range, start leashing
+          if true_aggro_target:GetAttackRange() <= SIMPLE_BOSS_LEASH_SIZE then
+            return StartLeashing(thisEntity)
+          end
+        end
+      else
+        -- Boss is outside of leash range and the unit he was attacking doesnt exist, start leashing
+        return StartLeashing(thisEntity)
+      end
+    end
+
+    -- Check if aggro_target exists
+    if thisEntity.aggro_target then
+      --print(thisEntity.aggro_target:GetUnitName())
+      -- Check if aggro_target is getting deleted soon from c++
+      if thisEntity.aggro_target:IsNull() then
+        thisEntity.aggro_target = nil
+      end
+      -- Check if state of aggro_target changed (died, became attack immune (ethereal), became invulnerable or banished)
+      local aggro_target = thisEntity.aggro_target
+      if not aggro_target:IsAlive() or aggro_target:IsAttackImmune() or aggro_target:IsInvulnerable() or aggro_target:IsOutOfGame() then
+        thisEntity.aggro_target = nil
+      end
+      -- Check if aggro_target is out of aggro/leash range
+      if (aggro_target:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > 2*SIMPLE_BOSS_LEASH_SIZE then
+        thisEntity.aggro_target = nil
+      elseif (aggro_target:GetAbsOrigin() - thisEntity.spawn_position):Length2D() > SIMPLE_BOSS_LEASH_SIZE then
+        -- Check aggro_target attack range, if its less than leash/aggro range
+        if aggro_target:GetAttackRange() <= SIMPLE_BOSS_LEASH_SIZE then
+          thisEntity.aggro_target = nil
+        end
+      end
+      -- Check HP of the boss
+      local current_hp_pct = thisEntity:GetHealth()/thisEntity:GetMaxHealth()
+      local aggro_hp_pct = SIMPLE_BOSS_AGGRO_HP_PERCENT/100
+      if current_hp_pct > aggro_hp_pct then
+        thisEntity.aggro_target = nil
+      end
+      -- Check if boss is stuck or idle because actual aggro target doesn't exist.
+      if not thisEntity:GetAggroTarget() or thisEntity:IsIdle() then
+        thisEntity.aggro_target = nil
+      end
+    else
+      -- Check HP of the boss and if its able to attack
+      local current_hp_pct = thisEntity:GetHealth()/thisEntity:GetMaxHealth()
+      local aggro_hp_pct = SIMPLE_BOSS_AGGRO_HP_PERCENT/100
+      if current_hp_pct < aggro_hp_pct then
+        AttackNearestTarget(thisEntity)
+      end
+
+      if not thisEntity.aggro_target then
+        thisEntity.state = SIMPLE_AI_STATE_LEASH
+      end
+    end
+
+    local enemies = FindUnitsInRadius(thisEntity:GetTeamNumber(), thisEntity:GetAbsOrigin(), nil, 450, DOTA_UNIT_TARGET_TEAM_ENEMY, bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC), DOTA_UNIT_TARGET_FLAG_NONE, FIND_ANY_ORDER, false)
+    if thisEntity.slam_ability and thisEntity.slam_ability:IsFullyCastable() and #enemies > 2 then
+      ExecuteOrderFromTable({
+        UnitIndex = thisEntity:entindex(),
+        OrderType = DOTA_UNIT_ORDER_CAST_NO_TARGET,
+        AbilityIndex = thisEntity.slam_ability:entindex(),
+        Queue = false,
+      })
+    end
+  elseif thisEntity.state == SIMPLE_AI_STATE_LEASH then
+    -- Actual leashing
+    thisEntity:MoveToPosition(thisEntity.spawn_position)
+    -- Check if boss reached the spawn_position
+    if (thisEntity.spawn_position - thisEntity:GetAbsOrigin()):Length2D() < 10 then
+      -- Go into the idle state if the boss is back to the spawn position
+      thisEntity:SetIdleAcquire(false)
+      thisEntity:SetAcquisitionRange(0)
+      thisEntity.state = SIMPLE_AI_STATE_IDLE
+    end
+  end
+  return 1
+end


### PR DESCRIPTION
* Added some warning particles to Slime boss, Swiper boss and Weaver boss. Line particle is too transparent, I will try to fix that some other time.
* Tried to fix Sven boss particles and animations. Needs new model.
* Weaver (Carapace) boss Headbutt damage increased from 1500 to 2000.
* Weaver (Carapace) boss Headbutt length increased from 200 to 300.
* Shielder boss Shield passive ability - changed icon.
* Shielder boss: Prevent Shielder reflect infinite loop when fighting another Shielder.
* Slime boss Jump ability damage reduced from 3000 to 2000.
* Slime boss Shake (Firestorm) ability damage increased from 500 to 1000.
* Slime boss abilities changed icons.
* Sven boss abilities changed icons
* Sven boss Swipe ability damage reduced from 6500 to 6000.
* Sven boss Thrust (Impale) ability damage reduced from 6500 to 6000.
* Slime Boss Shake (Firestorm) - improved code a little bit, it should lag less.
* Sven Boss Swipe ability - damage and effect will no longer go off if Sven boss is dead.
* Sven Boss Swipe ability - improved anti-stun buff while he is using it. It fixes him a little bit when he is being tilted.
* Bear boss: Added Earthshock aoe ability, it triggers if there are more than 1 unit nearby.

P.S. To Chris: open warning_particle_cone.vpcf in Particle editor.