### PR TITLE
Blade of Judecca another update

### DIFF
--- a/game/resource/English/ability/items/tooltip_trumps_fist.txt
+++ b/game/resource/English/ability/items/tooltip_trumps_fist.txt
@@ -3,10 +3,10 @@
 //===============================================================================
 "DOTA_Tooltip_Ability_item_trumps_fists"                                    "Blade of Judecca"
 "DOTA_Tooltip_Ability_item_recipe_trumps_fists"                             "Blade of Judecca Recipe"
-"DOTA_Tooltip_Ability_item_trumps_fists_Description"                        "<h1>Passive: Frostburn</h1> Your attacks and spells apply a debuff that deals damage to the affected enemy every time they gain health. Damage is equal to %heal_prevent_percent%%% of the gained health. Debuff lasts for %heal_prevent_duration% seconds."//<br><br>The heal reduction decays linearly with the duration."
+"DOTA_Tooltip_Ability_item_trumps_fists_Description"                        "<h1>Passive: Frostburn</h1> Your attacks and spells apply a debuff that deals magic damage to the affected enemy every time they gain health. Damage is equal to %heal_prevent_percent%%% of the gained health. Debuff lasts for %heal_prevent_duration% seconds."//<br><br>The heal reduction decays linearly with the duration."
 "DOTA_Tooltip_Ability_item_trumps_fists_Lore"                               "The ancient frozen hatred within this sacred blade has the power to cease bloodflow to the extremities of its victims."
-"DOTA_Tooltip_Ability_item_trumps_fists_Note0"                              "Frostburn is not reducing healing, health regen and lifesteal, its just applying damage based on gained health. This also means that it doesn't stack with Eye of Skadi and Shiva's Guard."
-"DOTA_Tooltip_Ability_item_trumps_fists_Note1"                              "Frostburn pierces spell immunity and its not dispellable."
+"DOTA_Tooltip_Ability_item_trumps_fists_Note0"                              "Frostburn is not reducing healing, health regen and lifesteal, it's applying magic damage based on gained health. This also means that it doesn't stack with Eye of Skadi and Shiva's Guard."
+"DOTA_Tooltip_Ability_item_trumps_fists_Note1"                              "Frostburn pierces spell immunity and it's not dispellable."
 "DOTA_Tooltip_Ability_item_trumps_fists_Note2"                              "Frostburn duration is not affected by status resistance."
 //"DOTA_Tooltip_Ability_item_trumps_fists_bonus_damage"                       "+$damage"
 "DOTA_Tooltip_Ability_item_trumps_fists_bonus_all_stats"                    "+$all"

--- a/game/scripts/vscripts/items/trumps_fists.lua
+++ b/game/scripts/vscripts/items/trumps_fists.lua
@@ -143,15 +143,20 @@ function modifier_item_trumps_fists_passive:OnTakeDamage(event)
     return
   end
 
-  -- If inflictor is this item, don't continue
+  -- If inflictor is this item or any other item (radiance e.g.), don't continue
   if inflictor then
-    if inflictor == ability or inflictor:GetAbilityName() == ability:GetAbilityName() then
+    if inflictor == ability or inflictor:GetAbilityName() == ability:GetAbilityName() or inflictor:IsItem() then
       return
     end
   end
 
   -- Ignore damage that has the no-reflect flag
   if bit.band(event.damage_flags, DOTA_DAMAGE_FLAG_REFLECTION) > 0 then
+    return
+  end
+
+  -- Ignore damage that has hp removal flag
+  if bit.band(event.damage_flags, DOTA_DAMAGE_FLAG_HPLOSS) > 0 then
     return
   end
 
@@ -222,7 +227,8 @@ function modifier_item_trumps_fists_frostbite:OnHealthGained( kv )
           victim = unit,
           attacker = caster,
           damage = damage,
-          damage_type = DAMAGE_TYPE_PURE,
+          damage_type = DAMAGE_TYPE_MAGICAL,
+          damage_flags = DOTA_DAMAGE_FLAG_NO_SPELL_LIFESTEAL,
           ability = self:GetAbility()
         }
         ApplyDamage(damage_table)


### PR DESCRIPTION
* Blade of Judecca changed damage type from Pure to Magical.
* Blade of Judecca damage can no longer spell lifesteal. (It's still affected by spell amp.)
* Blade of Judecca debuff cannot be applied with item damage anymore.
* Blade of Judecca debuff can no longer be applied with damage that has HP removal flag (Heartstopper Aura for example).

All you need to know: 
1) Rightclick-damage heroes without -magic resist or spell amp are better with Eye of Skadi. 
2) Casters and rightclick heroes with -magic resist or spell amp (Viper for example) are better with Judecca.
3) Judecca damage can now be mitigated with magic resistance and magic block.
4) Blademail and Spiked Mail actually return Judecca damage now without spell-lifesteal bs.
5) Radiance, Dagon, Spirit Vessel etc. no longer apply Judecca debuff.