### PR TITLE
Non-boss periodic capture points changes

### DIFF
--- a/game/scripts/vscripts/components/capturepoints/capturepoints.lua
+++ b/game/scripts/vscripts/components/capturepoints/capturepoints.lua
@@ -243,7 +243,7 @@ function CapturePoints:ActuallyStartCapture()
 
   local leftVector = GetGroundPosition(Vector(CurrentZones.left.x, CurrentZones.left.y, CurrentZones.left.z + 384), nil)
   local rightVector = GetGroundPosition(Vector(CurrentZones.right.x, CurrentZones.right.y, CurrentZones.right.z + 384), nil)
-  
+
   local fountains = Entities:FindAllByClassname("ent_dota_fountain")
   local radiant_fountain
   local dire_fountain

--- a/game/scripts/vscripts/components/capturepoints/capturepoints.lua
+++ b/game/scripts/vscripts/components/capturepoints/capturepoints.lua
@@ -179,10 +179,10 @@ function CapturePoints:StartCapture(color)
     y = 1
   }
   Notifications:TopToAll({text="#capturepoints_imminent_warning", duration=3.0, style={color="red", ["font-size"]="70px"}, replacement_map={seconds_to_cp = CAPTURE_FIRST_WARN}})
-  self:MinimapPing(5)
+  self:MinimapPing()
   Timers:CreateTimer(CAPTURE_FIRST_WARN - CAPTURE_SECOND_WARN, function ()
     Notifications:TopToAll({text="#capturepoints_imminent_warning", duration=3.0, style={color="red", ["font-size"]="70px"}, replacement_map={seconds_to_cp = CAPTURE_SECOND_WARN}})
-    CapturePoints:MinimapPing(5)
+    CapturePoints:MinimapPing()
   end)
 
   for index = 0,(CAPTURE_START_COUNTDOWN - 1) do
@@ -214,7 +214,7 @@ function CapturePoints:Reward(teamId)
     return
   end
 
-  PointsManager:AddPoints(teamId, NumCaptures)
+  PointsManager:AddPoints(teamId, 2*NumCaptures)
 
   if NumCaptures == 1 then
     self:GiveItemToWholeTeam("item_upgrade_core", teamId)
@@ -240,18 +240,18 @@ function CapturePoints:ActuallyStartCapture()
   DebugPrint ('CaptureStarted')
   Start.broadcast(self.currentCapture)
 
-  local leftVector = Vector(CurrentZones.left.x, CurrentZones.left.y, CurrentZones.left.z + 256)
-  local rightVector = Vector(CurrentZones.right.x, CurrentZones.right.y, CurrentZones.right.z + 256)
+  local leftVector = GetGroundPosition(Vector(CurrentZones.left.x, CurrentZones.left.y, CurrentZones.left.z + 384), nil)
+  local rightVector = GetGroundPosition(Vector(CurrentZones.right.x, CurrentZones.right.y, CurrentZones.right.z + 384), nil)
 
   -- Create under spectator team so that spectators can always see the capture point
-  local capturePointThinker1 = CreateModifierThinker(nil, nil, "modifier_standard_capture_point", nil, leftVector, DOTA_TEAM_SPECTATOR, false)
+  local capturePointThinker1 = CreateModifierThinker(nil, nil, "modifier_standard_capture_point", nil, leftVector, DOTA_TEAM_GOODGUYS, false)
   local capturePointModifier1 = capturePointThinker1:FindModifierByName("modifier_standard_capture_point")
   capturePointModifier1:SetCallback(partial(self.Reward, self))
   -- Give the thinker some vision so that spectators can always see the capture point
   capturePointThinker1:SetDayTimeVisionRange(1)
   capturePointThinker1:SetNightTimeVisionRange(1)
 
-  local capturePointThinker2 = CreateModifierThinker(nil, nil, "modifier_standard_capture_point", nil,  rightVector, DOTA_TEAM_SPECTATOR, false)
+  local capturePointThinker2 = CreateModifierThinker(nil, nil, "modifier_standard_capture_point", nil, rightVector, DOTA_TEAM_BADGUYS, false)
   local capturePointModifier2 = capturePointThinker2:FindModifierByName("modifier_standard_capture_point")
   capturePointModifier2:SetCallback(partial(self.Reward, self))
   -- Give the thinker some vision so that spectators can always see the capture point

--- a/game/scripts/vscripts/components/minimap/minimap_camps.lua
+++ b/game/scripts/vscripts/components/minimap/minimap_camps.lua
@@ -60,7 +60,7 @@ end
 function Minimap:SpawnCaptureIcon(location)
   for _,teamID in pairs({DOTA_TEAM_GOODGUYS, DOTA_TEAM_BADGUYS}) do
     local capture_point_minimap = CreateUnitByName('minimap_capture_point', location, false, nil, nil, teamID)
-    capture_point_minimap:AddNewModifier(capture_point_minimap, nil, "modifier_minimap", {IsCapture = true })
+    capture_point_minimap:AddNewModifier(capture_point_minimap, nil, "modifier_minimap", {IsCapture = true})
     capture_point_minimap.Respawn = true
   end
 end

--- a/game/scripts/vscripts/modifiers/modifier_minimap.lua
+++ b/game/scripts/vscripts/modifiers/modifier_minimap.lua
@@ -37,9 +37,18 @@ if IsServer() then
 
     --Capture points Icons
     if self.IsCapture then
-      Timers:CreateTimer(45, function()
-        if IsValidEntity(minimap_entity) and minimap_entity:IsAlive() then
-          minimap_entity:ForceKill(false)
+      Timers:CreateTimer(CAPTURE_LENTGH, function()
+        if not IsValidEntity(minimap_entity) or not minimap_entity:IsAlive() then
+          return -1
+        end
+
+        if CapturePoints and CapturePoints:IsActive() then
+          return 0.5
+        else
+          if IsValidEntity(minimap_entity) and minimap_entity:IsAlive() then
+            minimap_entity:ForceKill(false)
+            return -1
+          end
         end
       end)
       return -1

--- a/game/scripts/vscripts/modifiers/modifier_standard_capture_point.lua
+++ b/game/scripts/vscripts/modifiers/modifier_standard_capture_point.lua
@@ -66,7 +66,7 @@ end
 
 if IsServer() then
   function modifier_standard_capture_point:OnCreated(keys)
-    self.radius = keys.radius or 270
+    self.radius = keys.radius or 300
     self.captureTime = keys.captureTime or CAPTURE_LENTGH
     self.captureProgress = 0
     self.thinkInterval = 0.02

--- a/game/scripts/vscripts/modifiers/modifier_standard_capture_point_dummy_stuff.lua
+++ b/game/scripts/vscripts/modifiers/modifier_standard_capture_point_dummy_stuff.lua
@@ -1,0 +1,61 @@
+modifier_standard_capture_point_dummy_stuff = class(ModifierBaseClass)
+
+function modifier_standard_capture_point_dummy_stuff:IsHidden()
+  return true
+end
+
+function modifier_standard_capture_point_dummy_stuff:IsDebuff()
+  return false
+end
+
+function modifier_standard_capture_point_dummy_stuff:IsPurgable()
+  return false
+end
+
+function modifier_standard_capture_point_dummy_stuff:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_PHYSICAL,
+    MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_MAGICAL,
+    MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_PURE,
+    MODIFIER_PROPERTY_BONUS_DAY_VISION,
+    MODIFIER_PROPERTY_BONUS_NIGHT_VISION,
+  }
+end
+
+function modifier_standard_capture_point_dummy_stuff:GetAbsoluteNoDamagePhysical()
+  return 1
+end
+
+function modifier_standard_capture_point_dummy_stuff:GetAbsoluteNoDamageMagical()
+  return 1
+end
+
+function modifier_standard_capture_point_dummy_stuff:GetAbsoluteNoDamagePure()
+  return 1
+end
+
+function modifier_standard_capture_point_dummy_stuff:GetBonusDayVision()
+  return 300
+end
+
+function modifier_standard_capture_point_dummy_stuff:GetBonusNightVision()
+  return 300
+end
+
+function modifier_standard_capture_point_dummy_stuff:CheckState()
+  local state = {
+    [MODIFIER_STATE_UNSELECTABLE] = true,
+    [MODIFIER_STATE_NOT_ON_MINIMAP] = true,
+    [MODIFIER_STATE_NOT_ON_MINIMAP_FOR_ENEMIES] = true,
+    [MODIFIER_STATE_NO_HEALTH_BAR] = true,
+    [MODIFIER_STATE_NO_UNIT_COLLISION] = true,
+    [MODIFIER_STATE_OUT_OF_GAME] = true,
+    [MODIFIER_STATE_NO_TEAM_MOVE_TO] = true,
+    [MODIFIER_STATE_NO_TEAM_SELECT] = true,
+    [MODIFIER_STATE_COMMAND_RESTRICTED] = true,
+    [MODIFIER_STATE_ATTACK_IMMUNE] = true,
+    [MODIFIER_STATE_MAGIC_IMMUNE] = true,
+    [MODIFIER_STATE_FLYING] = true,
+  }
+  return state
+end


### PR DESCRIPTION
* Point Reward for capturing increased from 1/2/3/4/5/... to 2/4/6/8/10/...
* Radius increased from 270 to 300.
* They are visible to certain teams: capture points closer to the Radiant base are visible to the Radiant team and capture points closer to the Dire base are visible to the Dire team. You can also see if the enemy team is trying to take them over.
* Capture Points are now always above ground (unless they are inside the stairs).
* Capture Points minimap icons now last longer if they are not captured.