### PR TITLE
Fixes

### DIFF
--- a/game/scripts/vscripts/components/abilities/level.lua
+++ b/game/scripts/vscripts/components/abilities/level.lua
@@ -67,13 +67,17 @@ function AbilityLevels:CheckAbilityLevels (keys)
   local leveled_up_ability = keys.abilityname
   if leveled_up_ability then
     local talent = hero:FindAbilityByName(leveled_up_ability)
-    if string.find(leveled_up_ability, "special_bonus_") or talent:IsAttributeBonus() then
+    if string.find(leveled_up_ability, "special_bonus_") and talent:IsAttributeBonus() then
       -- Ability is a talent
 
-      -- Check for hero level and if talent is really taken
-      if level >= 27 and talent:GetLevel() == 0 then
+      -- Check for hero level
+      if level >= 27 then
         -- Refund a skill point if a player wasted it on a talent that is not supposed to be levelled.
-        hero:SetAbilityPoints(hero:GetAbilityPoints() + 1)
+        if talent:GetLevel() == 0 or ((talent:GetLevel() == 1) and talent.granted_with_oaa_scepter) then
+          -- Talent wasn't learned or was granted by Aghanim Scepter
+          -- dota_player_learned_ability event doesn't happen for abilities that are lvled with Lua: ability:SetLevel(level)
+          hero:SetAbilityPoints(hero:GetAbilityPoints() + 1)
+        end
       end
     end
   end
@@ -150,6 +154,7 @@ function AbilityLevels:SetTalents(hero)
     if claim then
       if leftLevel == 0 then
         leftAbility:SetLevel(1)
+        leftAbility.granted_with_oaa_scepter = true
         -- Check if this talent is on problematic list, add modifier if true
         for i = 1, #problematic_talents do
           local talent = problematic_talents[i]
@@ -166,6 +171,7 @@ function AbilityLevels:SetTalents(hero)
       end
       if rightLevel == 0 then
         rightAbility:SetLevel(1)
+        rightAbility.granted_with_oaa_scepter = true
         -- Check if this talent is on problematic list, add modifier if true
         for i = 1, #problematic_talents do
           local talent = problematic_talents[i]
@@ -185,11 +191,13 @@ function AbilityLevels:SetTalents(hero)
       if hero['talentChoice' .. level] == 'left' then
         if rightLevel ~= 0 then
           rightAbility:SetLevel(0)
+          rightAbility.granted_with_oaa_scepter = nil
           hero:RemoveModifierByName(AbilityLevels:GetTalentModifier(rightAbility:GetName()))
         end
       else
         if leftLevel ~= 0 then
           leftAbility:SetLevel(0)
+          leftAbility.granted_with_oaa_scepter = nil
           hero:RemoveModifierByName(AbilityLevels:GetTalentModifier(leftAbility:GetName()))
         end
       end

--- a/game/scripts/vscripts/components/abilities/level.lua
+++ b/game/scripts/vscripts/components/abilities/level.lua
@@ -73,7 +73,7 @@ function AbilityLevels:CheckAbilityLevels (keys)
       -- Check for hero level
       if level >= 27 then
         -- Refund a skill point if a player wasted it on a talent that is not supposed to be levelled.
-        if talent:GetLevel() == 0 or ((talent:GetLevel() == 1) and talent.granted_with_oaa_scepter) then
+        if talent:GetLevel() == 0 or talent.granted_with_oaa_scepter then
           -- Talent wasn't learned or was granted by Aghanim Scepter
           -- dota_player_learned_ability event doesn't happen for abilities that are lvled with Lua: ability:SetLevel(level)
           hero:SetAbilityPoints(hero:GetAbilityPoints() + 1)

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -463,6 +463,10 @@ function Duels:PreparePlayersToStartDuel(options, playerSplit)
     goodPlayerIndex = playerSplit.GoodPlayerIndex
   }
 
+  Timers:CreateTimer(2, function()
+    GridNav:RegrowAllTrees()
+  end)
+
   DebugPrint("Duel Info")
   DebugPrintTable(self.currentDuel)
 

--- a/game/scripts/vscripts/components/duels/final-duel.lua
+++ b/game/scripts/vscripts/components/duels/final-duel.lua
@@ -125,6 +125,7 @@ function FinalDuel:EndDuelHandler (currentDuel)
   self.goodCanWin = false
   self.badCanWin = false
 
-  local addToLimit = limitIncreaseAmounts[PointsManager:GetGameLength()]  -- this is 10; if you want to change put: PlayerResource:SafeGetTeamPlayerCount() * KILL_LIMIT_INCREASE
+  -- Increase the score limit
+  local addToLimit = PlayerResource:SafeGetTeamPlayerCount() * KILL_LIMIT_INCREASE -- old: limitIncreaseAmounts[PointsManager:GetGameLength()]
   PointsManager:IncreaseLimit(addToLimit)
 end

--- a/game/scripts/vscripts/components/duels/runes.lua
+++ b/game/scripts/vscripts/components/duels/runes.lua
@@ -59,10 +59,10 @@ function DuelRunes:StartTouch(event)
 ]]
   local modifier
   local activator = event.activator
-  if not activator:IsClone() and not activator:IsTempestDouble() then
+  if not activator:IsClone() and not activator:IsTempestDouble() and Duels:IsActive() and (not activator:HasModifier("modifier_out_of_duel")) then
     modifier = activator:AddNewModifier(activator, nil, "modifier_duel_rune_hill", {})
   end
-  -- No idea how this can be nil if the previous line doesn't have an error, but it happens for some reason
+
   if modifier then
     modifier.zone = event.caller
   end

--- a/game/scripts/vscripts/components/progression/talents.lua
+++ b/game/scripts/vscripts/components/progression/talents.lua
@@ -1,17 +1,39 @@
 if Talents == nil then
-    Talents = class({})
-    Debug.EnabledModules['progression:*'] = false
+  Talents = class({})
 end
 
 GameEvents:OnPlayerLearnedAbility(function(keys)
   -- OnPlayerLearnedAbility event doesn't happen for abilities that are leveled up in Lua with: ability:SetLevel(level)
+
+  --"PlayerID"
+  --"player"
+  --"abilityname"
+
   local playerID = keys.PlayerID or keys.player_id -- just in case Valve randomly changes it again
   local abilityname = keys.abilityname
 
-  if playerID and string.find(abilityname, "special_bonus") then
-    local hero = PlayerResource:GetSelectedHeroEntity(playerID)
-    local talentData = CustomNetTables:GetTableValue("talents", tostring(hero:entindex())) or {}
-    talentData[abilityname] = true
-    CustomNetTables:SetTableValue("talents", tostring(hero:entindex()), talentData)
+  local player
+  if keys.player then
+    player = EntIndexToHScript(keys.player)
+  else
+    player = PlayerResource:GetPlayer(playerID)
+  end
+
+  local hero
+  if player then
+    hero = player:GetAssignedHero()
+  else
+    hero = PlayerResource:GetSelectedHeroEntity(playerID)
+  end
+
+  if abilityname and hero then
+    local talent = hero:FindAbilityByName(abilityname)
+    -- Check if ability is a talent
+    if string.find(abilityname, "special_bonus_") and talent:IsAttributeBonus() then
+      -- Store information into net-table (probably not needed)
+      local talentData = CustomNetTables:GetTableValue("talents", tostring(hero:entindex())) or {}
+      talentData[abilityname] = true
+      CustomNetTables:SetTableValue("talents", tostring(hero:entindex()), talentData)
+    end
   end
 end)

--- a/game/scripts/vscripts/components/zonecontrol/cleaner.lua
+++ b/game/scripts/vscripts/components/zonecontrol/cleaner.lua
@@ -34,7 +34,7 @@ function ZoneCleaner:CleanZone(state)
   --DebugDrawBox(state.origin, state.bounds.Mins, state.bounds.Maxs, 255, 100, 0, 0, 30)
   --DebugDrawSphere(state.origin, Vector(255, 100, 0), 0, max(state.bounds.Maxs.x + state.bounds.Maxs.y, state.bounds.Mins.x + state.bounds.Mins.y), true, 30)
 
-  local entities = Entities:FindAllInSphere(state.origin, max(max(state.bounds.Mins.x, state.bounds.Maxs.x),max(state.bounds.Mins.y, state.bounds.Maxs.y)))
+  local entities = Entities:FindAllInSphere(state.origin, max(max(state.bounds.Mins.x, state.bounds.Maxs.x), max(state.bounds.Mins.y, state.bounds.Maxs.y)))
 
   for _,entity in pairs(entities) do
     for _,entry in pairs(ZoneCleaner.ForbiddenEntities) do
@@ -45,4 +45,10 @@ function ZoneCleaner:CleanZone(state)
       end
     end
   end
+
+  -- Clean up trees
+  GridNav:DestroyTreesAroundPoint(state.origin, max(max(state.bounds.Mins.x, state.bounds.Maxs.x), max(state.bounds.Mins.y, state.bounds.Maxs.y)), true)
+
+  -- Regrow them
+  GridNav:RegrowAllTrees()
 end

--- a/game/scripts/vscripts/components/zonecontrol/cleaner.lua
+++ b/game/scripts/vscripts/components/zonecontrol/cleaner.lua
@@ -27,14 +27,14 @@ ZoneCleaner.ForbiddenEntities = {
   "npc_dota_templar_assassin_psionic_trap",
   "npc_dota_earth_spirit_stone",
   "npc_dota_ember_spirit_remnant",
-  "npc_dota_healing_mine",
+  --"npc_dota_treant_eyes",
 }
 
 function ZoneCleaner:CleanZone(state)
   --DebugDrawBox(state.origin, state.bounds.Mins, state.bounds.Maxs, 255, 100, 0, 0, 30)
   --DebugDrawSphere(state.origin, Vector(255, 100, 0), 0, max(state.bounds.Maxs.x + state.bounds.Maxs.y, state.bounds.Mins.x + state.bounds.Mins.y), true, 30)
-
-  local entities = Entities:FindAllInSphere(state.origin, max(max(state.bounds.Mins.x, state.bounds.Maxs.x), max(state.bounds.Mins.y, state.bounds.Maxs.y)))
+  local radius = math.max(math.max(math.abs(state.bounds.Mins.x), math.abs(state.bounds.Maxs.x)), math.max(math.abs(state.bounds.Mins.y), math.abs(state.bounds.Maxs.y))) + 600
+  local entities = Entities:FindAllInSphere(state.origin, radius)
 
   for _,entity in pairs(entities) do
     for _,entry in pairs(ZoneCleaner.ForbiddenEntities) do
@@ -47,8 +47,5 @@ function ZoneCleaner:CleanZone(state)
   end
 
   -- Clean up trees
-  GridNav:DestroyTreesAroundPoint(state.origin, max(max(state.bounds.Mins.x, state.bounds.Maxs.x), max(state.bounds.Mins.y, state.bounds.Maxs.y)), true)
-
-  -- Regrow them
-  GridNav:RegrowAllTrees()
+  GridNav:DestroyTreesAroundPoint(state.origin, radius, true)
 end

--- a/game/scripts/vscripts/items/aghanims.lua
+++ b/game/scripts/vscripts/items/aghanims.lua
@@ -143,6 +143,7 @@ function modifier_item_aghanims_talents:SetTalents(tree)
     if claim then
       if leftLevel == 0 then
         leftAbility:SetLevel(1)
+        leftAbility.granted_with_oaa_scepter = true
         -- Check if this talent is on problematic list, add modifier if true
         for i = 1, #problematic_talents do
           local talent = problematic_talents[i]
@@ -159,6 +160,7 @@ function modifier_item_aghanims_talents:SetTalents(tree)
       end
       if rightLevel == 0 then
         rightAbility:SetLevel(1)
+        rightAbility.granted_with_oaa_scepter = true
         -- Check if this talent is on problematic list, add modifier if true
         for i = 1, #problematic_talents do
           local talent = problematic_talents[i]
@@ -178,11 +180,13 @@ function modifier_item_aghanims_talents:SetTalents(tree)
       if parent['talentChoice' .. level] == 'left' then
         if rightLevel ~= 0 then
           rightAbility:SetLevel(0)
+          rightAbility.granted_with_oaa_scepter = nil
           parent:RemoveModifierByName(AbilityLevels:GetTalentModifier(rightAbility:GetName()))
         end
       else
         if leftLevel ~= 0 then
           leftAbility:SetLevel(0)
+          leftAbility.granted_with_oaa_scepter = nil
           parent:RemoveModifierByName(AbilityLevels:GetTalentModifier(leftAbility:GetName()))
         end
       end

--- a/game/scripts/vscripts/modifiers/modifier_duel_rune_hill.lua
+++ b/game/scripts/vscripts/modifiers/modifier_duel_rune_hill.lua
@@ -63,6 +63,10 @@ end
 function modifier_duel_rune_hill:OnIntervalThink()
   local unit = self:GetCaster() or self:GetParent()
 
+  if not IsServer() then
+    return
+  end
+
   if unit:IsClone() or unit:IsTempestDouble() then
     return
   end

--- a/game/scripts/vscripts/units/ai_grendel.lua
+++ b/game/scripts/vscripts/units/ai_grendel.lua
@@ -50,8 +50,8 @@ function GrendelThink ()
     end
   end
 
-  -- Aggroed if its health is below 98%
-  local shouldAggro = hpPercent < 0.98
+  -- Aggroed if its health is below 95%
+  local shouldAggro = hpPercent < 0.95
 
   -- Check if it is aggroed but it shouldn't be aggroed
   if thisEntity.isAggro and not shouldAggro then
@@ -99,9 +99,7 @@ function GrendelThink ()
   end
 
   if not thisEntity.isAggro then
-    -- less going on so we do non-aggro case first....
-    -- don't degen if we're not aggrod yet
-    thisEntity:RemoveModifierByName("modifier_boss_regen_degen")
+    --thisEntity:RemoveModifierByName("modifier_boss_regen_degen")
     thisEntity:SetIdleAcquire(false)
     thisEntity:SetAcquisitionRange(0)
   else


### PR DESCRIPTION
* Fixed refunding a skill point not working for talents if you clicked on a talent granted by Aghanim Scepter.
* Fixed Grendel respawning more than once. (Only 2 Grendels are allowed per game)
* Fixed Final Duel score limit extension not being based on a number of players.
* Fixed being able to gain duel runes while disconnected.
* Fixed being able to gain duel runes while duels are not active.
* All trees in duel arenas are now being destroyed before duel start. Trees regrow 2 seconds after duel start.
* Grendel aggro hp percent reduced from 98% to 95%.
* Grendel no longer loses degen when not aggroed.
* Fixed Grendel component not working properly with load/save state.
* Improved zone cleaner (duel cleanup before duel start). Sometimes techies mines and other stuff were not being removed if they are close to the edge of the arena.
* Fixed duel rune buff error on the client.