### PR TITLE
Talent UI fix (WIP)

### DIFF
--- a/content/panorama/scripts/custom_game/hero_selection.js
+++ b/content/panorama/scripts/custom_game/hero_selection.js
@@ -546,27 +546,49 @@ function EnableChatWindow () {
   pregamePanel.style.zIndex = 10;
   pregamePanel.style.backgroundColor = 'transparent';
   let contentPanel = pregamePanel.FindChildTraverse('MainContents');
-  contentPanel.style.visibility = 'collapse';
+  if (contentPanel) {
+    contentPanel.style.visibility = 'collapse';
+  }
   let backgroundPanel = pregamePanel.FindChildTraverse('PregameBGStatic');
-  backgroundPanel.style.visibility = 'collapse';
+  if (backgroundPanel) {
+    backgroundPanel.style.visibility = 'collapse';
+  }
   let backgroundDashboardPanel = pregamePanel.FindChildTraverse('PregameBG');
-  backgroundDashboardPanel.style.visibility = 'collapse';
+  if (backgroundDashboardPanel) {
+    backgroundDashboardPanel.style.visibility = 'collapse';
+  }
   let radiantTeamPanel = pregamePanel.FindChildTraverse('RadiantTeamPlayers');
-  radiantTeamPanel.style.visibility = 'collapse';
+  if (radiantTeamPanel) {
+    radiantTeamPanel.style.visibility = 'collapse';
+  }
   let direTeamPanel = pregamePanel.FindChildTraverse('DireTeamPlayers');
-  direTeamPanel.style.visibility = 'collapse';
+  if (direTeamPanel) {
+    direTeamPanel.style.visibility = 'collapse';
+  }
   let headerPanel = pregamePanel.FindChildTraverse('Header');
-  headerPanel.style.visibility = 'collapse';
+  if (headerPanel) {
+    headerPanel.style.visibility = 'collapse';
+  }
   let minimapPanel = pregamePanel.FindChildTraverse('PreMinimapContainer');
-  minimapPanel.style.visibility = 'collapse';
-  let panel = pregamePanel.FindChildTraverse('FriendsAndFoes');
-  panel.style.visibility = 'collapse';
+  if (minimapPanel) {
+    minimapPanel.style.visibility = 'collapse';
+  }
+  let friendsAndFoesPanel = pregamePanel.FindChildTraverse('FriendsAndFoes');
+  if (friendsAndFoesPanel) {
+    friendsAndFoesPanel.style.visibility = 'collapse';
+  }
   let panel2 = pregamePanel.FindChildTraverse('HeroPickingTeamComposition');
-  panel2.style.visibility = 'collapse';
+  if (panel2) {
+    panel2.style.visibility = 'collapse';
+  }
   let panel3 = pregamePanel.FindChildTraverse('PlusChallengeSelector');
-  panel3.style.visibility = 'collapse';
+  if (panel3) {
+    panel3.style.visibility = 'collapse';
+  }
   let panel4 = pregamePanel.FindChildTraverse('AvailableItemsContainer');
-  panel4.style.visibility = 'collapse';
+  if (panel4) {
+    panel4.style.visibility = 'collapse';
+  }
 }
 
 function UpdatePreviews (data) {

--- a/content/panorama/scripts/custom_game/scepter_talents_overlay.js
+++ b/content/panorama/scripts/custom_game/scepter_talents_overlay.js
@@ -68,15 +68,14 @@ GameEvents.Subscribe('talent_tree_disable', function (args) {
   // Find the talent tree
   let talentTree = centerPanel.FindChildTraverse('StatBranch');
   // Find level up frame for the talent tree
-  let levelUpButton = centerPanel.FindChildTraverse('level_stats_frame')
-  
+  let levelUpButton = centerPanel.FindChildTraverse('level_stats_frame');
   if (args) {
     if (args.disable === 1) {
       // Disable clicking on the talent tree
       talentTree.SetPanelEvent('onactivate', function () {});
       // Remove level up above the talent tree
       levelUpButton.style.visibility = 'collapse';
-	}
+    }
   }
 
   // talentTree.style.visibility = 'collapse';

--- a/content/panorama/scripts/custom_game/scepter_talents_overlay.js
+++ b/content/panorama/scripts/custom_game/scepter_talents_overlay.js
@@ -9,7 +9,7 @@ function UpdateTalentBranchOption (talentSideRoot, isRightSide, isUpgrade) {
     $.Msg('ScepterUpgrade - Branch chosen by player');
     return;
   }
-  var label = talentSideRoot.FindChildrenWithClassTraverse('StatBonusLabel')[0];
+  let label = talentSideRoot.FindChildrenWithClassTraverse('StatBonusLabel')[0];
   if (isUpgrade) {
     label.style.textShadow = '0px 0px 1px 1.3 #EC780E24';
     label.style.color = '#E7D29188';
@@ -17,7 +17,7 @@ function UpdateTalentBranchOption (talentSideRoot, isRightSide, isUpgrade) {
     label.style.textShadow = '1px 1px 2px 2.0 #00000066';
     label.style.color = '#676E70';
   }
-  var scepterImage = talentSideRoot.FindChildTraverse('scepterUpgrade');
+  let scepterImage = talentSideRoot.FindChildTraverse('scepterUpgrade');
   if (scepterImage === null) {
     scepterImage = $.CreatePanel('Panel', talentSideRoot, 'scepterUpgrade');
   }
@@ -31,21 +31,21 @@ function UpdateTalentBranchOption (talentSideRoot, isRightSide, isUpgrade) {
   scepterImage.style.opacity = isUpgrade ? '0.2' : '0';
 }
 function UpdateTalentTreeBranch (level, isRightSide, isUpgrade) {
-  var root = FindDotaHudElement('StatPipContainer');
-  var talentTreeRowIds = ['undefined', 'StatRow10', 'StatRow15', 'StatRow20', 'StatRow25'];
+  let root = FindDotaHudElement('StatPipContainer');
+  let talentTreeRowIds = ['undefined', 'StatRow10', 'StatRow15', 'StatRow20', 'StatRow25'];
   if ((root.BHasClass('RightBranchSelected') && isRightSide) ||
         (root.BHasClass('LeftBranchSelected') && !isRightSide) || level < 1 || level > 4) {
     $.Msg('ScepterUpgrade - side is already selected or out of range');
     return;
   }
-  var talentTreeLvl = root.FindChildTraverse(talentTreeRowIds[level]);
-  var treeBranchClass = isRightSide ? 'RightBranchPip' : 'LeftBranchPip';
+  let talentTreeLvl = root.FindChildTraverse(talentTreeRowIds[level]);
+  let treeBranchClass = isRightSide ? 'RightBranchPip' : 'LeftBranchPip';
   talentTreeLvl.FindChildrenWithClassTraverse(treeBranchClass)[0].style.opacity = isUpgrade ? '1' : '0';
 }
 function FindTalentSideRootPanel (level, isRightSide) {
   $.Msg('UpgradeOption' + level.toString());
-  var upgradeTalentRoot = FindDotaHudElement('StatBranchColumn').FindChildTraverse('UpgradeOption' + level.toString());
-  var upgradeNumber = isRightSide ? (level - 1) * 2 + 1 : (level - 1) * 2 + 2;
+  let upgradeTalentRoot = FindDotaHudElement('StatBranchColumn').FindChildTraverse('UpgradeOption' + level.toString());
+  let upgradeNumber = isRightSide ? (level - 1) * 2 + 1 : (level - 1) * 2 + 2;
   $.Msg('Upgrade' + upgradeNumber.toString());
   return upgradeTalentRoot.FindChildTraverse('Upgrade' + upgradeNumber.toString());
 }
@@ -58,7 +58,23 @@ function FindTalentSideRootPanel (level, isRightSide) {
 // UpdateTalentBranchOption(FindTalentSideRootPanel(lvlMap[args.Level], args.IsRightSide), args.IsRightSide, args.IsUpgrade);
 // UpdateTalentTreeBranch(lvlMap[args.Level], args.IsRightSide, args.IsUpgrade);
 GameEvents.Subscribe('oaa_scepter_upgrade', function (args) {
-  var lvlMap = { '10': 1, '15': 2, '20': 3, '25': 4 };
+  let lvlMap = { '10': 1, '15': 2, '20': 3, '25': 4 };
   UpdateTalentBranchOption(FindTalentSideRootPanel(lvlMap[args.Level], args.IsRightSide), args.IsRightSide, args.IsUpgrade);
   UpdateTalentTreeBranch(lvlMap[args.Level], args.IsRightSide, args.IsUpgrade);
 });
+
+(function () {
+  let hudElements = FindDotaHudElement('HUDElements');
+  // let centerPanel = hudElements.FindChildTraverse('center_block');
+  // let talentBranch = centerPanel.FindChildTraverse('StatBranch');
+
+  // Find the talent tree and disable it
+  let talentTree = hudElements.FindChildTraverse('lower_hud').FindChildTraverse('center_with_stats').FindChildTraverse('center_block').FindChildTraverse('AbilitiesAndStatBranch').FindChildTraverse('StatBranch');
+  // talentTree.style.visibility = 'collapse';
+  talentTree.SetPanelEvent('onmouseover', function () {});
+  talentTree.SetPanelEvent('onactivate', function () {});
+
+  // Disable the level up frame for the talent tree
+  let levelUpButton = hudElements.FindChildTraverse('lower_hud').FindChildTraverse('center_with_stats').FindChildTraverse('center_block').FindChildTraverse('level_stats_frame');
+  levelUpButton.style.visibility = 'collapse';
+})();

--- a/content/panorama/scripts/custom_game/scepter_talents_overlay.js
+++ b/content/panorama/scripts/custom_game/scepter_talents_overlay.js
@@ -33,8 +33,7 @@ function UpdateTalentBranchOption (talentSideRoot, isRightSide, isUpgrade) {
 function UpdateTalentTreeBranch (level, isRightSide, isUpgrade) {
   let root = FindDotaHudElement('StatPipContainer');
   let talentTreeRowIds = ['undefined', 'StatRow10', 'StatRow15', 'StatRow20', 'StatRow25'];
-  if ((root.BHasClass('RightBranchSelected') && isRightSide) ||
-        (root.BHasClass('LeftBranchSelected') && !isRightSide) || level < 1 || level > 4) {
+  if ((root.BHasClass('RightBranchSelected') && isRightSide) || (root.BHasClass('LeftBranchSelected') && !isRightSide) || level < 1 || level > 4) {
     $.Msg('ScepterUpgrade - side is already selected or out of range');
     return;
   }
@@ -63,18 +62,23 @@ GameEvents.Subscribe('oaa_scepter_upgrade', function (args) {
   UpdateTalentTreeBranch(lvlMap[args.Level], args.IsRightSide, args.IsUpgrade);
 });
 
-(function () {
+GameEvents.Subscribe('talent_tree_disable', function (args) {
   let hudElements = FindDotaHudElement('HUDElements');
-  // let centerPanel = hudElements.FindChildTraverse('center_block');
-  // let talentBranch = centerPanel.FindChildTraverse('StatBranch');
+  let centerPanel = hudElements.FindChildTraverse('center_block');
+  // Find the talent tree
+  let talentTree = centerPanel.FindChildTraverse('StatBranch');
+  // Find level up frame for the talent tree
+  let levelUpButton = centerPanel.FindChildTraverse('level_stats_frame')
+  
+  if (args) {
+    if (args.disable === 1) {
+      // Disable clicking on the talent tree
+      talentTree.SetPanelEvent('onactivate', function () {});
+      // Remove level up above the talent tree
+      levelUpButton.style.visibility = 'collapse';
+	}
+  }
 
-  // Find the talent tree and disable it
-  let talentTree = hudElements.FindChildTraverse('lower_hud').FindChildTraverse('center_with_stats').FindChildTraverse('center_block').FindChildTraverse('AbilitiesAndStatBranch').FindChildTraverse('StatBranch');
   // talentTree.style.visibility = 'collapse';
-  talentTree.SetPanelEvent('onmouseover', function () {});
-  talentTree.SetPanelEvent('onactivate', function () {});
-
-  // Disable the level up frame for the talent tree
-  let levelUpButton = hudElements.FindChildTraverse('lower_hud').FindChildTraverse('center_with_stats').FindChildTraverse('center_block').FindChildTraverse('level_stats_frame');
-  levelUpButton.style.visibility = 'collapse';
-})();
+  // talentTree.SetPanelEvent('onmouseover', function () {});
+});

--- a/game/scripts/vscripts/components/abilities/level.lua
+++ b/game/scripts/vscripts/components/abilities/level.lua
@@ -66,11 +66,13 @@ function AbilityLevels:CheckAbilityLevels (keys)
 
   local leveled_up_ability = keys.abilityname
   if leveled_up_ability then
-    if string.find(leveled_up_ability, "special_bonus_") then
-      -- Ability is a talent (not a reliable way of checking but its temporary anyway)
-      -- Check for hero level:
-      if level > 27 then
-        -- Adding a skill point if a player leveled up a talent that is not supposed to be levelled.
+    local talent = hero:FindAbilityByName(leveled_up_ability)
+    if string.find(leveled_up_ability, "special_bonus_") or talent:IsAttributeBonus() then
+      -- Ability is a talent
+
+      -- Check for hero level and if talent is really taken
+      if level >= 27 and talent:GetLevel() == 0 then
+        -- Refund a skill point if a player wasted it on a talent that is not supposed to be levelled.
         hero:SetAbilityPoints(hero:GetAbilityPoints() + 1)
       end
     end

--- a/game/scripts/vscripts/components/progression/hero_progression.lua
+++ b/game/scripts/vscripts/components/progression/hero_progression.lua
@@ -4,7 +4,7 @@ if HeroProgression == nil then
 end
 
 GameEvents:OnPlayerLevelUp(function(keys)
-  Debug:EnableDebugging()
+  --Debug:EnableDebugging()
   -- dota_player_gained_level:
   --"player_id"
   --"level"


### PR DESCRIPTION
I have no idea how to prevent players from clicking on the talent after level 26. I managed to remove whole talent level up UI but they can still click on the talent. I also don't know when to disable talent UI without messing up bots talent UI and talent UI of switched heroes (heroes created with -switchhero command). 
I fixed one thing: players will not lose a skill point anymore if they accidentally click on a talent that cannot be learned.