### PR TITLE
Update some heal and lifesteal stuff

### DIFF
--- a/game/scripts/npc/items/neutral/item_blood_sword.txt
+++ b/game/scripts/npc/items/neutral/item_blood_sword.txt
@@ -45,7 +45,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_lifesteal_percent"                        "100"
+        "active_lifesteal_percent"                        "300"
       }
     }
   }

--- a/game/scripts/vscripts/abilities/oaa_abaddon_borrowed_time.lua
+++ b/game/scripts/vscripts/abilities/oaa_abaddon_borrowed_time.lua
@@ -176,7 +176,7 @@ function modifier_oaa_borrowed_time_buff_caster:GetModifierTotal_ConstantBlock(k
     ParticleManager:ReleaseParticleIndex(heal_particle)
 
     -- Heal amount is equal to the damage amount (damage after reductions, not original damage)
-    parent:Heal(kv.damage, parent)
+    parent:Heal(kv.damage, self:GetAbility())
 
     -- Block the damage
     return kv.damage

--- a/game/scripts/vscripts/items/martyrs_mail.lua
+++ b/game/scripts/vscripts/items/martyrs_mail.lua
@@ -210,15 +210,19 @@ function modifier_item_martyrs_mail_martyr_active:OnTakeDamage( kv )
 
 			-- ApplyDamage( damageTable )
 			-- EmitSoundOnClient( "DOTA_Item.BladeMail.Damage", kv.attacker:GetPlayerOwner() )
+            local ability = self:GetAbility()
+            if not ability or ability:IsNull() then
+              return
+            end
 
-			local martyr_heal_aoe = self:GetAbility():GetSpecialValueFor( "martyr_heal_aoe" )
-			local martyr_heal_percent = self:GetAbility():GetSpecialValueFor( "martyr_heal_percent" )
+            local martyr_heal_aoe = ability:GetSpecialValueFor( "martyr_heal_aoe" )
+            local martyr_heal_percent = ability:GetSpecialValueFor( "martyr_heal_percent" )
 
 			local allies = FindUnitsInRadius( hCaster:GetTeamNumber(), hCaster:GetOrigin(), hCaster, martyr_heal_aoe, DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC, 0, 0, false )
 			if #allies > 1 then
 				for _,ally in pairs(allies) do
 					if ally ~= hCaster then
-						ally:Heal( kv.original_damage * martyr_heal_percent / 100, hCaster )
+						ally:Heal( kv.original_damage * martyr_heal_percent / 100, ability )
 					end
 				end
 			end

--- a/game/scripts/vscripts/items/transformation/vampire.lua
+++ b/game/scripts/vscripts/items/transformation/vampire.lua
@@ -243,7 +243,7 @@ function vampire:lifesteal(event, spell, parent, amount)
     )
 
     if ufResult == UF_SUCCESS then
-      parent:Heal( damage * ( amount * 0.01 ), parent )
+      parent:Heal( damage * ( amount * 0.01 ), spell )
 
       local part = ParticleManager:CreateParticle( "particles/generic_gameplay/generic_lifesteal.vpcf", PATTACH_ABSORIGIN, parent )
       ParticleManager:ReleaseParticleIndex( part )


### PR DESCRIPTION
* Abaddon's Borrowed Time should now show the ability source of heal in the combat log.
* Martyr's Mail should now show the item source of heal in the combat log.
* Fixed Blood Sword not lifestealing.
* Blood Sword active lifesteal increased from 100% to 300%.
* Vampire Fang should now show the item source of lifesteal in the combat log.
