### PR TITLE
Offside protection buff

### DIFF
--- a/game/scripts/vscripts/modifiers/modifier_offside.lua
+++ b/game/scripts/vscripts/modifiers/modifier_offside.lua
@@ -94,7 +94,7 @@ function modifier_offside:DrawParticles()
     local stackCount = self:GetStackCount()
     local isInOffside = self:GetParent():HasModifier("modifier_is_in_offside")
 
-    local alpha = (stackCount -10) * 255/15
+    local alpha = (stackCount - 8) * 255/15
 
     if alpha >= 0 and isInOffside then
       if self.BloodOverlay == nil then
@@ -110,12 +110,12 @@ function modifier_offside:DrawParticles()
 
     if self.stackParticle then
       ParticleManager:DestroyParticle(self.stackParticle, false)
+      ParticleManager:ReleaseParticleIndex(self.stackParticle)
     end
     self.stackParticle = ParticleManager:CreateParticleForPlayer( "particles/dungeon_overhead_timer_colored.vpcf", PATTACH_OVERHEAD_FOLLOW, self:GetParent(), self:GetParent():GetPlayerOwner() )
     ParticleManager:SetParticleControl( self.stackParticle, 1, Vector( 0, stackCount, 0 ) )
     ParticleManager:SetParticleControl( self.stackParticle, 2, Vector( 2, 0, 0 ) )
     ParticleManager:SetParticleControl( self.stackParticle, 3, Vector( 255, 50, 0 ) )
-    ParticleManager:ReleaseParticleIndex( self.stackParticle )
   end
 end
 
@@ -149,7 +149,6 @@ function modifier_offside:OnIntervalThink()
     self.stackOffset = 0
   end
 
-  local playerHero = self:GetCaster()
   local h = parent:GetMaxHealth()
   local stackCount = self:GetStackCount()
 
@@ -167,12 +166,13 @@ function modifier_offside:OnIntervalThink()
     team,
     location,
     nil,
-    2000,
+    2500,
     DOTA_UNIT_TARGET_TEAM_ENEMY,
     DOTA_UNIT_TARGET_HERO,
     bit.bor(DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, DOTA_UNIT_TARGET_FLAG_INVULNERABLE, DOTA_UNIT_TARGET_FLAG_OUT_OF_WORLD),
     FIND_ANY_ORDER,
-    false) or nil
+    false
+  )
 
   if #defenders == 0 then
     defenders = nil
@@ -187,13 +187,13 @@ function modifier_offside:OnIntervalThink()
   local damageTable = {
     victim = parent,
     attacker = defenders,
-    damage = (h * ((0.15 * ((stackCount - 10)^2 + 10 * (stackCount - 10)))/100)) / TICKS_PER_SECOND,
+    damage = (h * ((0.15 * ((stackCount - 8)^2 + 10 * (stackCount - 8)))/100)) / TICKS_PER_SECOND,
     damage_type = DAMAGE_TYPE_PURE,
     damage_flags = bit.bor(DOTA_DAMAGE_FLAG_HPLOSS, DOTA_DAMAGE_FLAG_NO_DAMAGE_MULTIPLIERS, DOTA_DAMAGE_FLAG_REFLECTION),
     ability = nil
   }
 
-  if stackCount >= 10 then
+  if stackCount >= 8 then
     return ApplyDamage(damageTable)
   end
 end


### PR DESCRIPTION
* Damage now starts with 8 stacks instead of 10.
* Search radius for offside damage source increased from 2000 to 2500 (to match offside buff search radius).
* Fixed offside protection overhead particle being released too early.