### PR TITLE
Bosses small changes

### DIFF
--- a/game/resource/English/panorama/tips.txt
+++ b/game/resource/English/panorama/tips.txt
@@ -51,7 +51,7 @@
 "dota_tip_beginner_57"          "There are 4 Bounty Rune locations on the map. They spawn at the start of the game, and every 2 minutes."
 
 //INTERMEDIATE PAUSE TIPS
-"dota_tip_intermediate_1"       "First Wanderer (wandering boss) spawns between 12:00 and 15:00."
+"dota_tip_intermediate_1"       "First Wanderer spawns between 12:00 and 15:00."
 "dota_tip_intermediate_3"       "When Bosses are killed, a new higher tier Bosses will spawn at their place. Tier of a Boss can be seen on the minimap - every tier has a specific icon."
 "dota_tip_intermediate_4"       "Neutral creeps start spawning at 00:00, and then at every minute mark thereafter."
 "dota_tip_intermediate_9"       "Items that provide magic resistance will allow you to mitigate magic damage."
@@ -81,7 +81,7 @@
 "dota_tip_intermediate_65"      "Scan will alarm you if enemy heroes are in a targetted location for a brief period. Scan also reveals invisible enemy units and heroes but not wards."
 "dota_tip_intermediate_73"      "Tangoes are twice as effective when used to consume a tree created by an Iron Branch or some spell."
 "dota_tip_intermediate_75"      "Killing Neutral creeps will give a 40%% of the gold bounty to all allied heroes in 1500 radius."
-"dota_tip_intermediate_76"      "The first Wanderer kill will give two tier 2 upgrade cores. The second Wanderer kill will give two tier 3 cores. The third Wanderer kill will one tier 4 core."
+"dota_tip_intermediate_76"      "The first Wanderer kill will give one tier 1 upgrade core and one tier 2 upgrade core. The second Wanderer kill will give one tier 2 core and one tier 3 core. The third Wanderer kill will one tier 4 core."
 
 //ADVANCED PAUSE TIPS
 "dota_tip_advanced_1"           "Every Wanderer kill will give 2 points and a buff for your team (buff provides bonus attack damage and bonus movement speed). This buff doesn't work in Duels."

--- a/game/scripts/vscripts/components/boss/spawn.lua
+++ b/game/scripts/vscripts/components/boss/spawn.lua
@@ -194,14 +194,19 @@ function BossSpawner:SpawnBoss (pit, boss, bossTier, isProtected)
   bossAI.onDeath(function ()
     DebugPrint('Boss has died ' .. pit.killCount .. ' times')
     pit.killCount = pit.killCount + 1
-    -- Increasing the score limit with the first boss kill of the tier
-    --[[
+
     if not BossSpawner.hasKilledTiers[bossTier] then
       BossSpawner.hasKilledTiers[bossTier] = true
-      local scoreLimitIncrease = PlayerResource:SafeGetTeamPlayerCount() * KILL_LIMIT_INCREASE
-      PointsManager:IncreaseLimit(scoreLimitIncrease)
+      -- Notify everyone that a first boss is killed
+      local message = "First tier " .. tostring(bossTier) .. " boss has been slain!"
+      -- Show the message on the screen
+      Notifications:BottomToAll({text = message, duration = 5.0})
+      -- Show the message in chat
+      GameRules:SendCustomMessage(message, 0, 0)
+      -- Increasing the score limit with the first boss kill of the tier
+      --PointsManager:IncreaseLimit()
     end
-    ]]
+
     Timers:CreateTimer(BOSS_RESPAWN_TIMER, function()
       BossSpawner:SpawnBossAtPit(pit, bossTier)
     end)

--- a/game/scripts/vscripts/components/boss/wanderer.lua
+++ b/game/scripts/vscripts/components/boss/wanderer.lua
@@ -77,10 +77,10 @@ function Wanderer:SpawnWanderer ()
 
       -- Give cores and points to the capturing team
       if self.level == 1 then
-        BossAI:RewardBossKill(2, teamId)
+        BossAI:RewardBossKill(1, teamId)
         BossAI:RewardBossKill(2, teamId)
       elseif self.level == 2 then
-        BossAI:RewardBossKill(3, teamId)
+        BossAI:RewardBossKill(2, teamId)
         BossAI:RewardBossKill(3, teamId)
       elseif self.level > 2 then
         BossAI:RewardBossKill(4, teamId)

--- a/game/scripts/vscripts/modifiers/modifier_minimap.lua
+++ b/game/scripts/vscripts/modifiers/modifier_minimap.lua
@@ -61,7 +61,7 @@ if IsServer() then
       -- make sure we only search for neutrals on respawn to avoid performance issues
       if minimap_entity.Respawn then
         self.neutrals = FindUnitsInRadius(teamNumber, origin, nil, 300, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, 0, 0, false)
-		--self.neutrals = FindUnitsInRadius(DOTA_TEAM_NEUTRALS, origin, nil, 300, DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_BASIC, 0, 0, false)
+        --self.neutrals = FindUnitsInRadius(DOTA_TEAM_NEUTRALS, origin, nil, 300, DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_ALL, 0, 0, false)
         if #self.neutrals > 0 then
           minimap_entity.Respawn = false
           self.CampHasBeenKilled = false

--- a/game/scripts/vscripts/modifiers/modifier_minimap.lua
+++ b/game/scripts/vscripts/modifiers/modifier_minimap.lua
@@ -60,8 +60,8 @@ if IsServer() then
       end
       -- make sure we only search for neutrals on respawn to avoid performance issues
       if minimap_entity.Respawn then
-        --self.neutrals = FindUnitsInRadius(teamNumber, origin, nil, 300, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, 0, 0, false)
-		self.neutrals = FindUnitsInRadius(DOTA_TEAM_NEUTRALS, origin, nil, 300, DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_BASIC, 0, 0, false)
+        self.neutrals = FindUnitsInRadius(teamNumber, origin, nil, 300, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, 0, 0, false)
+		--self.neutrals = FindUnitsInRadius(DOTA_TEAM_NEUTRALS, origin, nil, 300, DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_BASIC, 0, 0, false)
         if #self.neutrals > 0 then
           minimap_entity.Respawn = false
           self.CampHasBeenKilled = false
@@ -84,8 +84,8 @@ if IsServer() then
       end
 
       if not hasCreepAlive and self.IsBoss then
-        if not self.DelayedRemoval then
-          self.DelayedRemoval = true
+        if not minimap_entity.DelayedRemoval then
+          minimap_entity.DelayedRemoval = true
           return 10
         else
           if IsValidEntity(minimap_entity) and minimap_entity:IsAlive() then

--- a/game/scripts/vscripts/modifiers/modifier_minimap.lua
+++ b/game/scripts/vscripts/modifiers/modifier_minimap.lua
@@ -84,7 +84,7 @@ if IsServer() then
       end
 
       if not hasCreepAlive and self.IsBoss then
-        if not minimap_entity.DelayedRemoval then
+        if minimap_entity and not minimap_entity.DelayedRemoval then
           minimap_entity.DelayedRemoval = true
           return 10
         else

--- a/game/scripts/vscripts/modifiers/modifier_minimap.lua
+++ b/game/scripts/vscripts/modifiers/modifier_minimap.lua
@@ -60,7 +60,8 @@ if IsServer() then
       end
       -- make sure we only search for neutrals on respawn to avoid performance issues
       if minimap_entity.Respawn then
-        self.neutrals = FindUnitsInRadius(DOTA_TEAM_NEUTRALS, origin, nil, 300, DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_BASIC, 0, 0, false)
+        --self.neutrals = FindUnitsInRadius(teamNumber, origin, nil, 300, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, 0, 0, false)
+		self.neutrals = FindUnitsInRadius(DOTA_TEAM_NEUTRALS, origin, nil, 300, DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_BASIC, 0, 0, false)
         if #self.neutrals > 0 then
           minimap_entity.Respawn = false
           self.CampHasBeenKilled = false


### PR DESCRIPTION
* Boss icon on the minimap will disappear after 10 seconds delay instead of instantly after killing a boss. This will make backdooring bosses easier because capture time is 10 seconds.
* First boss kill of the tier will now display a message. This will warn/remind some players that they should start doing bosses if the enemy team started doing them. Or just a warning that one team has a core advantage.