### PR TITLE
Greater Travel Boots tweaks

### DIFF
--- a/game/resource/English/ability/items/tooltip_greater_travel_boots.txt
+++ b/game/resource/English/ability/items/tooltip_greater_travel_boots.txt
@@ -7,7 +7,8 @@
 "DOTA_Tooltip_Ability_item_greater_travel_boots_Lore"                           "The boots of a once renowned legendary merchant."
 "DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_movement_speed"           "+$move_speed"
 "DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_boss_damage"              "%BONUS BOSS DAMAGE:"
-"DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_damage_during_duels"      "%BONUS DAMAGE DURING DUELS:"
+"DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_damage_during_duels"      "%BONUS ATTACK DAMAGE DURING DUELS:"
+"DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_spell_amp_during_duels"   "%BONUS SPELL AMP DURING DUELS:"
 "item_greater_travel_boots_ability_Description"                                 "<h1>Active: Teleport</h1> Teleports you to any allied structure or unit, including heroes. Teleporting is interrupted if the target dies or if you become rooted."
 
 "DOTA_Tooltip_Ability_item_greater_travel_boots_2"                              "#{DOTA_Tooltip_Ability_item_greater_travel_boots}"
@@ -17,6 +18,7 @@
 "DOTA_Tooltip_Ability_item_greater_travel_boots_2_bonus_movement_speed"         "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_movement_speed}"
 "DOTA_Tooltip_Ability_item_greater_travel_boots_2_bonus_boss_damage"            "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_boss_damage}"
 "DOTA_Tooltip_Ability_item_greater_travel_boots_2_bonus_damage_during_duels"    "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_damage_during_duels}"
+"DOTA_Tooltip_Ability_item_greater_travel_boots_2_bonus_spell_amp_during_duels" "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_spell_amp_during_duels}"
 
 "DOTA_Tooltip_Ability_item_greater_travel_boots_3"                              "#{DOTA_Tooltip_Ability_item_greater_travel_boots}"
 "DOTA_Tooltip_Ability_item_recipe_greater_travel_boots_3"                       "#{DOTA_Tooltip_Ability_item_recipe_greater_travel_boots}"
@@ -25,6 +27,7 @@
 "DOTA_Tooltip_Ability_item_greater_travel_boots_3_bonus_movement_speed"         "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_movement_speed}"
 "DOTA_Tooltip_Ability_item_greater_travel_boots_3_bonus_boss_damage"            "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_boss_damage}"
 "DOTA_Tooltip_Ability_item_greater_travel_boots_3_bonus_damage_during_duels"    "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_damage_during_duels}"
+"DOTA_Tooltip_Ability_item_greater_travel_boots_3_bonus_spell_amp_during_duels" "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_spell_amp_during_duels}"
 
 "DOTA_Tooltip_Ability_item_greater_travel_boots_4"                              "#{DOTA_Tooltip_Ability_item_greater_travel_boots}"
 "DOTA_Tooltip_Ability_item_recipe_greater_travel_boots_4"                       "#{DOTA_Tooltip_Ability_item_recipe_greater_travel_boots}"
@@ -33,6 +36,7 @@
 "DOTA_Tooltip_Ability_item_greater_travel_boots_4_bonus_movement_speed"         "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_movement_speed}"
 "DOTA_Tooltip_Ability_item_greater_travel_boots_4_bonus_boss_damage"            "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_boss_damage}"
 "DOTA_Tooltip_Ability_item_greater_travel_boots_4_bonus_damage_during_duels"    "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_damage_during_duels}"
+"DOTA_Tooltip_Ability_item_greater_travel_boots_4_bonus_spell_amp_during_duels" "#{DOTA_Tooltip_Ability_item_greater_travel_boots_bonus_spell_amp_during_duels}"
 
 "DOTA_Tooltip_Ability_item_travel_boots_oaa"                                    "#{DOTA_Tooltip_Ability_item_travel_boots}"
 "DOTA_Tooltip_Ability_item_recipe_travel_boots_oaa"                             "#{DOTA_Tooltip_Ability_item_recipe_travel_boots}"

--- a/game/scripts/npc/items/farming/item_greater_travel_boots.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots.txt
@@ -82,7 +82,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_boss_damage"                               "20 25 30 35"
+        "bonus_spell_amp_during_duels"                    "18 22 26 30"
+      }
+      "04"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_boss_damage"                               "25 35 45 55"
       }
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_travel_boots_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots_2.txt
@@ -85,7 +85,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_boss_damage"                               "20 25 30 35"
+        "bonus_spell_amp_during_duels"                    "18 22 26 30"
+      }
+      "04"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_boss_damage"                               "25 35 45 55"
       }
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_travel_boots_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots_3.txt
@@ -77,7 +77,7 @@
         "var_type"                                        "FIELD_INTEGER"
         "bonus_movement_speed"                            "100 120 140 160"
       }
-      "02" // percentage bonus based on base (white) dmg
+      "02"
       {
         "var_type"                                        "FIELD_INTEGER"
         "bonus_damage_during_duels"                       "15 20 25 30"
@@ -85,7 +85,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_boss_damage"                               "20 25 30 35"
+        "bonus_spell_amp_during_duels"                    "18 22 26 30"
+      }
+      "04"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_boss_damage"                               "25 35 45 55"
       }
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_travel_boots_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots_4.txt
@@ -78,7 +78,7 @@
         "var_type"                                        "FIELD_INTEGER"
         "bonus_movement_speed"                            "100 120 140 160"
       }
-      "02" // percentage bonus based on base (white) dmg
+      "02"
       {
         "var_type"                                        "FIELD_INTEGER"
         "bonus_damage_during_duels"                       "15 20 25 30"
@@ -86,7 +86,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_boss_damage"                               "20 25 30 35"
+        "bonus_spell_amp_during_duels"                    "18 22 26 30"
+      }
+      "04"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_boss_damage"                               "25 35 45 55"
       }
     }
   }

--- a/game/scripts/npc/items/item_travel_boots.txt
+++ b/game/scripts/npc/items/item_travel_boots.txt
@@ -81,6 +81,11 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
+        "bonus_spell_amp_during_duels"                    "0"
+      }
+      "04"
+      {
+        "var_type"                                        "FIELD_INTEGER"
         "bonus_boss_damage"                               "0"
       }
     }

--- a/game/scripts/vscripts/items/farming/greater_travel_boots.lua
+++ b/game/scripts/vscripts/items/farming/greater_travel_boots.lua
@@ -171,6 +171,7 @@ function modifier_item_greater_travel_boots_unique_passive:OnCreated()
   local ability = self:GetAbility()
   if ability and not ability:IsNull() then
     self.dmg = ability:GetSpecialValueFor("bonus_damage_during_duels")
+    self.spell_amp = ability:GetSpecialValueFor("bonus_spell_amp_during_duels")
   end
   if IsServer() then
     self:StartIntervalThink(0)
@@ -181,6 +182,7 @@ function modifier_item_greater_travel_boots_unique_passive:OnRefresh()
   local ability = self:GetAbility()
   if ability and not ability:IsNull() then
     self.dmg = ability:GetSpecialValueFor("bonus_damage_during_duels")
+    self.spell_amp = ability:GetSpecialValueFor("bonus_spell_amp_during_duels")
   end
 end
 
@@ -195,6 +197,7 @@ end
 function modifier_item_greater_travel_boots_unique_passive:DeclareFunctions()
   local funcs = {
     MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE,
+    MODIFIER_PROPERTY_SPELL_AMPLIFY_PERCENTAGE,
   }
 
   return funcs
@@ -203,6 +206,14 @@ end
 function modifier_item_greater_travel_boots_unique_passive:GetModifierBaseDamageOutgoing_Percentage()
   if self:GetStackCount() == 1 then
     return self.dmg or self:GetAbility():GetSpecialValueFor("bonus_damage_during_duels")
+  end
+
+  return 0
+end
+
+function modifier_item_greater_travel_boots_unique_passive:GetModifierSpellAmplify_Percentage()
+  if self:GetStackCount() == 1 then
+    return self.spell_amp or self:GetAbility():GetSpecialValueFor("bonus_spell_amp_during_duels")
   end
 
   return 0


### PR DESCRIPTION
* Now also grants bonus spell amp during duels: +18%/22%/26%/30%
* Bonus boss damage increased from 20%/25%/30%/35% to 25%/35%/45%/55%.