### PR TITLE
Earth Spirit buff

### DIFF
--- a/game/scripts/npc/abilities/earth_spirit_magnetize.txt
+++ b/game/scripts/npc/abilities/earth_spirit_magnetize.txt
@@ -37,7 +37,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cast_radius"                                     "350"
+        "cast_radius"                                     "375" //OAA
       }
       "02"
       {

--- a/game/scripts/npc/abilities/earth_spirit_magnetize.txt
+++ b/game/scripts/npc/abilities/earth_spirit_magnetize.txt
@@ -19,7 +19,7 @@
 
     // Casting
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCastRange"                                    "350"
+    "AbilityCastRange"                                    "375" //OAA
     "AbilityCastPoint"                                    "0.01"
 
     // Time
@@ -42,7 +42,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage_per_second"                               "50 150 250 450 650" //OAA
+        "damage_per_second"                               "80 200 340 480 960" //OAA
       }
       "03"
       {


### PR DESCRIPTION
+25 is seemingly a very icefrog kind of buff (timber q and axe call) and the dmg per second has been increased at all levels. Max oaa level is a lot seemingly because the thought process is simple: If you're level 49 and don't have a dispel you are a monkey.