### PR TITLE
Mini Roshans small rework

### DIFF
--- a/game/resource/English/ability/units/tooltip_mini_rosh_abilities.txt
+++ b/game/resource/English/ability/units/tooltip_mini_rosh_abilities.txt
@@ -1,0 +1,21 @@
+"DOTA_Tooltip_Ability_mini_rosh_passives"                                       "Tenacity"
+"DOTA_Tooltip_Ability_mini_rosh_passives_Description"                           "This creature has bonus status resistance, bonus armor aura, and it will block one targeted spell every 15 seconds."
+"DOTA_Tooltip_Ability_mini_rosh_passives_Note0"                                 "Spell Block doesn't work if dominated but it works on Doom. Spell Block can be disabled with Break."
+"DOTA_Tooltip_Ability_mini_rosh_passives_Note1"                                 "Aura is not bestowed when the aura source is on the neutral team. Aura can be disabled with Break."
+"DOTA_Tooltip_Ability_mini_rosh_passives_Note2"                                 "Bonus status resist doesn't work on Doom."
+"DOTA_Tooltip_Ability_mini_rosh_passives_bonus_status_resistance"               "#BONUS STATUS RESIST:"
+"DOTA_Tooltip_Ability_mini_rosh_passives_aura_bonus_armor"                      "AURA BONUS ARMOR:"
+"DOTA_Tooltip_Ability_mini_rosh_passives_aura_radius"                           "AURA RADIUS:"
+
+"DOTA_Tooltip_Ability_mini_rosh_root"                                           "Root"
+"DOTA_Tooltip_Ability_mini_rosh_root_Description"                               "This creature has a chance to root and deal bonus damage on attack. Goes on cooldown when it procs."
+"DOTA_Tooltip_Ability_mini_rosh_root_root_chance"                               "%ROOT CHANCE:"
+"DOTA_Tooltip_Ability_mini_rosh_root_bonus_damage"                              "BONUS DAMAGE:"
+"DOTA_Tooltip_Ability_mini_rosh_root_root_duration"                             "ROOT DURATION:"
+
+"DOTA_Tooltip_modifier_mini_rosh_aura_effect"                                   "Tenacity Aura"
+"DOTA_Tooltip_modifier_mini_rosh_aura_effect_Description"                       "Armor increased by %dMODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS%."
+
+"DOTA_Tooltip_modifier_mini_rosh_root_effect"                                   "Rooted"
+"DOTA_Tooltip_modifier_mini_rosh_root_effect_Description"                       "Cannot move, use blink or reposition abilities."
+

--- a/game/scripts/npc/abilities/neutrals/mini_rosh_passives.txt
+++ b/game/scripts/npc/abilities/neutrals/mini_rosh_passives.txt
@@ -1,0 +1,40 @@
+"DOTAAbilities"
+{
+  //=================================================================================================================
+  // Unit Name: Mini Rosh Passives - Spell Block, Free Pathing, True Sight, Status Resistance
+  //=================================================================================================================
+  "mini_rosh_passives"
+  {
+    "ID"                                                  "3594"
+    "BaseClass"                                           "ability_lua"
+    "ScriptFile"                                          "abilities/neutrals/oaa_mini_rosh_passives.lua"
+    "AbilityTextureName"                                  "roshan_spell_block"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+    "SpellDispellableType"                                "SPELL_DISPELLABLE_NO"
+
+    "MaxLevel"                                            "1"
+
+    "AbilityCooldown"                                     "15"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_status_resistance"                         "35"
+      }
+      "02"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "aura_bonus_armor"                                "5"
+      }
+      "03"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "aura_radius"                                     "1200"
+      }
+    }
+  }
+}

--- a/game/scripts/npc/abilities/neutrals/mini_rosh_root.txt
+++ b/game/scripts/npc/abilities/neutrals/mini_rosh_root.txt
@@ -1,0 +1,44 @@
+"DOTAAbilities"
+{
+  //=================================================================================================================
+  // Unit Name: Root
+  //=================================================================================================================
+  "mini_rosh_root"
+  {
+    "ID"                                                  "3595"
+    "BaseClass"                                           "ability_lua"
+    "ScriptFile"                                          "abilities/neutrals/oaa_mini_rosh_root.lua"
+    "AbilityTextureName"                                  "roshan_bash"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+    "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
+    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+    "AbilityUnitDamageType"                               "DAMAGE_TYPE_MAGICAL"
+    "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_YES"
+    "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
+
+    "MaxLevel"                                            "1"
+
+    "AbilityCooldown"                                     "2.0"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "root_chance"                                     "25"
+      }
+      "02"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_damage"                                    "50"
+      }
+      "03"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "root_duration"                                   "1.65"
+      }
+    }
+  }
+}

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -189,6 +189,9 @@
 #base "abilities/neutrals/alpha_wolf_invisibility_oaa.txt"
 #base "abilities/neutrals/alpha_wolf_critical_strike_aura_oaa.txt"
 
+#base "abilities/neutrals/mini_rosh_root.txt"
+#base "abilities/neutrals/mini_rosh_passives.txt"
+
 #base "abilities/misc/out_of_game.txt"
 #base "abilities/misc/environment_passive.txt"
 #base "abilities/misc/bottle_selection.txt"

--- a/game/scripts/npc/units/neutrals/npc_dota_mini_roshan.txt
+++ b/game/scripts/npc/units/neutrals/npc_dota_mini_roshan.txt
@@ -8,7 +8,7 @@
     "Model"                                               "models/creeps/roshan/roshan.vmdl"  // Model.
     "SoundSet"                                            "n_creep_Ranged"
     "ModelScale"                                          "0.25"
-    "Level"                                               "30"
+    "Level"                                               "6"
     "IsAncient"                                           "1"
     "ConsideredHero"                                      "0"
     "IsNeutralUnitType"                                   "1"
@@ -16,23 +16,20 @@
 
     // Abilities
     //----------------------------------------------------------------
-    "Ability1"                                            "roshan_spell_block"		// Ability 1.
-    "Ability2"                                            "roshan_bash"			// Ability 2.
-    "Ability3"                                            "roshan_slam"			// Ability 3.
-    "Ability4"                                            "boss_cliffwalk"		// Ability 4.
-    "Ability5"                                            "necronomicon_warrior_sight"		// Ability 5
+    "Ability1"                                            "mini_rosh_root"          // Ability 1.
+    "Ability2"                                            "mini_rosh_passives"      // Ability 2.
 
     // Armor
     //----------------------------------------------------------------
     "ArmorPhysical"                                       "15.0"      // Physical protection.
-    "MagicalResistance"                                   "55"                  // Magical protection (percentage).
+    "MagicalResistance"                                   "50"                  // Magical protection (percentage).
 
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_MELEE_ATTACK"
     "AttackDamageMin"                                     "65"    // Damage range min.
     "AttackDamageMax"                                     "65"    // Damage range max.
-    "AttackRate"                                          "2.5"     // Speed of attack.
+    "AttackRate"                                          "1.7"     // Speed of attack.
     "AttackAnimationPoint"                                "0.6"    // Normalized time in animation cycle to attack.
     "AttackAcquisitionRange"                              "300"    // Range within a target can be acquired.
     "AttackRange"                                         "150"    // Range within a target can be attacked.
@@ -61,8 +58,8 @@
     //----------------------------------------------------------------
     "StatusHealth"                                        "5500"    // Base health.
     "StatusHealthRegen"                                   "20"    // Health regeneration rate.
-    "StatusMana"                                          "300"    // Base mana.
-    "StatusManaRegen"                                     "1"    // Mana regeneration rate.
+    "StatusMana"                                          "0"    // Base mana.
+    "StatusManaRegen"                                     "0"    // Mana regeneration rate.
 
     // Team
     //----------------------------------------------------------------

--- a/game/scripts/vscripts/abilities/neutrals/oaa_mini_rosh_passives.lua
+++ b/game/scripts/vscripts/abilities/neutrals/oaa_mini_rosh_passives.lua
@@ -1,0 +1,172 @@
+mini_rosh_passives = class(AbilityBaseClass)
+
+LinkLuaModifier("modifier_mini_rosh_passives", "abilities/neutrals/oaa_mini_rosh_passives.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_mini_rosh_aura_effect", "abilities/neutrals/oaa_mini_rosh_passives.lua", LUA_MODIFIER_MOTION_NONE)
+
+function mini_rosh_passives:GetIntrinsicModifierName()
+  return "modifier_mini_rosh_passives"
+end
+
+function mini_rosh_passives:ShouldUseResources()
+  return true
+end
+
+--------------------------------------------------------------------------------
+
+modifier_mini_rosh_passives = class(ModifierBaseClass)
+
+function modifier_mini_rosh_passives:IsHidden()
+  return true
+end
+
+function modifier_mini_rosh_passives:IsDebuff()
+  return false
+end
+
+function modifier_mini_rosh_passives:IsPurgable()
+  return false
+end
+
+function modifier_mini_rosh_passives:IsAura()
+  local parent = self:GetParent()
+  if parent:PassivesDisabled() then
+    return false
+  end
+  return true
+end
+
+function modifier_mini_rosh_passives:GetModifierAura()
+  return "modifier_mini_rosh_aura_effect"
+end
+
+function modifier_mini_rosh_passives:GetAuraRadius()
+  return self:GetAbility():GetSpecialValueFor("aura_radius")
+end
+
+function modifier_mini_rosh_passives:GetAuraSearchTeam()
+  return DOTA_UNIT_TARGET_TEAM_FRIENDLY
+end
+
+function modifier_mini_rosh_passives:GetAuraSearchType()
+  return bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC)
+end
+
+function modifier_mini_rosh_passives:GetAuraSearchFlags()
+  return DOTA_UNIT_TARGET_FLAG_NOT_ILLUSIONS
+end
+
+function modifier_mini_rosh_passives:GetAuraEntityReject(hEntity)
+  local caster = self:GetCaster()
+  -- Dont provide the aura effect to allies when caster (owner of this aura) cannot be controlled
+  if hEntity ~= caster and not caster:IsControllableByAnyPlayer() then
+    return true
+  end
+  return false
+end
+
+function modifier_mini_rosh_passives:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_STATUS_RESISTANCE_STACKING,
+    MODIFIER_PROPERTY_ABSORB_SPELL,
+  }
+end
+
+function modifier_mini_rosh_passives:CheckState()
+  local parent = self:GetParent()
+  local state = {}
+  if not parent:IsControllableByAnyPlayer() then
+    state = {
+      [MODIFIER_STATE_FLYING_FOR_PATHING_PURPOSES_ONLY] = true,
+      [MODIFIER_STATE_NO_UNIT_COLLISION] = true,
+    }
+  end
+  return state
+end
+
+function modifier_mini_rosh_passives:GetModifierStatusResistanceStacking()
+  if not self:GetParent():IsHero() then
+    return self:GetAbility():GetSpecialValueFor("bonus_status_resistance")
+  else
+    return 0
+  end
+end
+
+function modifier_mini_rosh_passives:GetAbsorbSpell(event)
+  if not IsServer() then
+    return
+  end
+
+  local parent = self:GetParent()
+  local ability = self:GetAbility()
+
+  if not ability or ability:IsNull() then
+    return
+  end
+
+  -- No need to dodge if parent is invulnerable
+  if parent:IsInvulnerable() or parent:IsDominated() or parent:PassivesDisabled() or parent:IsIllusion() then
+    return
+  end
+
+  -- Don't dodge if passive is on cooldown
+  if not ability:IsCooldownReady() then
+    return
+  end
+
+  -- Start cooldown respecting cooldown reductions
+  ability:UseResources(true, true, true)
+
+  -- Particle
+  local particle_name = "particles/items_fx/immunity_sphere.vpcf"
+  local particle = ParticleManager:CreateParticle(particle_name, PATTACH_POINT_FOLLOW, parent)
+  ParticleManager:ReleaseParticleIndex(particle)
+
+  -- Sound
+  parent:EmitSound("DOTA_Item.LinkensSphere.Activate")
+
+  return 1
+end
+
+--------------------------------------------------------------------------------
+
+modifier_mini_rosh_aura_effect = class(ModifierBaseClass)
+
+function modifier_mini_rosh_aura_effect:IsHidden()
+  return false
+end
+
+function modifier_mini_rosh_aura_effect:IsDebuff()
+  return false
+end
+
+function modifier_mini_rosh_aura_effect:IsPurgable()
+  return false
+end
+
+function modifier_mini_rosh_aura_effect:OnCreated()
+  local ability = self:GetAbility()
+  if ability then
+    self.bonus_armor = ability:GetSpecialValueFor("aura_bonus_armor")
+  end
+end
+
+function modifier_mini_rosh_aura_effect:OnRefresh()
+  local ability = self:GetAbility()
+  if ability then
+    self.bonus_armor = ability:GetSpecialValueFor("aura_bonus_armor")
+  end
+end
+
+function modifier_mini_rosh_aura_effect:DeclareFunctions()
+  local funcs = {
+    MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS,
+  }
+  return funcs
+end
+
+function modifier_mini_rosh_aura_effect:GetModifierPhysicalArmorBonus()
+  if self.bonus_armor then
+    return self.bonus_armor
+  end
+  return 5
+end

--- a/game/scripts/vscripts/abilities/neutrals/oaa_mini_rosh_root.lua
+++ b/game/scripts/vscripts/abilities/neutrals/oaa_mini_rosh_root.lua
@@ -1,0 +1,161 @@
+mini_rosh_root = class(AbilityBaseClass)
+
+LinkLuaModifier("modifier_mini_rosh_root_applier", "abilities/neutrals/oaa_mini_rosh_root.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_mini_rosh_root_effect", "abilities/neutrals/oaa_mini_rosh_root.lua", LUA_MODIFIER_MOTION_NONE)
+
+function mini_rosh_root:GetIntrinsicModifierName()
+  return "modifier_mini_rosh_root_applier"
+end
+
+function mini_rosh_root:ShouldUseResources()
+  return true
+end
+
+--------------------------------------------------------------------------------
+
+modifier_mini_rosh_root_applier = class(ModifierBaseClass)
+
+function modifier_mini_rosh_root_applier:IsHidden()
+  return true
+end
+
+function modifier_mini_rosh_root_applier:IsDebuff()
+  return false
+end
+
+function modifier_mini_rosh_root_applier:IsPurgable()
+  return false
+end
+
+function modifier_mini_rosh_root_applier:OnCreated()
+  local ability = self:GetAbility()
+  if ability and not ability:IsNull() then
+    self.chance = ability:GetSpecialValueFor("root_chance")
+    self.damage = ability:GetSpecialValueFor("bonus_damage")
+    self.duration = ability:GetSpecialValueFor("root_duration")
+  else
+    self.chance = 25
+    self.damage = 50
+    self.duration = 1.65
+  end
+end
+
+modifier_mini_rosh_root_applier.OnRefresh = modifier_mini_rosh_root_applier.OnCreated
+
+function modifier_mini_rosh_root_applier:DeclareFunctions()
+  local funcs = {
+    MODIFIER_EVENT_ON_ATTACK_LANDED,
+  }
+  return funcs
+end
+
+function modifier_mini_rosh_root_applier:OnAttackLanded(event)
+  if not IsServer() then
+    return
+  end
+
+  local ability = self:GetAbility()
+  local attacker = event.attacker
+  local target = event.target
+  local parent = self:GetParent()
+
+  if not attacker or attacker:IsNull() then
+    return
+  end
+
+  if parent ~= attacker then
+    return
+  end
+
+  -- No root while broken or illusion
+  if parent:PassivesDisabled() or parent:IsIllusion() then
+    return
+  end
+
+  -- To prevent crashes:
+  if not target or target:IsNull() then
+    return
+  end
+
+  -- Check for existence of GetUnitName method to determine if target is a unit or an item (or rune)
+  -- items don't have that method -> nil; if the target is an item, don't continue
+  if target.GetUnitName == nil then
+    return
+  end
+
+  -- Don't affect buildings, wards and invulnerable units.
+  if target:IsTower() or target:IsBarracks() or target:IsBuilding() or target:IsOther() or target:IsInvulnerable() then
+    return
+  end
+  
+  if not ability or ability:IsNull() then
+    return
+  end
+
+  -- Don't root while on cooldown
+  if not ability:IsCooldownReady() then
+    return
+  end
+
+  local chance = self.chance / 100
+  local damage = self.damage
+
+  -- Get number of failures
+  local prngMult = self:GetStackCount() + 1
+
+  if RandomFloat(0.0, 1.0) <= (PrdCFinder:GetCForP(chance) * prngMult) then
+    -- Reset failure count
+    self:SetStackCount(0)
+
+    -- Apply root
+    target:AddNewModifier(attacker, self:GetAbility(), "modifier_mini_rosh_root_effect", {duration = self.duration})
+
+    -- Sound
+    parent:EmitSound("n_creep_TrollWarlord.Ensnare")
+
+    -- Damage table
+    local damage_table = {}
+    damage_table.attacker = parent
+    damage_table.damage_type = ability:GetAbilityDamageType()
+    damage_table.ability = ability
+    damage_table.damage = damage
+    damage_table.victim = target
+
+    -- Apply bonus damage
+    ApplyDamage(damage_table)
+	
+	-- Start cooldown respecting cooldown reductions
+    ability:UseResources(true, true, true)
+  else
+    -- Increment number of failures
+    self:SetStackCount(prngMult)
+  end
+end
+
+--------------------------------------------------------------------------------
+
+modifier_mini_rosh_root_effect = class(ModifierBaseClass)
+
+function modifier_mini_rosh_root_effect:IsHidden()
+  return false
+end
+
+function modifier_mini_rosh_root_effect:IsDebuff()
+  return true
+end
+
+function modifier_mini_rosh_root_effect:IsPurgable()
+  return true
+end
+
+function modifier_mini_rosh_root_effect:GetEffectName()
+  return "particles/neutral_fx/dark_troll_ensnare.vpcf"
+end
+
+function modifier_mini_rosh_root_effect:CheckState()
+  local state = {
+    [MODIFIER_STATE_ROOTED] = true,
+  }
+  return state
+end
+


### PR DESCRIPTION
* Removed **True Sight** from Mini Roshans.
* Removed **Slam** from Mini Roshans.
* Chen Holy Persuasion and Doom Devour now work normally on Mini Roshans.
* Mini Roshan's BAT improved from 2.5 to 1.7
* Mini Roshan's magic resistance reduced from 55% to 50%.
* Mini Roshans no longer have mana (they don't use it anyway).
* Replaced Bash with **Root**: _Mini Roshan has 25% chance to root on attack. Root lasts 1.65s and has 2s proc cooldown._
* Combined Spell Block and Cliff Walk abilities into 1 ability called **Tenacity**: _Mini Roshan has 35% status resistance, spell block, free pathing, and bonus armor aura._ 
* Important things to know about Tenacity:
1) Spell Block doesn't work if dominated but it works on Doom. Spell Block can be disabled with Break. Spell Block has 15s cooldown.
2) Free pathing works only on neutral Mini Roshans (doesn't work when dominated or on Doom).
3) Neutral Mini Roshans don't bestow the armor aura to other neutrals. When dominated or on Doom, it works normally. Armor aura can be disabled with Break.
4) Bonus status resistance doesn't work on Doom.
