### PR TITLE
Spiked Mail update

### DIFF
--- a/game/resource/English/ability/items/tooltip_spiked_mail.txt
+++ b/game/resource/English/ability/items/tooltip_spiked_mail.txt
@@ -3,10 +3,10 @@
 //==========================================================================
 "DOTA_Tooltip_Ability_item_spiked_mail_1"                                "Spiked Mail"
 "DOTA_Tooltip_Ability_item_recipe_spiked_mail_1"                         "Spiked Mail Recipe"
-"DOTA_Tooltip_Ability_item_spiked_mail_1_Description"                    "<h1>Active: Spiked Protection</h1>For %duration% seconds, returns %active_reflection_pct%%% of the damage taken back to the unit that dealt the damage as Pure damage.\n<h1>Passive: Damage Return</h1>Returns %passive_reflection_pct%%% of the damage taken back to the unit that dealt the damage."
+"DOTA_Tooltip_Ability_item_spiked_mail_1_Description"                    "<h1>Active: Spiked</h1>For %duration% seconds, returns %active_reflection_pct%%% of the damage taken back to the unit that dealt the damage.\n<h1>Passive: Damage Return</h1>Returns %passive_reflection_pct%%% of the damage taken back to the unit that dealt the damage."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_Lore"                           "Mail made from Zealot Scarab's carapace."
-"DOTA_Tooltip_Ability_item_spiked_mail_1_Note0"                          "Spiked Protection damage is Pure and calculated before reductions. Damage Return damage type is the same as it was received."
-"DOTA_Tooltip_Ability_item_spiked_mail_1_Note1"                          "Spiked Protection and Damage Return both pierce Spell Immunity."
+"DOTA_Tooltip_Ability_item_spiked_mail_1_Note0"                          "Damage is calculated before reductions and amplifications. Damage type is the same as it was received."
+"DOTA_Tooltip_Ability_item_spiked_mail_1_Note1"                          "Spiked and Damage Return both pierce Spell Immunity."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_Note2"                          "Shares cooldown with Blade Mail."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_bonus_damage"                   "+$damage"
 "DOTA_Tooltip_Ability_item_spiked_mail_1_bonus_armor"                    "+$armor"
@@ -57,4 +57,4 @@
 "DOTA_Tooltip_Ability_item_spiked_mail_5_bonus_intellect"                "#{DOTA_Tooltip_Ability_item_spiked_mail_1_bonus_intellect}"
 
 "DOTA_Tooltip_modifier_item_spiked_mail_active_return"                   "#{DOTA_Tooltip_Ability_item_spiked_mail_1}"
-"DOTA_Tooltip_modifier_item_spiked_mail_active_return_Description"       "Returns 80%% of the damage taken before reductions as Pure damage."
+"DOTA_Tooltip_modifier_item_spiked_mail_active_return_Description"       "Returns a percent of the damage taken back to the damage dealer."

--- a/game/resource/English/ability/items/tooltip_spiked_mail.txt
+++ b/game/resource/English/ability/items/tooltip_spiked_mail.txt
@@ -3,7 +3,7 @@
 //==========================================================================
 "DOTA_Tooltip_Ability_item_spiked_mail_1"                                "Spiked Mail"
 "DOTA_Tooltip_Ability_item_recipe_spiked_mail_1"                         "Spiked Mail Recipe"
-"DOTA_Tooltip_Ability_item_spiked_mail_1_Description"                    "<h1>Active: Spiked</h1>For %duration% seconds, returns %active_reflection_pct%%% of the damage taken back to the unit that dealt the damage.\n<h1>Passive: Damage Return</h1>Returns %passive_reflection_pct%%% of the damage taken back to the unit that dealt the damage."
+"DOTA_Tooltip_Ability_item_spiked_mail_1_Description"                    "<h1>Active: Spiked</h1>For %duration% seconds, returns %active_reflection_pct%%% of the damage taken back to the unit that dealt the damage.\n<h1>Passive: Damage Return</h1>Every time you are damaged, you return %passive_reflection_pct%%% of the damage taken back to the unit that dealt the damage."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_Lore"                           "Mail made from Zealot Scarab's carapace."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_Note0"                          "Damage is calculated before reductions and amplifications. Damage type is the same as it was received."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_Note1"                          "Spiked and Damage Return both pierce Spell Immunity."

--- a/game/scripts/npc/items/custom/item_spiked_mail_1.txt
+++ b/game/scripts/npc/items/custom/item_spiked_mail_1.txt
@@ -46,7 +46,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "25.0"
     "AbilitySharedCooldown"                               "blademail"
-    "AbilityManaCost"                                     "100"
+    "AbilityManaCost"                                     "25"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------
@@ -97,7 +97,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_reflection_pct"                           "80"
+        "active_reflection_pct"                           "80 85 90 95 100"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_spiked_mail_2.txt
+++ b/game/scripts/npc/items/custom/item_spiked_mail_2.txt
@@ -47,7 +47,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "25.0"
     "AbilitySharedCooldown"                               "blademail"
-    "AbilityManaCost"                                     "100"
+    "AbilityManaCost"                                     "25"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------
@@ -98,7 +98,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_reflection_pct"                           "80"
+        "active_reflection_pct"                           "80 85 90 95 100"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_spiked_mail_3.txt
+++ b/game/scripts/npc/items/custom/item_spiked_mail_3.txt
@@ -47,7 +47,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "25.0"
     "AbilitySharedCooldown"                               "blademail"
-    "AbilityManaCost"                                     "100"
+    "AbilityManaCost"                                     "25"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------
@@ -98,7 +98,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_reflection_pct"                           "80"
+        "active_reflection_pct"                           "80 85 90 95 100"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_spiked_mail_4.txt
+++ b/game/scripts/npc/items/custom/item_spiked_mail_4.txt
@@ -47,7 +47,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "25.0"
     "AbilitySharedCooldown"                               "blademail"
-    "AbilityManaCost"                                     "100"
+    "AbilityManaCost"                                     "25"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------
@@ -98,7 +98,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_reflection_pct"                           "80"
+        "active_reflection_pct"                           "80 85 90 95 100"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_spiked_mail_5.txt
+++ b/game/scripts/npc/items/custom/item_spiked_mail_5.txt
@@ -48,7 +48,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "25.0"
     "AbilitySharedCooldown"                               "blademail"
-    "AbilityManaCost"                                     "100"
+    "AbilityManaCost"                                     "25"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------
@@ -98,7 +98,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_reflection_pct"                           "80"
+        "active_reflection_pct"                           "80 85 90 95 100"
       }
     }
   }


### PR DESCRIPTION
* Returned damage from both components is now the same damage type as the original/received damage.
* Spiked return damage now scales with levels: 80/85/90/95/100%
* Spiked return damage now stacks with passive damage return of Spiked Mail. While Spiked Mail is active damage returned is: 100/105/110/115/120%. (2 damage instances)
* Spiked Mail mana cost reduced from 100 to 25.
* Fixed Blade Mail passive stacking with Spiked Mail passive and active. Now only 20 constant damage from Blade Mail's passive stacks.
* Fixed Veil of Discord debuff amplifying damage from Spiked Mail (both passive and active).