### PR TITLE
Hurricane Pike and Splash Cannon buffs

### DIFF
--- a/game/resource/English/ability/items/tooltip_hurricane_pike.txt
+++ b/game/resource/English/ability/items/tooltip_hurricane_pike.txt
@@ -1,6 +1,8 @@
 //=================================================================================================================
 // Recipe: Hurricane Pike
 //=================================================================================================================
+"DOTA_Tooltip_Ability_item_hurricane_pike_cooldown_tooltip"                 "COOLDOWN:"
+
 "DOTA_Tooltip_Ability_item_hurricane_pike_2"                                "#{DOTA_Tooltip_Ability_item_hurricane_pike}"
 "DOTA_Tooltip_Ability_item_recipe_hurricane_pike_2"                         "Hurricane Pike Recipe"
 "DOTA_Tooltip_Ability_item_hurricane_pike_2_Description"                    "#{DOTA_Tooltip_Ability_item_hurricane_pike_Description}"
@@ -12,6 +14,7 @@
 "DOTA_Tooltip_Ability_item_hurricane_pike_2_bonus_health"                   "#{DOTA_Tooltip_Ability_item_hurricane_pike_bonus_health}"
 "DOTA_Tooltip_Ability_item_hurricane_pike_2_bonus_agility"                  "#{DOTA_Tooltip_Ability_item_hurricane_pike_bonus_agility}"
 "DOTA_Tooltip_Ability_item_hurricane_pike_2_bonus_strength"                 "#{DOTA_Tooltip_Ability_item_hurricane_pike_bonus_strength}"
+"DOTA_Tooltip_Ability_item_hurricane_pike_2_cooldown_tooltip"               "#{DOTA_Tooltip_Ability_item_hurricane_pike_cooldown_tooltip}"
 //"DOTA_Tooltip_Ability_item_hurricane_pike_2_base_attack_range"              "+$attack_range"
 //"DOTA_Tooltip_Ability_item_hurricane_pike_2_range_duration"                 "UNLIMITED RANGE DURATION:"
 //"DOTA_Tooltip_Ability_item_hurricane_pike_2_cast_range_enemy"               "CAST RANGE ON ENEMY:"
@@ -28,6 +31,7 @@
 "DOTA_Tooltip_Ability_item_hurricane_pike_3_bonus_health"                   "#{DOTA_Tooltip_Ability_item_hurricane_pike_bonus_health}"
 "DOTA_Tooltip_Ability_item_hurricane_pike_3_bonus_agility"                  "#{DOTA_Tooltip_Ability_item_hurricane_pike_bonus_agility}"
 "DOTA_Tooltip_Ability_item_hurricane_pike_3_bonus_strength"                 "#{DOTA_Tooltip_Ability_item_hurricane_pike_bonus_strength}"
+"DOTA_Tooltip_Ability_item_hurricane_pike_3_cooldown_tooltip"               "#{DOTA_Tooltip_Ability_item_hurricane_pike_cooldown_tooltip}"
 //"DOTA_Tooltip_Ability_item_hurricane_pike_3_base_attack_range"              "+$attack_range"
 //"DOTA_Tooltip_Ability_item_hurricane_pike_3_range_duration"                 "UNLIMITED RANGE DURATION:"
 //"DOTA_Tooltip_Ability_item_hurricane_pike_3_cast_range_enemy"               "CAST RANGE ON ENEMY:"
@@ -44,6 +48,7 @@
 "DOTA_Tooltip_Ability_item_hurricane_pike_4_bonus_health"                   "#{DOTA_Tooltip_Ability_item_hurricane_pike_bonus_health}"
 "DOTA_Tooltip_Ability_item_hurricane_pike_4_bonus_agility"                  "#{DOTA_Tooltip_Ability_item_hurricane_pike_bonus_agility}"
 "DOTA_Tooltip_Ability_item_hurricane_pike_4_bonus_strength"                 "#{DOTA_Tooltip_Ability_item_hurricane_pike_bonus_strength}"
+"DOTA_Tooltip_Ability_item_hurricane_pike_4_cooldown_tooltip"               "#{DOTA_Tooltip_Ability_item_hurricane_pike_cooldown_tooltip}"
 //"DOTA_Tooltip_Ability_item_hurricane_pike_4_base_attack_range"              "+$attack_range"
 //"DOTA_Tooltip_Ability_item_hurricane_pike_4_range_duration"                 "UNLIMITED RANGE DURATION:"
 //"DOTA_Tooltip_Ability_item_hurricane_pike_4_cast_range_enemy"               "CAST RANGE ON ENEMY:"
@@ -60,6 +65,7 @@
 "DOTA_Tooltip_Ability_item_hurricane_pike_5_bonus_health"                   "#{DOTA_Tooltip_Ability_item_hurricane_pike_bonus_health}"
 "DOTA_Tooltip_Ability_item_hurricane_pike_5_bonus_agility"                  "#{DOTA_Tooltip_Ability_item_hurricane_pike_bonus_agility}"
 "DOTA_Tooltip_Ability_item_hurricane_pike_5_bonus_strength"                 "#{DOTA_Tooltip_Ability_item_hurricane_pike_bonus_strength}"
+"DOTA_Tooltip_Ability_item_hurricane_pike_5_cooldown_tooltip"               "#{DOTA_Tooltip_Ability_item_hurricane_pike_cooldown_tooltip}"
 //"DOTA_Tooltip_Ability_item_hurricane_pike_5_base_attack_range"              "+$attack_range"
 //"DOTA_Tooltip_Ability_item_hurricane_pike_5_range_duration"                 "UNLIMITED RANGE DURATION:"
 //"DOTA_Tooltip_Ability_item_hurricane_pike_5_cast_range_enemy"               "CAST RANGE ON ENEMY:"

--- a/game/scripts/npc/items/custom/item_siege_mode.txt
+++ b/game/scripts/npc/items/custom/item_siege_mode.txt
@@ -1,7 +1,7 @@
 "DOTAAbilities"
 {
   //=================================================================================================================
-  // Recipe: Splash Gun
+  // Recipe: Splash Cannon
   //=================================================================================================================
   "item_recipe_siege_mode"
   {
@@ -30,7 +30,7 @@
   }
 
   //=================================================================================================================
-  // Splash Gun
+  // Splash Cannon
   //=================================================================================================================
   "item_siege_mode"
   {
@@ -57,7 +57,7 @@
     "ItemShopTags"                                        "damage"
     "ItemQuality"                                         "artifact"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
-    "ItemAliases"                                         "splash gun;splash;siege"
+    "ItemAliases"                                         "splash cannon;splash;siege;cannon"
 
     "MaxUpgradeLevel"                                     "2"
     "ItemBaseLevel"                                       "1"
@@ -79,7 +79,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "50 70"
+        "bonus_agility"                                   "65 90"
       }
       "02"
       {
@@ -89,7 +89,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "43 63"
+        "bonus_intellect"                                 "45 65"
       }
       "04"
       {

--- a/game/scripts/npc/items/custom/item_siege_mode_2.txt
+++ b/game/scripts/npc/items/custom/item_siege_mode_2.txt
@@ -1,7 +1,7 @@
 "DOTAAbilities"
 {
   //=================================================================================================================
-  // Recipe: Splash Gun 2
+  // Recipe: Splash Cannon 2
   //=================================================================================================================
   "item_recipe_siege_mode_2"
   {
@@ -31,7 +31,7 @@
   }
 
   //=================================================================================================================
-  // Splash Gun 2
+  // Splash Cannon 2
   //=================================================================================================================
   "item_siege_mode_2"
   {
@@ -58,7 +58,8 @@
     "ItemShopTags"                                        "damage"
     "ItemQuality"                                         "artifact"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
-    "ItemAliases"                                         "splash gun 2;splash 2; siege 2"
+    "ItemAliases"                                         "splash cannon 2;splash 2;siege 2;cannon 2"
+
     "MaxUpgradeLevel"                                     "2"
     "ItemBaseLevel"                                       "2"
 
@@ -78,7 +79,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "50 70"
+        "bonus_agility"                                   "65 90"
       }
       "02"
       {
@@ -88,7 +89,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_intellect"                                 "43 63"
+        "bonus_intellect"                                 "45 65"
       }
       "04"
       {

--- a/game/scripts/npc/items/item_hurricane_pike.txt
+++ b/game/scripts/npc/items/item_hurricane_pike.txt
@@ -44,7 +44,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "550"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "23.0"
+    "AbilityCooldown"                                     "23 20 17 14 11" //OAA
     "AbilitySharedCooldown"                               "force"
 
     // Item Info
@@ -76,7 +76,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "20 25 35 50 70"
+        "bonus_agility"                                   "20 30 45 65 90"
       }
       "04"
       {
@@ -117,6 +117,11 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "bonus_attack_speed"                              "100 110 120 130 140"
+      }
+      "20" //OAA
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "cooldown_tooltip"                                "23 20 17 14 11"
       }
     }
   }

--- a/game/scripts/npc/items/item_hurricane_pike_2.txt
+++ b/game/scripts/npc/items/item_hurricane_pike_2.txt
@@ -48,7 +48,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "550"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "23.0"
+    "AbilityCooldown"                                     "23 20 17 14 11"
     "AbilitySharedCooldown"                               "force"
 
     // Item Info
@@ -80,7 +80,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "20 25 35 50 70"
+        "bonus_agility"                                   "20 30 45 65 90"
       }
       "04"
       {
@@ -121,6 +121,11 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "bonus_attack_speed"                              "100 110 120 130 140"
+      }
+      "20" //OAA
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "cooldown_tooltip"                                "23 20 17 14 11"
       }
     }
   }

--- a/game/scripts/npc/items/item_hurricane_pike_3.txt
+++ b/game/scripts/npc/items/item_hurricane_pike_3.txt
@@ -48,7 +48,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "550"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "23.0"
+    "AbilityCooldown"                                     "23 20 17 14 11"
     "AbilitySharedCooldown"                               "force"
 
     // Item Info
@@ -80,7 +80,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "20 25 35 50 70"
+        "bonus_agility"                                   "20 30 45 65 90"
       }
       "04"
       {
@@ -121,6 +121,11 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "bonus_attack_speed"                              "100 110 120 130 140"
+      }
+      "20" //OAA
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "cooldown_tooltip"                                "23 20 17 14 11"
       }
     }
   }

--- a/game/scripts/npc/items/item_hurricane_pike_4.txt
+++ b/game/scripts/npc/items/item_hurricane_pike_4.txt
@@ -48,7 +48,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "550"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "23.0"
+    "AbilityCooldown"                                     "23 20 17 14 11"
     "AbilitySharedCooldown"                               "force"
 
     // Item Info
@@ -80,7 +80,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "20 25 35 50 70"
+        "bonus_agility"                                   "20 30 45 65 90"
       }
       "04"
       {
@@ -121,6 +121,11 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "bonus_attack_speed"                              "100 110 120 130 140"
+      }
+      "20" //OAA
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "cooldown_tooltip"                                "23 20 17 14 11"
       }
     }
   }

--- a/game/scripts/npc/items/item_hurricane_pike_5.txt
+++ b/game/scripts/npc/items/item_hurricane_pike_5.txt
@@ -49,7 +49,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastRange"                                    "550"
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "23.0"
+    "AbilityCooldown"                                     "23 20 17 14 11"
     "AbilitySharedCooldown"                               "force"
 
     // Item Info
@@ -81,7 +81,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_agility"                                   "20 25 35 50 70"
+        "bonus_agility"                                   "20 30 45 65 90"
       }
       "04"
       {
@@ -122,6 +122,11 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "bonus_attack_speed"                              "100 110 120 130 140"
+      }
+      "20" //OAA
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "cooldown_tooltip"                                "23 20 17 14 11"
       }
     }
   }


### PR DESCRIPTION
* Hurricane Pike bonus agility increased from 20/25/35/50/70 to 20/30/45/65/90.
* Hurricane Pike cooldown reduced from 23 to 23/20/17/14/11 seconds.
* Splash Cannon bonus agility increased from 50/70 to 65/90.
* Splash Cannon bonus intelligence increased from 43/63 to 45/65.