### PR TITLE
Damage Block items buffs

### DIFF
--- a/game/scripts/npc/items/custom/item_shield_staff.txt
+++ b/game/scripts/npc/items/custom/item_shield_staff.txt
@@ -95,12 +95,12 @@
         "var_type"                                        "FIELD_FLOAT"
         "bonus_mana_regen"                                "1.0 1.25 1.75 2.5 3.5"
       }
-      "05"
+      "05" // unused
       {
         "var_type"                                        "FIELD_FLOAT"
         "bonus_armor"                                     "0"
       }
-      "06"
+      "06" // unused
       {
         "var_type"                                        "FIELD_INTEGER"
         "bonus_magic_resistance"                          "0"
@@ -108,12 +108,12 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_attack_damage_block_melee"               "70 100 140 190 250"
+        "passive_attack_damage_block_melee"               "70 120 170 220 270"
       }
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_attack_damage_block_ranged"              "35 50 70 95 125"
+        "passive_attack_damage_block_ranged"              "35 70 105 140 175"
       }
       "09" // Vanguard (60)
       {

--- a/game/scripts/npc/items/custom/item_shield_staff_2.txt
+++ b/game/scripts/npc/items/custom/item_shield_staff_2.txt
@@ -110,12 +110,12 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_attack_damage_block_melee"               "70 100 140 190 250"
+        "passive_attack_damage_block_melee"               "70 120 170 220 270"
       }
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_attack_damage_block_ranged"              "35 50 70 95 125"
+        "passive_attack_damage_block_ranged"              "35 70 105 140 175"
       }
       "09"
       {

--- a/game/scripts/npc/items/custom/item_shield_staff_3.txt
+++ b/game/scripts/npc/items/custom/item_shield_staff_3.txt
@@ -110,12 +110,12 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_attack_damage_block_melee"               "70 100 140 190 250"
+        "passive_attack_damage_block_melee"               "70 120 170 220 270"
       }
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_attack_damage_block_ranged"              "35 50 70 95 125"
+        "passive_attack_damage_block_ranged"              "35 70 105 140 175"
       }
       "09"
       {

--- a/game/scripts/npc/items/custom/item_shield_staff_4.txt
+++ b/game/scripts/npc/items/custom/item_shield_staff_4.txt
@@ -110,12 +110,12 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_attack_damage_block_melee"               "70 100 140 190 250"
+        "passive_attack_damage_block_melee"               "70 120 170 220 270"
       }
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_attack_damage_block_ranged"              "35 50 70 95 125"
+        "passive_attack_damage_block_ranged"              "35 70 105 140 175"
       }
       "09"
       {

--- a/game/scripts/npc/items/custom/item_shield_staff_5.txt
+++ b/game/scripts/npc/items/custom/item_shield_staff_5.txt
@@ -111,12 +111,12 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_attack_damage_block_melee"               "70 100 140 190 250"
+        "passive_attack_damage_block_melee"               "70 120 170 220 270"
       }
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_attack_damage_block_ranged"              "35 50 70 95 125"
+        "passive_attack_damage_block_ranged"              "35 70 105 140 175"
       }
       "09"
       {

--- a/game/scripts/npc/items/item_abyssal_blade.txt
+++ b/game/scripts/npc/items/item_abyssal_blade.txt
@@ -80,12 +80,12 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee"                              "70 100 130 160 190"
+        "block_damage_melee"                              "70 120 170 220 270"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged"                             "35 50 70 100 140"
+        "block_damage_ranged"                             "35 70 105 140 175"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_abyssal_blade_2.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_2.txt
@@ -81,12 +81,12 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee"                              "70 100 130 160 190"
+        "block_damage_melee"                              "70 120 170 220 270"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged"                             "35 50 70 100 140"
+        "block_damage_ranged"                             "35 70 105 140 175"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_abyssal_blade_3.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_3.txt
@@ -81,12 +81,12 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee"                              "70 100 130 160 190"
+        "block_damage_melee"                              "70 120 170 220 270"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged"                             "35 50 70 100 140"
+        "block_damage_ranged"                             "35 70 105 140 175"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_abyssal_blade_4.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_4.txt
@@ -82,12 +82,12 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee"                              "70 100 130 160 190"
+        "block_damage_melee"                              "70 120 170 220 270"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged"                             "35 50 70 100 140"
+        "block_damage_ranged"                             "35 70 105 140 175"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_abyssal_blade_5.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_5.txt
@@ -82,12 +82,12 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee"                              "70 100 130 160 190"
+        "block_damage_melee"                              "70 120 170 220 270"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged"                             "35 50 70 100 140"
+        "block_damage_ranged"                             "35 70 105 140 175"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_crimson_guard.txt
+++ b/game/scripts/npc/items/item_crimson_guard.txt
@@ -77,12 +77,12 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee"                              "70 100 150 200 300"
+        "block_damage_melee"                              "70 120 170 220 270"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged"                             "35 50 75 100 150"
+        "block_damage_ranged"                             "35 70 105 140 175"
       }
       "06"
       {
@@ -102,12 +102,12 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee_active"                       "70 100 140 190 250"
+        "block_damage_melee_active"                       "100 150 200 250 300" //OAA
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged_active"                      "70 100 140 190 250"
+        "block_damage_ranged_active"                      "100 150 200 250 300" //OAA
       }
       "11"
       {

--- a/game/scripts/npc/items/item_crimson_guard_2.txt
+++ b/game/scripts/npc/items/item_crimson_guard_2.txt
@@ -82,12 +82,12 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee"                              "70 100 150 200 300"
+        "block_damage_melee"                              "70 120 170 220 270"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged"                             "35 50 75 100 150"
+        "block_damage_ranged"                             "35 70 105 140 175"
       }
       "06"
       {
@@ -107,12 +107,12 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee_active"                       "70 100 140 190 250"
+        "block_damage_melee_active"                       "100 150 200 250 300"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged_active"                      "70 100 140 190 250"
+        "block_damage_ranged_active"                      "100 150 200 250 300"
       }
       "11"
       {

--- a/game/scripts/npc/items/item_crimson_guard_3.txt
+++ b/game/scripts/npc/items/item_crimson_guard_3.txt
@@ -82,12 +82,12 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee"                              "70 100 150 200 300"
+        "block_damage_melee"                              "70 120 170 220 270"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged"                             "35 50 75 100 150"
+        "block_damage_ranged"                             "35 70 105 140 175"
       }
       "06"
       {
@@ -107,12 +107,12 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee_active"                       "70 100 140 190 250"
+        "block_damage_melee_active"                       "100 150 200 250 300"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged_active"                      "70 100 140 190 250"
+        "block_damage_ranged_active"                      "100 150 200 250 300"
       }
       "11"
       {

--- a/game/scripts/npc/items/item_crimson_guard_4.txt
+++ b/game/scripts/npc/items/item_crimson_guard_4.txt
@@ -83,12 +83,12 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee"                              "70 100 150 200 300"
+        "block_damage_melee"                              "70 120 170 220 270"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged"                             "35 50 75 100 150"
+        "block_damage_ranged"                             "35 70 105 140 175"
       }
       "06"
       {
@@ -108,12 +108,12 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee_active"                       "70 100 140 190 250"
+        "block_damage_melee_active"                       "100 150 200 250 300"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged_active"                      "70 100 140 190 250"
+        "block_damage_ranged_active"                      "100 150 200 250 300"
       }
       "11"
       {

--- a/game/scripts/npc/items/item_crimson_guard_5.txt
+++ b/game/scripts/npc/items/item_crimson_guard_5.txt
@@ -83,12 +83,12 @@
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee"                              "70 100 150 200 300"
+        "block_damage_melee"                              "70 120 170 220 270"
       }
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged"                             "35 50 75 100 150"
+        "block_damage_ranged"                             "35 70 105 140 175"
       }
       "06"
       {
@@ -108,12 +108,12 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_melee_active"                       "70 100 140 190 250"
+        "block_damage_melee_active"                       "100 150 200 250 300"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "block_damage_ranged_active"                      "70 100 140 190 250"
+        "block_damage_ranged_active"                      "100 150 200 250 300"
       }
       "11"
       {


### PR DESCRIPTION
* Abyssal Blade passive damage block on melee heroes increased from 130/160/190 to 170/220/270.
* Abyssal Blade passive damage block on ranged heroes increased from 70/100/140 to 105/140/175.
* Crimson Guard passive damage block on melee heroes rescaled from 70/100/150/200/300 to 70/120/170/220/270.
* Crimson Guard passive damage block on ranged heroes increased from 35/50/75/100/150 to 35/70/105/140/175.
* Crimson Guard active damage block increased from 70/100/140/190/250 to 100/150/200/250/300.
* Force Shield Staff passive attack damage block on melee heroes increased from 70/100/140/190/250 to 70/120/170/220/270.
* Force Shield Staff passive attack damage block on ranged heroes increased from 35/50/70/95/125 to 35/70/105/140/175.
* Force Shield Staff: Reworked pseudo-random chances for attack damage block and spell damage block to use OAA custom pseudo-random which is more reliable.