### PR TITLE
Item balance (May 2021)

### DIFF
--- a/game/resource/English/ability/items/tooltip_martyrs_mail.txt
+++ b/game/resource/English/ability/items/tooltip_martyrs_mail.txt
@@ -3,7 +3,7 @@
 //============================================================================
 "DOTA_Tooltip_Ability_item_martyrs_mail"                                    "Martyr's Mail"
 "DOTA_Tooltip_Ability_item_recipe_martyrs_mail"                             "Martyr's Mail Recipe"
-"DOTA_Tooltip_Ability_item_martyrs_mail_Description"                        "<h1>Active: Martyr</h1> For %martyr_duration% seconds, heals nearby allies for %martyr_heal_percent%%% of any damage taken. <br><br>Radius: %martyr_heal_aoe%"
+"DOTA_Tooltip_Ability_item_martyrs_mail_Description"                        "<h1>Active: Martyrdom</h1> For %martyr_duration% seconds, heals nearby allies for %martyr_heal_percent%%% of any damage taken. <br><br>Radius: %martyr_heal_aoe%\n<h1>Passive: Martyr's Morale</h1> Allies near the Martyr cannot be broken and gain %aura_attack_speed% attack speed.<br><br>Radius: %aura_radius%"
 "DOTA_Tooltip_Ability_item_martyrs_mail_Lore"                               "The tattered remains of a paladin's hauberk."
 "DOTA_Tooltip_Ability_item_martyrs_mail_Note0"                              "Martyr is calculated before any kind of reduction."
 "DOTA_Tooltip_Ability_item_martyrs_mail_bonus_damage"                       "+$damage"
@@ -36,3 +36,15 @@
 "DOTA_Tooltip_Ability_item_martyrs_mail_4_bonus_damage"                     "#{DOTA_Tooltip_Ability_item_martyrs_mail_bonus_damage}"
 "DOTA_Tooltip_Ability_item_martyrs_mail_4_bonus_armor"                      "#{DOTA_Tooltip_Ability_item_martyrs_mail_bonus_armor}"
 "DOTA_Tooltip_Ability_item_martyrs_mail_4_bonus_intellect"                  "#{DOTA_Tooltip_Ability_item_martyrs_mail_bonus_intellect}"
+
+//=============================================================================
+// Martyrs Mail Modifiers
+//=============================================================================
+"DOTA_Tooltip_modifier_item_martyrs_mail_martyr_active"                     "Martyrdom"
+"DOTA_Tooltip_modifier_item_martyrs_mail_martyr_active_Description"         "Healing nearby allies for the damage taken."
+
+"DOTA_Tooltip_modifier_item_martyrs_mail_martyr_aura"                       "Martyrdom"
+"DOTA_Tooltip_modifier_item_martyrs_mail_martyr_aura_Description"           "Unit is being healed by a hero with Martyr's Mail."
+
+"DOTA_Tooltip_modifier_item_martyrs_mail_passive_aura_effect"               "Martyr's Morale"
+"DOTA_Tooltip_modifier_item_martyrs_mail_passive_aura_effect_Description"   "Unbreakable (passives cannot be disabled) and bonus attack speed."

--- a/game/resource/English/modifier/items/modifier_martyrs_mail.txt
+++ b/game/resource/English/modifier/items/modifier_martyrs_mail.txt
@@ -1,8 +1,0 @@
-//=============================================================================
-// Martyrs Mail Return
-//=============================================================================
-"DOTA_Tooltip_modifier_item_martyrs_mail_martyr_active"              "Martyrdom"
-"DOTA_Tooltip_modifier_item_martyrs_mail_martyr_active_Description"  "Healing nearby allies for the damage taken."
-
-"DOTA_Tooltip_modifier_item_martyrs_mail_martyr_aura"                "Martyrdom"
-"DOTA_Tooltip_modifier_item_martyrs_mail_martyr_aura_Description"    "Unit is being healed by a hero with Martyr's Mail."

--- a/game/scripts/npc/items/custom/item_martyrs_mail.txt
+++ b/game/scripts/npc/items/custom/item_martyrs_mail.txt
@@ -71,7 +71,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "17 20 24 29"
+        "bonus_armor"                                     "12 15 19 24"
       }
       "03"
       {
@@ -92,6 +92,16 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "martyr_heal_percent"                             "100"
+      }
+      "07"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "aura_attack_speed"                               "100"
+      }
+      "08"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "aura_radius"                                     "1200"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_martyrs_mail_2.txt
+++ b/game/scripts/npc/items/custom/item_martyrs_mail_2.txt
@@ -72,7 +72,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "17 20 24 29"
+        "bonus_armor"                                     "12 15 19 24"
       }
       "03"
       {
@@ -93,6 +93,16 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "martyr_heal_percent"                             "100"
+      }
+      "07"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "aura_attack_speed"                               "100"
+      }
+      "08"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "aura_radius"                                     "1200"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_martyrs_mail_3.txt
+++ b/game/scripts/npc/items/custom/item_martyrs_mail_3.txt
@@ -72,7 +72,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "17 20 24 29"
+        "bonus_armor"                                     "12 15 19 24"
       }
       "03"
       {
@@ -93,6 +93,16 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "martyr_heal_percent"                             "100"
+      }
+      "07"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "aura_attack_speed"                               "100"
+      }
+      "08"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "aura_radius"                                     "1200"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_martyrs_mail_4.txt
+++ b/game/scripts/npc/items/custom/item_martyrs_mail_4.txt
@@ -74,7 +74,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "17 20 24 29"
+        "bonus_armor"                                     "12 15 19 24"
       }
       "03"
       {
@@ -95,6 +95,16 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "martyr_heal_percent"                             "100"
+      }
+      "07"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "aura_attack_speed"                               "100"
+      }
+      "08"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "aura_radius"                                     "1200"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_regen_crystal_1.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_1.txt
@@ -42,7 +42,7 @@
     "AbilityTextureName"                                  "custom/regen_crystal_1"
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "20.0"
+    "AbilityCooldown"                                     "25"
     "AbilityCastPoint"                                    "0.0"
     "AbilitySharedCooldown"                               "regen_crystal"
 
@@ -76,17 +76,17 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "max_mana_to_hp_regen"                            "3"
+        "max_mana_to_hp_regen"                            "5"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen"                                 "300 400 500"
+        "active_hp_regen"                                 "400 500 600"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen_amp"                             "100"
+        "active_hp_regen_amp"                             "50"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_regen_crystal_2.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_2.txt
@@ -43,7 +43,7 @@
     "AbilityTextureName"                                  "custom/regen_crystal_2"
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "20.0"
+    "AbilityCooldown"                                     "25"
     "AbilityCastPoint"                                    "0.0"
     "AbilitySharedCooldown"                               "regen_crystal"
 
@@ -77,17 +77,17 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "max_mana_to_hp_regen"                            "3"
+        "max_mana_to_hp_regen"                            "5"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen"                                 "300 400 500"
+        "active_hp_regen"                                 "400 500 600"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen_amp"                             "100"
+        "active_hp_regen_amp"                             "50"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_regen_crystal_3.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_3.txt
@@ -44,7 +44,7 @@
     "AbilityTextureName"                                  "custom/regen_crystal_3"
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "20.0"
+    "AbilityCooldown"                                     "25"
     "AbilityCastPoint"                                    "0.0"
     "AbilitySharedCooldown"                               "regen_crystal"
 
@@ -78,17 +78,17 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "max_mana_to_hp_regen"                            "3"
+        "max_mana_to_hp_regen"                            "5"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen"                                 "300 400 500"
+        "active_hp_regen"                                 "400 500 600"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen_amp"                             "100"
+        "active_hp_regen_amp"                             "50"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_sacred_skull.txt
+++ b/game/scripts/npc/items/custom/item_sacred_skull.txt
@@ -147,7 +147,7 @@
       "16"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "death_vision_duration"                           "10"
+        "death_vision_duration"                           "30"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_sacred_skull_2.txt
+++ b/game/scripts/npc/items/custom/item_sacred_skull_2.txt
@@ -140,7 +140,7 @@
       "16"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "death_vision_duration"                           "10"
+        "death_vision_duration"                           "30"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_sacred_skull_3.txt
+++ b/game/scripts/npc/items/custom/item_sacred_skull_3.txt
@@ -140,7 +140,7 @@
       "16"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "death_vision_duration"                           "10"
+        "death_vision_duration"                           "30"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_sacred_skull_4.txt
+++ b/game/scripts/npc/items/custom/item_sacred_skull_4.txt
@@ -139,7 +139,7 @@
       "16"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "death_vision_duration"                           "10"
+        "death_vision_duration"                           "30"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_stoneskin.txt
+++ b/game/scripts/npc/items/custom/item_stoneskin.txt
@@ -75,7 +75,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "25 30"
+        "bonus_armor"                                     "20 25"
       }
       "02"
       {
@@ -105,7 +105,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "stone_armor"                                     "75 90"
+        "stone_armor"                                     "100"
       }
       "08"
       {

--- a/game/scripts/npc/items/custom/item_stoneskin_2.txt
+++ b/game/scripts/npc/items/custom/item_stoneskin_2.txt
@@ -74,7 +74,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "25 30"
+        "bonus_armor"                                     "20 25"
       }
       "02"
       {
@@ -104,7 +104,7 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "stone_armor"                                     "75 90"
+        "stone_armor"                                     "100"
       }
       "08"
       {

--- a/game/scripts/npc/items/item_bloodthorn.txt
+++ b/game/scripts/npc/items/item_bloodthorn.txt
@@ -12,7 +12,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "1000" //OAA
+    "ItemCost"                                            "800"
     "ItemShopTags"                                        ""
 
     // Recipe
@@ -55,7 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "100"
-    "ItemCost"                                            "6475" //OAA
+    "ItemCost"                                            "6275"
     "ItemShopTags"                                        "int;attack_speed;damage;regen_mana;damage;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "orchid malevolence;bloodthorn"
@@ -98,7 +98,7 @@
       "07"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "target_crit_multiplier"                          "130 140 150 160 170"
+        "target_crit_multiplier"                          "120 130 140 150 160" //OAA
       }
       "08"
       {

--- a/game/scripts/npc/items/item_bloodthorn_2.txt
+++ b/game/scripts/npc/items/item_bloodthorn_2.txt
@@ -102,7 +102,7 @@
       "07"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "target_crit_multiplier"                          "130 140 150 160 170"
+        "target_crit_multiplier"                          "120 130 140 150 160"
       }
       "08"
       {

--- a/game/scripts/npc/items/item_bloodthorn_3.txt
+++ b/game/scripts/npc/items/item_bloodthorn_3.txt
@@ -102,7 +102,7 @@
       "07"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "target_crit_multiplier"                          "130 140 150 160 170"
+        "target_crit_multiplier"                          "120 130 140 150 160"
       }
       "08"
       {

--- a/game/scripts/npc/items/item_bloodthorn_4.txt
+++ b/game/scripts/npc/items/item_bloodthorn_4.txt
@@ -102,7 +102,7 @@
       "07"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "target_crit_multiplier"                          "130 140 150 160 170"
+        "target_crit_multiplier"                          "120 130 140 150 160"
       }
       "08"
       {

--- a/game/scripts/npc/items/item_bloodthorn_5.txt
+++ b/game/scripts/npc/items/item_bloodthorn_5.txt
@@ -102,7 +102,7 @@
       "07"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "target_crit_multiplier"                          "130 140 150 160 170"
+        "target_crit_multiplier"                          "120 130 140 150 160"
       }
       "08"
       {

--- a/game/scripts/npc/items/item_shivas_guard.txt
+++ b/game/scripts/npc/items/item_shivas_guard.txt
@@ -71,7 +71,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "15 17 20 24 29"
+        "bonus_armor"                                     "10 12 15 19 24" //OAA
       }
       "03"
       {

--- a/game/scripts/npc/items/item_shivas_guard_2.txt
+++ b/game/scripts/npc/items/item_shivas_guard_2.txt
@@ -74,7 +74,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "15 17 20 24 29"
+        "bonus_armor"                                     "10 12 15 19 24"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_shivas_guard_3.txt
+++ b/game/scripts/npc/items/item_shivas_guard_3.txt
@@ -73,7 +73,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "15 17 20 24 29"
+        "bonus_armor"                                     "10 12 15 19 24"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_shivas_guard_4.txt
+++ b/game/scripts/npc/items/item_shivas_guard_4.txt
@@ -73,7 +73,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "15 17 20 24 29"
+        "bonus_armor"                                     "10 12 15 19 24"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_shivas_guard_5.txt
+++ b/game/scripts/npc/items/item_shivas_guard_5.txt
@@ -74,7 +74,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "15 17 20 24 29"
+        "bonus_armor"                                     "10 12 15 19 24"
       }
       "03"
       {

--- a/game/scripts/vscripts/items/martyrs_mail.lua
+++ b/game/scripts/vscripts/items/martyrs_mail.lua
@@ -1,13 +1,23 @@
-LinkLuaModifier( "modifier_item_martyrs_mail_passive", "items/martyrs_mail.lua", LUA_MODIFIER_MOTION_NONE )
-LinkLuaModifier( "modifier_item_martyrs_mail_martyr_active", "items/martyrs_mail.lua", LUA_MODIFIER_MOTION_NONE )
-LinkLuaModifier( "modifier_item_martyrs_mail_martyr_aura", "items/martyrs_mail.lua", LUA_MODIFIER_MOTION_NONE )
+LinkLuaModifier("modifier_intrinsic_multiplexer", "modifiers/modifier_intrinsic_multiplexer.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_martyrs_mail_passive", "items/martyrs_mail.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_martyrs_mail_passive_aura", "items/martyrs_mail.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_martyrs_mail_passive_aura_effect", "items/martyrs_mail.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_martyrs_mail_martyr_active", "items/martyrs_mail.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_martyrs_mail_martyr_aura", "items/martyrs_mail.lua", LUA_MODIFIER_MOTION_NONE)
 
 --------------------------------------------------------------------------------
 
 item_martyrs_mail = class(ItemBaseClass)
 
 function item_martyrs_mail:GetIntrinsicModifierName()
-	return "modifier_item_martyrs_mail_passive"
+  return "modifier_intrinsic_multiplexer"
+end
+
+function item_martyrs_mail:GetIntrinsicModifierNames()
+  return {
+    "modifier_item_martyrs_mail_passive",
+    "modifier_item_martyrs_mail_passive_aura",
+  }
 end
 
 function item_martyrs_mail:OnSpellStart()
@@ -74,7 +84,55 @@ function modifier_item_martyrs_mail_passive:GetModifierBonusStats_Intellect()
 	return self.bonus_intellect
 end
 
---------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
+
+modifier_item_martyrs_mail_passive_aura = class(ModifierBaseClass)
+
+function modifier_item_martyrs_mail_passive_aura:IsHidden()
+  return true
+end
+
+function modifier_item_martyrs_mail_passive_aura:IsDebuff()
+  return false
+end
+
+function modifier_item_martyrs_mail_passive_aura:IsPurgable()
+  return false
+end
+
+function modifier_item_martyrs_mail_passive_aura:IsAura()
+  return true
+end
+
+function modifier_item_martyrs_mail_passive_aura:GetModifierAura()
+  return "modifier_item_martyrs_mail_passive_aura_effect"
+end
+
+function modifier_item_martyrs_mail_passive_aura:GetAuraRadius()
+  return self.aura_radius or 1200
+end
+
+function modifier_item_martyrs_mail_passive_aura:GetAuraSearchTeam()
+  return DOTA_UNIT_TARGET_TEAM_FRIENDLY
+end
+
+function modifier_item_martyrs_mail_passive_aura:GetAuraSearchType()
+  return bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC)
+end
+
+function modifier_item_martyrs_mail_passive_aura:OnCreated()
+  local ability = self:GetAbility()
+  local radius = 1200
+  if ability and not ability:IsNull() then
+    radius = ability:GetSpecialValueFor("aura_radius")
+  end
+
+  self.aura_radius = radius
+end
+
+modifier_item_martyrs_mail_passive_aura.OnRefresh = modifier_item_martyrs_mail_passive_aura.OnCreated
+
+---------------------------------------------------------------------------------------------------
 
 modifier_item_martyrs_mail_martyr_active = class(ModifierBaseClass)
 
@@ -182,7 +240,7 @@ function modifier_item_martyrs_mail_martyr_active:GetTexture()
   return "custom/martyrs_mail_4"
 end
 
---------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------
 
 modifier_item_martyrs_mail_martyr_aura = class(ModifierBaseClass)
 
@@ -207,5 +265,65 @@ function modifier_item_martyrs_mail_martyr_aura:GetEffectAttachType()
 end
 
 function modifier_item_martyrs_mail_martyr_aura:GetTexture()
+  return "custom/martyrs_mail_4"
+end
+
+---------------------------------------------------------------------------------------------------
+
+modifier_item_martyrs_mail_passive_aura_effect = class(ModifierBaseClass)
+
+function modifier_item_martyrs_mail_passive_aura_effect:IsHidden()
+  return false
+end
+
+function modifier_item_martyrs_mail_passive_aura_effect:IsDebuff()
+  return false
+end
+
+function modifier_item_martyrs_mail_passive_aura_effect:IsPurgable()
+  return false
+end
+
+function modifier_item_martyrs_mail_passive_aura_effect:GetPriority()
+  return MODIFIER_PRIORITY_SUPER_ULTRA + 10000
+end
+
+function modifier_item_martyrs_mail_passive_aura_effect:OnCreated()
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.attack_speed = ability:GetSpecialValueFor("aura_attack_speed")
+  end
+end
+
+modifier_item_martyrs_mail_passive_aura_effect.OnRefresh = modifier_item_martyrs_mail_passive_aura_effect.OnCreated
+
+function modifier_item_martyrs_mail_passive_aura_effect:CheckState()
+  local state = {
+    [MODIFIER_STATE_PASSIVES_DISABLED] = false,
+    --[MODIFIER_STATE_FEARED] = false,
+  }
+
+  return state
+end
+
+function modifier_item_martyrs_mail_passive_aura_effect:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT,
+  }
+end
+
+function modifier_item_martyrs_mail_passive_aura_effect:GetModifierAttackSpeedBonus_Constant()
+  return self.attack_speed or self:GetAbility():GetSpecialValueFor("aura_attack_speed")
+end
+
+--function modifier_item_martyrs_mail_passive_aura_effect:GetEffectName()
+	--return "particles/world_shrine/radiant_shrine_active_ray.vpcf"
+--end
+
+--function modifier_item_martyrs_mail_passive_aura_effect:GetEffectAttachType()
+	--return PATTACH_ABSORIGIN_FOLLOW
+--end
+
+function modifier_item_martyrs_mail_passive_aura_effect:GetTexture()
   return "custom/martyrs_mail_4"
 end

--- a/game/scripts/vscripts/items/martyrs_mail.lua
+++ b/game/scripts/vscripts/items/martyrs_mail.lua
@@ -100,6 +100,16 @@ function modifier_item_martyrs_mail_passive_aura:IsPurgable()
   return false
 end
 
+function modifier_item_martyrs_mail_passive_aura:OnCreated()
+  self.aura_radius = 1200
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.aura_radius = ability:GetSpecialValueFor("aura_radius")
+  end
+end
+
+modifier_item_martyrs_mail_passive_aura.OnRefresh = modifier_item_martyrs_mail_passive_aura.OnCreated
+
 function modifier_item_martyrs_mail_passive_aura:IsAura()
   return true
 end
@@ -109,7 +119,7 @@ function modifier_item_martyrs_mail_passive_aura:GetModifierAura()
 end
 
 function modifier_item_martyrs_mail_passive_aura:GetAuraRadius()
-  return self.aura_radius or 1200
+  return self.aura_radius
 end
 
 function modifier_item_martyrs_mail_passive_aura:GetAuraSearchTeam()
@@ -119,18 +129,6 @@ end
 function modifier_item_martyrs_mail_passive_aura:GetAuraSearchType()
   return bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC)
 end
-
-function modifier_item_martyrs_mail_passive_aura:OnCreated()
-  local ability = self:GetAbility()
-  local radius = 1200
-  if ability and not ability:IsNull() then
-    radius = ability:GetSpecialValueFor("aura_radius")
-  end
-
-  self.aura_radius = radius
-end
-
-modifier_item_martyrs_mail_passive_aura.OnRefresh = modifier_item_martyrs_mail_passive_aura.OnCreated
 
 ---------------------------------------------------------------------------------------------------
 
@@ -289,6 +287,7 @@ function modifier_item_martyrs_mail_passive_aura_effect:GetPriority()
 end
 
 function modifier_item_martyrs_mail_passive_aura_effect:OnCreated()
+  self.attack_speed = 100
   local ability = self:GetAbility()
   if ability and not ability:IsNull() then
     self.attack_speed = ability:GetSpecialValueFor("aura_attack_speed")

--- a/game/scripts/vscripts/modifiers/modifier_item_spell_lifesteal_oaa.lua
+++ b/game/scripts/vscripts/modifiers/modifier_item_spell_lifesteal_oaa.lua
@@ -8,6 +8,10 @@ function modifier_item_spell_lifesteal_oaa:IsPurgable()
   return false
 end
 
+function modifier_item_spell_lifesteal_oaa:GetAttributes()
+  return MODIFIER_ATTRIBUTE_MULTIPLE
+end
+
 function modifier_item_spell_lifesteal_oaa:DeclareFunctions()
   local funcs = {
     MODIFIER_EVENT_ON_TAKEDAMAGE,


### PR DESCRIPTION
* Bloodthorn active crit multiplier reduced from 130%/140%/150%/160%/170% to 120%/130%/140%/150%/160%.
* Bloodthorn level 1 recipe cost reduced from 1000 to 800.
* Shiva's Guard bonus armor reduced from 15/17/20/24/29 to 10/12/15/19/24.
* Stoneskin Armor bonus armor reduced from 25/30 to 20/25.
* Stoneskin Armor Stone Form armor increased from 75/90 to 100.
* Martyr's Mail bonus armor reduced from 29 to 24.
* Martyr's Mail now passively provides an aura that gives 100 attack speed.
* Martyr's Mail passive aura also applies Unbreakable (can't be affected by Break).
* A Sacred Skull death vision duration increased from 10 to 30 seconds.
* Spell Lifesteal from items now stacks normally.