### PR TITLE
Fixed Jakiro oneshotting people

### DIFF
--- a/game/scripts/npc/abilities/talents/jakiro_talent2.txt
+++ b/game/scripts/npc/abilities/talents/jakiro_talent2.txt
@@ -18,7 +18,7 @@
 			"01"
 			{
 				"var_type"					"FIELD_FLOAT"
-				"value"				"75" //OAA
+				"value"				"2"
         "ad_linked_ability"			"jakiro_dual_breath"
 			}
 		}


### PR DESCRIPTION
Valve updated jakiros talents in 7.29, removing the dual breath cast range and damage talents, instead merging them both into one talent at level 25. Jakiros new level 25 talent should be "x2 Dual Breath damage/Range" but currently its "x75 Dual Breath damage/Range". This is because this KV file used to be linked to the +40 dual breath talent at level 15, which was later buffed to +75 dual breath damage. 