### PR TITLE
Fixes july 2021

### DIFF
--- a/content/panorama/scripts/custom_game/core_points.js
+++ b/content/panorama/scripts/custom_game/core_points.js
@@ -36,5 +36,5 @@ function OnCorePointsChanged (args) {
 
 (function () {
   GameEvents.Subscribe('core_point_number_changed', OnCorePointsChanged);
-  OnCorePointsChanged({cp:'-'});
+  OnCorePointsChanged({cp: '-'});
 })();

--- a/game/scripts/npc/abilities/broodmother_spawn_spiderlings_oaa.txt
+++ b/game/scripts/npc/abilities/broodmother_spawn_spiderlings_oaa.txt
@@ -31,7 +31,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "spiderling_hp_per_level"                         "50"
+        "spiderling_hp_per_level"                         "20"
       }
       "03"
       {
@@ -69,7 +69,7 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "spiderling_spawn_count"                          "3"
+        "spiderling_spawn_count"                          "1"
       }
       "10"
       {
@@ -85,7 +85,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "giant_spiderling_base_attack_damage"             "40"
+        "giant_spiderling_base_attack_damage"             "30"
         "LinkedSpecialBonus"                              "special_bonus_unique_broodmother_4"
         "CalculateSpellDamageTooltip"                     "0"
       }

--- a/game/scripts/npc/abilities/broodmother_spawn_spiderlings_oaa.txt
+++ b/game/scripts/npc/abilities/broodmother_spawn_spiderlings_oaa.txt
@@ -31,7 +31,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "spiderling_hp_per_level"                         "20"
+        "spiderling_hp_per_level"                         "25"
       }
       "03"
       {
@@ -74,7 +74,7 @@
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "spiderling_max_count"                            "20"
+        "spiderling_max_count"                            "15"
       }
       "11"
       {
@@ -93,6 +93,11 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "giant_spiderling_spawn_count"                    "1"
+      }
+      "14"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "spiderling_spawn_radius"                         "900"
       }
     }
   }

--- a/game/scripts/npc/abilities/broodmother_spin_web.txt
+++ b/game/scripts/npc/abilities/broodmother_spin_web.txt
@@ -45,7 +45,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "heath_regen"                                     "5 10 15 20 30 40" //OAA
+        "heath_regen"                                     "3 7 11 15 30 60" //OAA
       }
       "04"
       {

--- a/game/scripts/npc/units/npc_dota_broodmother_giant_spiderling.txt
+++ b/game/scripts/npc/units/npc_dota_broodmother_giant_spiderling.txt
@@ -37,12 +37,12 @@
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_MELEE_ATTACK"
-    "AttackDamageMin"                                     "40"    // Damage range min.
-    "AttackDamageMax"                                     "40"    // Damage range max.
-    "AttackRate"                                          "0.675"    // Speed of attack.
-    "AttackAnimationPoint"                                "0.5"    // Normalized time in animation cycle to attack.
-    "AttackAcquisitionRange"                              "500"    // Range within a target can be acquired.
-    "AttackRange"                                         "100"    // Range within a target can be attacked.
+    "AttackDamageMin"                                     "30"    // Damage range min.
+    "AttackDamageMax"                                     "30"    // Damage range max.
+    "AttackRate"                                          "1.35"  // Speed of attack.
+    "AttackAnimationPoint"                                "0.5"   // Normalized time in animation cycle to attack.
+    "AttackAcquisitionRange"                              "500"   // Range within a target can be acquired.
+    "AttackRange"                                         "100"   // Range within a target can be attacked.
     "ProjectileModel"                                     ""      // Particle system model for projectile.
     "ProjectileSpeed"                                     ""      // Speed of projectile.
 

--- a/game/scripts/npc/units/npc_dota_broodmother_spiderling.txt
+++ b/game/scripts/npc/units/npc_dota_broodmother_spiderling.txt
@@ -34,7 +34,7 @@
     "AttackCapabilities"          "DOTA_UNIT_CAP_MELEE_ATTACK"
     "AttackDamageMin"             "14"		// Damage range min.
     "AttackDamageMax"             "16"		// Damage range max.
-    "AttackRate"                  "1.35"		// Speed of attack.
+    "AttackRate"                  "1.35"	// Speed of attack.
     "AttackAnimationPoint"        "0.5"		// Normalized time in animation cycle to attack.
     "AttackAcquisitionRange"      "500"		// Range within a target can be acquired.
     "AttackRange"                 "100"		// Range within a target can be attacked.
@@ -60,7 +60,7 @@
 
     // Status
     //----------------------------------------------------------------
-    "StatusHealth"                "320"		// OAA
+    "StatusHealth"                "320"		// Base HP
     "StatusHealthRegen"           "2.0"		// Health regeneration rate.
     "StatusMana"                  "0"			// Base mana.
     "StatusManaRegen"             "0"			// Mana regeneration rate.

--- a/game/scripts/vscripts/abilities/oaa_bristleback.lua
+++ b/game/scripts/vscripts/abilities/oaa_bristleback.lua
@@ -102,7 +102,7 @@ function modifier_bristleback_oaa:GetModifierTotal_ConstantBlock(keys)
 
   -- Do nothing if damage has Reflection flag
   if bit.band(keys.damage_flags, DOTA_DAMAGE_FLAG_REFLECTION) == DOTA_DAMAGE_FLAG_REFLECTION then
-    return
+    return 0
   end
 
   local attacker = keys.attacker

--- a/game/scripts/vscripts/abilities/oaa_broodmother_spawn_spiderlings.lua
+++ b/game/scripts/vscripts/abilities/oaa_broodmother_spawn_spiderlings.lua
@@ -118,6 +118,12 @@ function modifier_broodmother_spawn_spiderlings_oaa:OnDeath(event)
   local summon_duration = ability:GetSpecialValueFor("spiderling_duration")
   local summon_count = ability:GetSpecialValueFor("spiderling_spawn_count")
   local max_count = ability:GetSpecialValueFor("spiderling_max_count")
+  local spawn_radius = ability:GetSpecialValueFor("spiderling_spawn_radius")
+
+  -- Spiderlings can spawn spiderlings only if near Broodmother, otherwise don't continue
+  if killer ~= parent and (killer:GetAbsOrigin() - parent:GetAbsOrigin()):Length2D() > spawn_radius then
+    return
+  end
 
   -- Don't continue if we already reached the max amount of spiders
   if self.spider_counter_oaa >= max_count then
@@ -249,19 +255,58 @@ function modifier_broodmother_giant_spiderling_passive:IsPurgable()
 end
 
 function modifier_broodmother_giant_spiderling_passive:OnCreated()
+  self.bonus_ms = 18
+  self.bonus_hp_regen = 3
+
   if not IsServer() then
     return
   end
-  local ability = spin_web
+
+  local caster = self:GetCaster()
+  local ability = caster:FindAbilityByName("broodmother_spin_web")
   if ability and not ability:IsNull() then
-    self.bonus_ms = 0
+    local ability_level = ability:GetLevel()
+    if ability_level > 0 then
+      self.bonus_ms = ability:GetLevelSpecialValueFor("bonus_movespeed", ability_level-1)
+      self.bonus_hp_regen = ability:GetLevelSpecialValueFor("heath_regen", ability_level-1)
+    end
   end
 
   self:StartIntervalThink(0)
 end
 
+function modifier_broodmother_giant_spiderling_passive:OnRefresh()
+  if not IsServer() then
+    return
+  end
+  local caster = self:GetCaster()
+  local ability = caster:FindAbilityByName("broodmother_spin_web")
+  if not ability or ability:IsNull() then
+    return
+  end
+
+  local ability_level = ability:GetLevel()
+  if ability_level > 0 then
+    self.bonus_ms = ability:GetLevelSpecialValueFor("bonus_movespeed", ability_level-1)
+    self.bonus_hp_regen = ability:GetLevelSpecialValueFor("heath_regen", ability_level-1)
+  end
+end
+
+
 function modifier_broodmother_giant_spiderling_passive:OnIntervalThink()
-  local condition = false
+  if not IsServer() then
+    return
+  end
+  local caster = self:GetCaster()
+  local ability = caster:FindAbilityByName("broodmother_spin_web")
+  if not ability or ability:IsNull() then
+    return
+  end
+  local web_radius = ability:GetSpecialValueFor("radius")
+  local origin = self:GetParent():GetAbsOrigin()
+  local webs = Entities:FindAllByClassnameWithin("npc_dota_broodmother_web", origin, web_radius)
+  local condition = #webs > 0
+  -- If parent is near a web, apply web buffs
   if condition then
     self:SetStackCount(1)
   else
@@ -272,6 +317,7 @@ end
 function modifier_broodmother_giant_spiderling_passive:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE,
+    MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT,
     --MODIFIER_PROPERTY_IGNORE_MOVESPEED_LIMIT,
   }
 end
@@ -280,6 +326,16 @@ function modifier_broodmother_giant_spiderling_passive:GetModifierMoveSpeedBonus
   if self:GetStackCount() == 1 then
     return self.bonus_ms
   end
+
+  return 0
+end
+
+function modifier_broodmother_giant_spiderling_passive:GetModifierConstantHealthRegen()
+	if self:GetStackCount() == 1 then
+    return self.bonus_hp_regen
+  end
+
+  return 0
 end
 
 -- function modifier_broodmother_giant_spiderling_passive:GetModifierIgnoreMovespeedLimit()

--- a/game/scripts/vscripts/abilities/oaa_broodmother_spawn_spiderlings.lua
+++ b/game/scripts/vscripts/abilities/oaa_broodmother_spawn_spiderlings.lua
@@ -248,25 +248,54 @@ function modifier_broodmother_giant_spiderling_passive:IsPurgable()
   return false
 end
 
+function modifier_broodmother_giant_spiderling_passive:OnCreated()
+  if not IsServer() then
+    return
+  end
+  local ability = spin_web
+  if ability and not ability:IsNull() then
+    self.bonus_ms = 0
+  end
+
+  self:StartIntervalThink(0)
+end
+
+function modifier_broodmother_giant_spiderling_passive:OnIntervalThink()
+  local condition = false
+  if condition then
+    self:SetStackCount(1)
+  else
+    self:SetStackCount(2)
+  end
+end
+
 function modifier_broodmother_giant_spiderling_passive:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE,
-    MODIFIER_PROPERTY_IGNORE_MOVESPEED_LIMIT,
+    --MODIFIER_PROPERTY_IGNORE_MOVESPEED_LIMIT,
   }
 end
 
 function modifier_broodmother_giant_spiderling_passive:GetModifierMoveSpeedBonus_Percentage()
-  return 110
+  if self:GetStackCount() == 1 then
+    return self.bonus_ms
+  end
 end
 
-function modifier_broodmother_giant_spiderling_passive:GetModifierIgnoreMovespeedLimit()
-  return 1
-end
+-- function modifier_broodmother_giant_spiderling_passive:GetModifierIgnoreMovespeedLimit()
+  -- if self:GetStackCount() == 1 then
+    -- return 1
+  -- end
+-- end
 
 function modifier_broodmother_giant_spiderling_passive:CheckState()
-  local state = {
-    [MODIFIER_STATE_FLYING_FOR_PATHING_PURPOSES_ONLY] = true,
-    [MODIFIER_STATE_NO_UNIT_COLLISION] = true,
-  }
-  return state
+  if self:GetStackCount() == 1 then
+    local state = {
+      [MODIFIER_STATE_FLYING_FOR_PATHING_PURPOSES_ONLY] = true,
+      [MODIFIER_STATE_NO_UNIT_COLLISION] = true,
+    }
+    return state
+  else
+    return {}
+  end
 end

--- a/game/scripts/vscripts/components/cave/protection.lua
+++ b/game/scripts/vscripts/components/cave/protection.lua
@@ -71,7 +71,7 @@ function ProtectionAura:Init ()
 end
 
 function ProtectionAura:IsInEnemyZone(teamID, entity)
-  for roomID = 0,MAX_ROOMS do
+  for roomID = 0, MAX_ROOMS do
     if ProtectionAura:IsInSpecificZone(teamID, roomID, entity) then
       return true
     end
@@ -125,6 +125,8 @@ function ProtectionAura:EndTouch(event)
 
   -- Remove offside thinker if activator is not in offside
   if (team == DOTA_TEAM_GOODGUYS and not IsLocationInDireOffside(origin)) or (team == DOTA_TEAM_BADGUYS and not IsLocationInRadiantOffside(origin)) then
-    activator:RemoveModifierByName("modifier_is_in_offside")
+    if activator:HasModifier("modifier_is_in_offside") then
+      activator:RemoveModifierByName("modifier_is_in_offside")
+    end
   end
 end

--- a/game/scripts/vscripts/components/corepoints/core_points.lua
+++ b/game/scripts/vscripts/components/corepoints/core_points.lua
@@ -433,7 +433,7 @@ end
 modifier_core_points_counter_oaa = class({})
 
 function modifier_core_points_counter_oaa:IsHidden()
-  return false
+  return not IsInToolsMode()
 end
 
 function modifier_core_points_counter_oaa:IsPurgable()
@@ -442,6 +442,13 @@ end
 
 function modifier_core_points_counter_oaa:RemoveOnDeath()
   return false
+end
+
+function modifier_core_points_counter_oaa:OnCreated()
+  if IsServer() then
+    local count = CorePointsManager.playerID_table[UnitVarToPlayerID(self:GetParent())] or 0
+    self:SetStackCount(count)
+  end
 end
 
 -- function modifier_core_points_counter_oaa:OnStackCountChanged(old_stacks)

--- a/game/scripts/vscripts/items/neutral/dragon_scale.lua
+++ b/game/scripts/vscripts/items/neutral/dragon_scale.lua
@@ -86,6 +86,21 @@ function modifier_item_dragon_scale_oaa_passive:OnTakeDamage(event)
     return
   end
 
+  -- Don't trigger on self damage or on damage originating from allies
+  if attacker == parent or attacker:GetTeamNumber() == parent:GetTeamNumber() then
+    return
+  end
+
+  -- Don't trigger if attacker is dead, invulnerable or banished
+  if not attacker:IsAlive() or attacker:IsInvulnerable() or attacker:IsOutOfGame() then
+    return
+  end
+
+  -- Don't trigger on buildings, towers and wards
+  if attacker:IsBuilding() or attacker:IsTower() or attacker:IsOther() then
+    return
+  end
+
   if not ability:IsCooldownReady() then
     return
   end

--- a/game/scripts/vscripts/modifiers/sparks/modifier_spark_power.lua
+++ b/game/scripts/vscripts/modifiers/sparks/modifier_spark_power.lua
@@ -188,6 +188,10 @@ function modifier_spark_power:OnStackCountChanged(old_stacks)
   if parent:IsIllusion() then
     return
   end
+  
+  if old_stacks == self:GetStackCount() then
+    return
+  end
 
   parent.power_spark_bonus = self:GetStackCount()
 

--- a/game/scripts/vscripts/modifiers/sparks/modifier_spark_power.lua
+++ b/game/scripts/vscripts/modifiers/sparks/modifier_spark_power.lua
@@ -81,6 +81,10 @@ function modifier_spark_power:OnCreated()
     return
   end
 
+  -- Initialize with 0
+  parent.power_spark_bonus = 0
+  self:SetStackCount(0)
+
   if IsServer() then
     -- Current damage values
     local base_damage_max = parent:GetBaseDamageMax()
@@ -106,10 +110,9 @@ function modifier_spark_power:OnCreated()
 
     -- Bonus damage/block formula
     local bonus = math.ceil(3188/61 + (4166 * current_average_base_damage - 7312 * starting_average_base_damage)/8723)
+    -- Change stack count
     self:SetStackCount(bonus)
   end
-
-  parent.power_spark_bonus = self:GetStackCount()
 
   self:StartIntervalThink(0.3)
 
@@ -130,6 +133,16 @@ function modifier_spark_power:OnCreated()
     end
   end
   ]]
+end
+
+function modifier_spark_power:OnRefresh()
+  local parent = self:GetParent()
+
+  if parent:IsIllusion() then
+    return
+  end
+
+  --parent.power_spark_bonus = self:GetStackCount()
 end
 
 function modifier_spark_power:OnIntervalThink()
@@ -166,7 +179,20 @@ function modifier_spark_power:OnIntervalThink()
     self:SetStackCount(bonus)
   end
 
+  --parent.power_spark_bonus = self:GetStackCount()
+end
+
+function modifier_spark_power:OnStackCountChanged(old_stacks)
+  local parent = self:GetParent()
+
+  if parent:IsIllusion() then
+    return
+  end
+
   parent.power_spark_bonus = self:GetStackCount()
+
+  -- This will refresh the stacks and maybe refresh the aura too
+  self:ForceRefresh()
 end
 
 function modifier_spark_power:OnTooltip()


### PR DESCRIPTION
* Broodmother spiderling hp bonus per broodmother level reduced from 50 to 25.
* Broodmother spiderling spawn count from creep kill reduced from 3 to 1.
* Broodmother giant spiderling base attack damage reduced from 40 to 30.
* Broodmother giant spiderling base attack time increased from 0.675 to 1.35
* Broodmother Spin Web bonus hp regen reduced from 5/10/15/20/30/40 to 3/7/11/15/30/60.
* Broodmother Spawn Spiderling max spider count reduced from 20 to 15.
* Spiderlings can no longer spawn more spiderlings when killing creeps if not within 900 radius of Broodmother.
* Spin Web bonuses are now applied to giant spiderlings only when giant spiderlings are on the web.
* Fixed Dragon Scale triggering on self-damage, damage from allies, damage from invulnerable enemies, and damage from wards.
* Fixed Power Spark not showing the correct damage value in the buff. Forcing Power Spark aura to refresh every time hero's stats change.
* Hopefully fixed offside protection this time.
* Made core points modifier hidden.