### PR TITLE
Underlord ult balance

### DIFF
--- a/game/resource/English/ability/units/tooltip_abyssal_underlord_dark_rift_oaa.txt
+++ b/game/resource/English/ability/units/tooltip_abyssal_underlord_dark_rift_oaa.txt
@@ -14,7 +14,7 @@
 "DOTA_Tooltip_ability_abyssal_underlord_dark_rift_oaa_damage"                   "DAMAGE:"
 "DOTA_Tooltip_ability_abyssal_underlord_dark_rift_oaa_teleport_delay_scepter"   "SCEPTER CHANNEL DURATION:"
 "DOTA_Tooltip_ability_abyssal_underlord_dark_rift_oaa_cooldown_scepter"         "SCEPTER COOLDOWN:"
-"DOTA_Tooltip_ability_abyssal_underlord_dark_rift_oaa_scepter_description"      "Reduces channel time to 0.1 second and cooldown to 40 seconds."
+"DOTA_Tooltip_ability_abyssal_underlord_dark_rift_oaa_scepter_description"      "Reduces channel time to 0.5 seconds and cooldown to 60 seconds."
 
 "DOTA_Tooltip_ability_abyssal_underlord_dark_rift"                              "#{DOTA_Tooltip_ability_abyssal_underlord_dark_rift_oaa}"
 "DOTA_Tooltip_ability_abyssal_underlord_dark_rift_Description"                  "CHANNELED - After channeling for %teleport_delay% seconds, Underlord teleports to the target location, stunning and damaging enemies in a radius."

--- a/game/scripts/npc/abilities/abyssal_underlord_cancel_dark_rift_oaa.txt
+++ b/game/scripts/npc/abilities/abyssal_underlord_cancel_dark_rift_oaa.txt
@@ -13,8 +13,8 @@
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
-    "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
-    "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_YES"
+    //"AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+    "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_NO"
     "AbilityTextureName"                                  "abyssal_underlord_cancel_dark_rift"
 
     "MaxLevel"                                            "5"

--- a/game/scripts/npc/abilities/abyssal_underlord_dark_rift.txt
+++ b/game/scripts/npc/abilities/abyssal_underlord_dark_rift.txt
@@ -32,7 +32,7 @@
 
     // Cost
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityManaCost"                                     "125 175 225 275 325"  //OAA, for picking screen tooltip
+    "AbilityManaCost"                                     "150 225 300 375 450"  //OAA, for picking screen tooltip
 
     // Special
     //-------------------------------------------------------------------------------------------------------------
@@ -51,7 +51,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "scepter_teleport_delay"                          "0.1" // OAA, for picking screen tooltip
+        "scepter_teleport_delay"                          "0.5" // OAA, for picking screen tooltip
       }
       "04"
       {
@@ -62,7 +62,7 @@
       "05" //OAA, for picking screen tooltip
       {
         "var_type"                                        "FIELD_FLOAT"
-        "stun_duration"                                   "2.0 2.25 2.5 2.75 3.0"
+        "stun_duration"                                   "2.25 2.5 2.75 3.0 3.25"
       }
       "06" //OAA, for picking screen tooltip
       {

--- a/game/scripts/npc/abilities/abyssal_underlord_dark_rift_oaa.txt
+++ b/game/scripts/npc/abilities/abyssal_underlord_dark_rift_oaa.txt
@@ -26,7 +26,7 @@
 
     "HasScepterUpgrade"                                   "1"
 
-    "AbilityCastRange"                                    "1200 1400 1600 1800 2000"
+    "AbilityCastRange"                                    "1350 1400 1450 1500 1550"
     "AbilityCastPoint"                                    "0.0"
     "AbilityCastAnimation"                                "ACT_DOTA_CAST_ABILITY_4"
     "AbilityChannelTime"                                  "1.5"
@@ -37,7 +37,7 @@
 
     // Cost
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityManaCost"                                     "125 175 225 275 325"
+    "AbilityManaCost"                                     "150 225 300 375 450"
 
     // Special
     //-------------------------------------------------------------------------------------------------------------
@@ -51,7 +51,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "stun_duration"                                   "2.0 2.25 2.5 2.75 3.0"
+        "stun_duration"                                   "2.25 2.5 2.75 3.0 3.25"
       }
       "03"
       {
@@ -66,13 +66,13 @@
       "05"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "teleport_delay_scepter"                          "0.1"
+        "teleport_delay_scepter"                          "0.5"
         "RequiresScepter"                                 "1"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cooldown_scepter"                                "40"
+        "cooldown_scepter"                                "60"
         "RequiresScepter"                                 "1"
       }
     }

--- a/game/scripts/vscripts/abilities/oaa_cancel_dark_rift.lua
+++ b/game/scripts/vscripts/abilities/oaa_cancel_dark_rift.lua
@@ -32,26 +32,28 @@ function abyssal_underlord_cancel_dark_rift_oaa:OnSpellStart()
 
   local targetTeam = self:GetAbilityTargetTeam()
   local targetType = self:GetAbilityTargetType()
-  local targetFlags = self:GetAbilityTargetFlags()
+  local targetFlags = DOTA_UNIT_TARGET_FLAG_NONE --self:GetAbilityTargetFlags()
 
   local units = FindUnitsInRadius(caster:GetTeamNumber(), start, nil, radius, targetTeam, targetType, targetFlags, FIND_ANY_ORDER, false)
   for _, unit in pairs(units) do
     -- Teleport only units that are stunned by Dark Rift
     if unit and not unit:IsNull() and unit.HasModifier and unit:HasModifier("modifier_underlord_dark_rift_oaa_stun") then
-      should_teleport_caster = true
-      if destination then
-        -- Teleport the unit
-        unit:SetAbsOrigin(destination)
-        FindClearSpaceForUnit(unit, destination, true)
+      if not unit:IsOAABoss() then
+        should_teleport_caster = true
+        if destination then
+          -- Teleport the unit
+          unit:SetAbsOrigin(destination)
+          FindClearSpaceForUnit(unit, destination, true)
 
-        -- Disjoint disjointable/dodgeable projectiles
-        ProjectileManager:ProjectileDodge(unit)
+          -- Disjoint disjointable/dodgeable projectiles
+          ProjectileManager:ProjectileDodge(unit)
 
-        -- Teleportation particle
-        --local part = ParticleManager:CreateParticle("particles/units/heroes/heroes_underlord/abbysal_underlord_darkrift_ambient_end.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster)
-        --ParticleManager:SetParticleControl(part, 2, unit:GetAbsOrigin())
-        --ParticleManager:SetParticleControl(part, 5, unit:GetAbsOrigin())
-        --ParticleManager:ReleaseParticleIndex(part)
+          -- Teleportation particle
+          --local part = ParticleManager:CreateParticle("particles/units/heroes/heroes_underlord/abbysal_underlord_darkrift_ambient_end.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster)
+          --ParticleManager:SetParticleControl(part, 2, unit:GetAbsOrigin())
+          --ParticleManager:SetParticleControl(part, 5, unit:GetAbsOrigin())
+          --ParticleManager:ReleaseParticleIndex(part)
+        end
       end
     end
   end


### PR DESCRIPTION
* Dark Rift mana cost increased from 125/175/225/275/325 to 150/225/300/375/450.
* Dark Rift cast range rescaled from 1200/1400/1600/1800/2000 to 1350/1400/1450/1500/1550.
* Dark Rift stun duration increased by 0.25 at all levels.
* Dark Rift scepter channel duration increased from 0.1 to 0.5 seconds.
* Dark Rift scepter cooldown increased from 40 to 60 seconds.
* Dark Abduction no longer works on spell-immune units. (Cannot teleport spell-immune enemies.)
* Dark Abduction no longer works on bosses. (Cannot teleport Wanderer anymore for example.)