### PR TITLE
Power spark change

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1626,6 +1626,7 @@ read_globals = { -- these globals can only be accessed.
 "class",
 "DMG_FALL",
 "MODIFIER_PROPERTY_TOOLTIP",
+"MODIFIER_PROPERTY_TOOLTIP2",
 "DOTA_LOADOUT_TYPE_NONE",
 "DOTA_LOADOUT_TYPE_SHOULDER",
 "CEntityScriptFramework",

--- a/game/resource/English/modifier/tooltip_modifier_sparks.txt
+++ b/game/resource/English/modifier/tooltip_modifier_sparks.txt
@@ -7,5 +7,8 @@
 "DOTA_Tooltip_modifier_spark_midas"                       "XP Spark"
 "DOTA_Tooltip_modifier_spark_midas_Description"           "Generates 2 charges every second. At 100 charges, your next attack on a non-ancient neutral creep will instantly kill it for %dMODIFIER_PROPERTY_TOOLTIP% additional gold and 25%% extra experience."
 
-"DOTA_Tooltip_modifier_spark_power"                       "Power Spark"
-"DOTA_Tooltip_modifier_spark_power_Description"           "Bonus %dMODIFIER_PROPERTY_TOOLTIP% pure damage against neutral creeps. 30%% more gold from killing neutral creeps."
+"DOTA_Tooltip_modifier_spark_power"                       "Power Spark (Hero)"
+"DOTA_Tooltip_modifier_spark_power_Description"           "Bonus %dMODIFIER_PROPERTY_TOOLTIP% pure damage against neutral creeps. Affects illusions and summons you control. 30%% more gold from killing neutral creeps."
+
+"DOTA_Tooltip_modifier_spark_power_effect"                "Power Spark (Summon)"
+"DOTA_Tooltip_modifier_spark_power_effect_Description"    "Bonus %dMODIFIER_PROPERTY_TOOLTIP% pure damage against neutral creeps and 50%% chance to block %dMODIFIER_PROPERTY_TOOLTIP2% damage from neutral creeps. 30%% more gold from killing neutral creeps."

--- a/game/resource/English/panorama/spark_selection.txt
+++ b/game/resource/English/panorama/spark_selection.txt
@@ -13,7 +13,7 @@
 "spark_selection_midas_desc"          "One-shot a non-ancient creep for bonus gold and experience when off cooldown."
 
 "spark_selection_power"               "Power"
-"spark_selection_power_desc"          "Attacks deal additional pure damage to creeps."
+"spark_selection_power_desc"          "Attacks deal additional pure damage to creeps. Summons and illusions gain bonus damage and damage block."
 
 "spark_selection_cleave"              "Cleave"
 "spark_selection_cleave_desc"         "Attacks splinter to nearby creeps."

--- a/game/scripts/vscripts/components/creeps/creep_kill_bounty.lua
+++ b/game/scripts/vscripts/components/creeps/creep_kill_bounty.lua
@@ -103,7 +103,7 @@ GameEvents:OnEntityFatalDamage(function (keys)
   local creepBountyMultiplier = 1
   if attacker:HasModifier("modifier_spark_cleave") then
     creepBountyMultiplier = creepBountyMultiplier + CREEP_BOUNTY_BONUS_PERCENT_CLEAVE/100
-  elseif attacker:HasModifier("modifier_spark_power") then
+  elseif attacker:HasModifier("modifier_spark_power") or attacker:HasModifier("modifier_spark_power_effect") then
     creepBountyMultiplier = creepBountyMultiplier + CREEP_BOUNTY_BONUS_PERCENT_POWER/100
   end
 

--- a/game/scripts/vscripts/components/sparks/sparks.lua
+++ b/game/scripts/vscripts/components/sparks/sparks.lua
@@ -9,6 +9,7 @@ function Sparks:Init()
   LinkLuaModifier("modifier_spark_gpm", "modifiers/sparks/modifier_spark_gpm.lua", LUA_MODIFIER_MOTION_NONE)
   LinkLuaModifier("modifier_spark_midas", "modifiers/sparks/modifier_spark_midas.lua", LUA_MODIFIER_MOTION_NONE)
   LinkLuaModifier("modifier_spark_power", "modifiers/sparks/modifier_spark_power.lua", LUA_MODIFIER_MOTION_NONE)
+  LinkLuaModifier("modifier_spark_power_effect", "modifiers/sparks/modifier_spark_power.lua", LUA_MODIFIER_MOTION_NONE)
 
   Sparks.data = {
     [DOTA_TEAM_GOODGUYS] = {

--- a/game/scripts/vscripts/modifiers/sparks/modifier_spark_power.lua
+++ b/game/scripts/vscripts/modifiers/sparks/modifier_spark_power.lua
@@ -1,7 +1,7 @@
 modifier_spark_power = class(ModifierBaseClass)
 
 function modifier_spark_power:IsHidden()
-  return false
+  return true
 end
 
 function modifier_spark_power:IsDebuff()
@@ -21,6 +21,10 @@ function modifier_spark_power:GetAttributes()
 end
 
 function modifier_spark_power:AllowIllusionDuplicate()
+  return false
+end
+
+function modifier_spark_power:IsAura()
   return true
 end
 
@@ -28,8 +32,48 @@ function modifier_spark_power:GetTexture()
   return "custom/spark_power"
 end
 
+function modifier_spark_power:GetModifierAura()
+  return "modifier_spark_power_effect"
+end
+
+function modifier_spark_power:GetAuraRadius()
+  return 1200
+end
+
+function modifier_spark_power:GetAuraSearchTeam()
+  return DOTA_UNIT_TARGET_TEAM_FRIENDLY
+end
+
+function modifier_spark_power:GetAuraSearchType()
+  return bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC)
+end
+
+function modifier_spark_power:GetAuraEntityReject(hEntity)
+  local caster = self:GetCaster()
+  -- Dont provide the aura effect to allies that you can't control
+  if hEntity ~= caster then
+    if IsServer() then
+      if UnitVarToPlayerID(hEntity) ~= UnitVarToPlayerID(caster) then
+        return true
+      end
+    else
+      if hEntity.GetPlayerOwnerID then
+        if hEntity:GetPlayerOwnerID() ~= caster:GetPlayerOwnerID() then
+          return true
+        end
+      end
+    end
+  end
+  return false
+end
+
 function modifier_spark_power:OnCreated()
   local parent = self:GetParent()
+
+  if parent:IsIllusion() then
+    return
+  end
+
   if IsServer() then
     -- Current damage values
     local base_damage_max = parent:GetBaseDamageMax()
@@ -53,9 +97,9 @@ function modifier_spark_power:OnCreated()
     local base_damage_level_1_min = base_damage_min - current_primary_stat_value + starting_primary_stat_value
     local starting_average_base_damage = (base_damage_level_1_max + base_damage_level_1_min)/2
 
-    -- Bonus damage formula
-    self.bonus_damage = math.ceil(3188/61 + (4166 * current_average_base_damage - 7312 * starting_average_base_damage)/8723)
-    self:SetStackCount(self.bonus_damage)
+    -- Bonus damage/block formula
+    local bonus = math.ceil(3188/61 + (4166 * current_average_base_damage - 7312 * starting_average_base_damage)/8723)
+    self:SetStackCount(bonus)
     self:StartIntervalThink(1)
   end
 
@@ -108,19 +152,70 @@ function modifier_spark_power:OnIntervalThink()
     local base_damage_level_1_min = base_damage_min - current_primary_stat_value + starting_primary_stat_value
     local starting_average_base_damage = (base_damage_level_1_max + base_damage_level_1_min)/2
 
-    self.bonus_damage = math.ceil(3188/61 + (4166 * current_average_base_damage - 7312 * starting_average_base_damage)/8723)
-    self:SetStackCount(self.bonus_damage)
+    local bonus = math.ceil(3188/61 + (4166 * current_average_base_damage - 7312 * starting_average_base_damage)/8723)
+    self:SetStackCount(bonus)
   end
+
+  parent.power_spark_bonus = self:GetStackCount()
 end
 
-function modifier_spark_power:DeclareFunctions()
+---------------------------------------------------------------------------------------------------
+
+function modifier_spark_power_effect:IsHidden()
+  return false
+end
+
+function modifier_spark_power_effect:IsDebuff()
+  return false
+end
+
+function modifier_spark_power_effect:IsPurgable()
+  return false
+end
+
+function modifier_spark_power_effect:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_TOOLTIP,
     MODIFIER_PROPERTY_PROCATTACK_BONUS_DAMAGE_PURE,
+    MODIFIER_PROPERTY_PHYSICAL_CONSTANT_BLOCK,
   }
 end
 
-function modifier_spark_power:GetModifierProcAttack_BonusDamage_Pure(event)
+function modifier_spark_power_effect:OnCreated()
+  local caster = self:GetCaster()
+  if not caster or caster:IsNull() then
+    return
+  end
+
+  if caster:IsIllusion() then
+    return
+  end
+
+  if not caster.power_spark_bonus then
+    return
+  end
+
+  self.bonus = caster.power_spark_bonus
+end
+
+function modifier_spark_power_effect:OnRefresh()
+  local caster = self:GetCaster()
+  if not caster or caster:IsNull() then
+    return
+  end
+
+  if caster:IsIllusion() then
+    return
+  end
+
+  if not caster.power_spark_bonus then
+    return
+  end
+
+  self.bonus = caster.power_spark_bonus
+end
+
+function modifier_spark_power_effect:GetModifierProcAttack_BonusDamage_Pure(event)
   local parent = self:GetParent()
   local target = event.target
 
@@ -174,7 +269,7 @@ function modifier_spark_power:GetModifierProcAttack_BonusDamage_Pure(event)
     end
   end
   ]]
-  local damage = self.bonus_damage
+  local damage = self.bonus
   if parent:IsIllusion() then
     damage = damage/10
   end
@@ -185,6 +280,14 @@ function modifier_spark_power:GetModifierProcAttack_BonusDamage_Pure(event)
   return damage
 end
 
-function modifier_spark_power:OnTooltip()
-  return self:GetStackCount()
+function modifier_spark_power_effect:GetModifierPhysical_ConstantBlock()
+  return self.bonus
+end
+
+function modifier_spark_power_effect:OnTooltip()
+  return self.bonus
+end
+
+function modifier_spark_power_effect:GetTexture()
+  return "custom/spark_power"
 end

--- a/game/scripts/vscripts/modifiers/sparks/modifier_spark_power.lua
+++ b/game/scripts/vscripts/modifiers/sparks/modifier_spark_power.lua
@@ -280,8 +280,23 @@ function modifier_spark_power_effect:GetModifierProcAttack_BonusDamage_Pure(even
   return damage
 end
 
-function modifier_spark_power_effect:GetModifierPhysical_ConstantBlock()
-  return self.bonus
+function modifier_spark_power_effect:GetModifierPhysical_ConstantBlock(keys)
+  local parent = self:GetParent()
+  local attacker = keys.attacker
+
+  if not attacker or attacker:IsNull() then
+    return 0
+  end
+
+  if parent:IsRealHero() then
+    return 0
+  end
+
+  if attacker:GetTeamNumber() == DOTA_TEAM_NEUTRALS and not attacker:IsOAABoss() then
+    return self.bonus
+  end
+
+  return 0
 end
 
 function modifier_spark_power_effect:OnTooltip()


### PR DESCRIPTION
* Power spark now provides an aura that affects units, illusions, and wards under the player's control. Aura radius: 1200
* Bonus pure damage on summons, illusions and wards, is 1/10 of the value on the original hero.
* Aura also provides a 50% chance to block damage from neutral creeps (Doesn't block damage from bosses).
* Damage block value on summons and wards is equal to 1/2 of the bonus damage value on the original hero.
* Original hero doesn't get damage block, but his illusions do: Damage block on illusions is equal to the bonus damage on the original hero.

TLDR: Same as before, it works on illusions but they need to be close (within 1200 radius) to the original hero. Now, summons also get bonus damage and they can block damage from neutrals (they are tankier). This should make summon and illusion heroes better at farming.

Bugs: typical aura stuff not getting refreshed properly. Nothing I can do there except force refresh every time stats get updated. Not a major bug.
Chance to proc damage block is true random. Pseudo-random api stuff not available on the client. Can be considered intended.