### PR TITLE
Blade of Judecca update

### DIFF
--- a/game/resource/English/ability/items/tooltip_trumps_fist.txt
+++ b/game/resource/English/ability/items/tooltip_trumps_fist.txt
@@ -3,9 +3,9 @@
 //===============================================================================
 "DOTA_Tooltip_Ability_item_trumps_fists"                                    "Blade of Judecca"
 "DOTA_Tooltip_Ability_item_recipe_trumps_fists"                             "Blade of Judecca Recipe"
-"DOTA_Tooltip_Ability_item_trumps_fists_Description"                        "<h1>Passive: Frostburn</h1> Your attacks apply a debuff that deals damage to the affected enemy every time they gain health. Damage is equal to %heal_prevent_percent%%% of the gained health. Debuff lasts for %heal_prevent_duration% seconds."//<br><br>The heal reduction decays linearly with the duration."
+"DOTA_Tooltip_Ability_item_trumps_fists_Description"                        "<h1>Passive: Frostburn</h1> Your attacks and spells apply a debuff that deals damage to the affected enemy every time they gain health. Damage is equal to %heal_prevent_percent%%% of the gained health. Debuff lasts for %heal_prevent_duration% seconds."//<br><br>The heal reduction decays linearly with the duration."
 "DOTA_Tooltip_Ability_item_trumps_fists_Lore"                               "The ancient frozen hatred within this sacred blade has the power to cease bloodflow to the extremities of its victims."
-"DOTA_Tooltip_Ability_item_trumps_fists_Note0"                              "Frostburn is not reducing healing, health regen and lifesteal, its just applying damage based on gained health."
+"DOTA_Tooltip_Ability_item_trumps_fists_Note0"                              "Frostburn is not reducing healing, health regen and lifesteal, its just applying damage based on gained health. This also means that it doesn't stack with Eye of Skadi and Shiva's Guard."
 "DOTA_Tooltip_Ability_item_trumps_fists_Note1"                              "Frostburn pierces spell immunity and its not dispellable."
 "DOTA_Tooltip_Ability_item_trumps_fists_Note2"                              "Frostburn duration is not affected by status resistance."
 //"DOTA_Tooltip_Ability_item_trumps_fists_bonus_damage"                       "+$damage"

--- a/game/scripts/npc/items/custom/item_trumps_fists.txt
+++ b/game/scripts/npc/items/custom/item_trumps_fists.txt
@@ -83,7 +83,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "heal_prevent_percent"                            "100"
+        "heal_prevent_percent"                            "75"
       }
       "06"
       {

--- a/game/scripts/npc/items/custom/item_trumps_fists_2.txt
+++ b/game/scripts/npc/items/custom/item_trumps_fists_2.txt
@@ -83,7 +83,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "heal_prevent_percent"                            "100"
+        "heal_prevent_percent"                            "75"
       }
       "06"
       {


### PR DESCRIPTION
* Frostburn damage reduced from 100% to 75% of the affected hero's gained health through regen, heals, lifesteal etc.
* Blade of Judecca now works with spells - spell damage now also applies Frostburn debuff.