### PR TITLE
Greater Tranquil Boots changes

### DIFF
--- a/game/resource/English/ability/items/tooltip_greater_tranquil_boots.txt
+++ b/game/resource/English/ability/items/tooltip_greater_tranquil_boots.txt
@@ -5,12 +5,13 @@
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots"                              "Greater Tranquil Boots"
 "DOTA_Tooltip_Ability_item_recipe_greater_tranquil_boots"                       "Greater Tranquil Boots Recipe"
 //"DOTA_Tooltip_Ability_item_greater_tranquil_boots_Description"                  "<h1>Passive: Break</h1> Whenever you are attacked by a hero, the bonus %bonus_health_health% HP regen is lost and the movement speed bonus is reduced to %broken_movement_speed% for %break_time% seconds."
-"DOTA_Tooltip_Ability_item_greater_tranquil_boots_Description"                  "<h1>Active: Naturalize</h1> Sprouts a ring of trees around a unit, trapping it in place. Affected allies gain tree-walking and %hp_regen_amp%%% hp regen amplification for %sprout_duration% seconds. Affected enemies have their attack speed slowed by %attack_speed_slow% for %slow_duration% seconds. Trees last %sprout_duration% seconds. \n<h1>Passive: Tree-Walking</h1> You can walk through trees without destroying them."
+"DOTA_Tooltip_Ability_item_greater_tranquil_boots_Description"                  "<h1>Active: Naturalize</h1> Sprouts a ring of trees around a unit, trapping it in place. Affected allies gain tree-walking, %active_hp_regen_amp%%% hp regen amplification and %active_heal_amp%%% heal amplification for %sprout_duration% seconds. Affected enemies have their attack speed slowed by %attack_speed_slow% for %slow_duration% seconds. Trees last %sprout_duration% seconds.\n<h1>Passive: Tree Protection</h1> When within %passive_tree_radius% of a tree, you take %passive_damage_reduction%%% less damage and you gain %passive_hp_regen_amp%%% hp regen amplification, %passive_heal_amp%%% heal amplification, and %passive_status_resistance%%% status resistance.\n<h1>Passive: Tree-Walking</h1> You can walk through trees without destroying them."
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_Lore"                         "Pacifying enemies just by using these boots was never so easy."
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_Note0"                        "Attack speed slow doesn't work on bosses."
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_movement_speed"         "+$move_speed"
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_health_regen"           "+$hp_regen"
-"DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_armor"                  "+$armor"
+//"DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_armor"                  "+$armor"
+"DOTA_Tooltip_Ability_item_greater_tranquil_boots_cooldown_tooltip"             "COOLDOWN:"
 //"item_greater_tranquil_boots_naturalize_Description"                            "<h1>Passive: Naturalize</h1> Generate charges every %distance_per_charge% distance moved. At 100 charges, your next attack on a non-ancient neutral creep will consume them to instantly kill it for %bonus_gold% additional gold."
 
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_2"                            "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots}"
@@ -20,7 +21,8 @@
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_2_Note0"                      "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_Note0}"
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_2_bonus_movement_speed"       "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_movement_speed}"
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_2_bonus_health_regen"         "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_health_regen}"
-"DOTA_Tooltip_Ability_item_greater_tranquil_boots_2_bonus_armor"                "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_armor}"
+//"DOTA_Tooltip_Ability_item_greater_tranquil_boots_2_bonus_armor"                "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_armor}"
+"DOTA_Tooltip_Ability_item_greater_tranquil_boots_2_cooldown_tooltip"           "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_cooldown_tooltip}"
 
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_3"                            "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots}"
 "DOTA_Tooltip_Ability_item_recipe_greater_tranquil_boots_3"                     "#{DOTA_Tooltip_Ability_item_recipe_greater_tranquil_boots}"
@@ -29,7 +31,8 @@
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_3_Note0"                      "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_Note0}"
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_3_bonus_movement_speed"       "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_movement_speed}"
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_3_bonus_health_regen"         "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_health_regen}"
-"DOTA_Tooltip_Ability_item_greater_tranquil_boots_3_bonus_armor"                "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_armor}"
+//"DOTA_Tooltip_Ability_item_greater_tranquil_boots_3_bonus_armor"                "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_armor}"
+"DOTA_Tooltip_Ability_item_greater_tranquil_boots_3_cooldown_tooltip"           "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_cooldown_tooltip}"
 
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_4"                            "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots}"
 "DOTA_Tooltip_Ability_item_recipe_greater_tranquil_boots_4"                     "#{DOTA_Tooltip_Ability_item_recipe_greater_tranquil_boots}"
@@ -38,16 +41,8 @@
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_4_Note0"                      "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_Note0}"
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_4_bonus_movement_speed"       "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_movement_speed}"
 "DOTA_Tooltip_Ability_item_greater_tranquil_boots_4_bonus_health_regen"         "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_health_regen}"
-"DOTA_Tooltip_Ability_item_greater_tranquil_boots_4_bonus_armor"                "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_armor}"
-
-"DOTA_Tooltip_Ability_item_greater_tranquil_boots_5"                            "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots}"
-"DOTA_Tooltip_Ability_item_recipe_greater_tranquil_boots_5"                     "#{DOTA_Tooltip_Ability_item_recipe_greater_tranquil_boots}"
-"DOTA_Tooltip_Ability_item_greater_tranquil_boots_5_Description"                "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_Description}"
-"DOTA_Tooltip_Ability_item_greater_tranquil_boots_5_Lore"                       "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_Lore}"
-"DOTA_Tooltip_Ability_item_greater_tranquil_boots_5_Note0"                      "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_Note0}"
-"DOTA_Tooltip_Ability_item_greater_tranquil_boots_5_bonus_movement_speed"       "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_movement_speed}"
-"DOTA_Tooltip_Ability_item_greater_tranquil_boots_5_bonus_health_regen"         "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_health_regen}"
-"DOTA_Tooltip_Ability_item_greater_tranquil_boots_5_bonus_armor"                "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_armor}"
+//"DOTA_Tooltip_Ability_item_greater_tranquil_boots_4_bonus_armor"                "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_bonus_armor}"
+"DOTA_Tooltip_Ability_item_greater_tranquil_boots_4_cooldown_tooltip"           "#{DOTA_Tooltip_Ability_item_greater_tranquil_boots_cooldown_tooltip}"
 
 //"DOTA_Tooltip_Ability_item_tranquil_origin"                                     "Tranquil Spark"
 //"DOTA_Tooltip_Ability_item_recipe_tranquil_origin"                              "Traqnuil Spark Recipe"
@@ -60,4 +55,7 @@
 "DOTA_Tooltip_modifier_greater_tranquils_tranquilize_debuff_Description"        "Attack speed reduced by %dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%."
 
 "DOTA_Tooltip_modifier_greater_tranquils_tranquilize_buff"                      "Tranquility"
-"DOTA_Tooltip_modifier_greater_tranquils_tranquilize_buff_Description"          "Tree-Walking and bonus hp regen amplification."
+"DOTA_Tooltip_modifier_greater_tranquils_tranquilize_buff_Description"          "Tree-Walking, bonus hp regen amplification and bonus heal amplification."
+
+"DOTA_Tooltip_modifier_greater_tranquils_trees_buff"                            "Tree Protection"
+"DOTA_Tooltip_modifier_greater_tranquils_trees_buff_Description"                "While near a tree, taking less damage, bonus hp regen amplification, bonus heal amplification, and bonus status resist."

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots.txt
@@ -11,6 +11,7 @@
     "BaseClass"                                           "item_datadriven"
     "Model"                                               "models/props_gameplay/recipe.vmdl"
     "AbilityTextureName"                                  "custom/recipe/recipe_2"
+
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCorePointCost"                                   "0"
@@ -45,6 +46,7 @@
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "AbilityTextureName"                                  "custom/greater_tranquils"
+
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "18 17 16 15"
@@ -64,7 +66,6 @@
     "MaxUpgradeLevel"                                     "4"
     "ItemBaseLevel"                                       "1"
     "UpgradesItems"                                       "item_greater_tranquil_boots_1;item_greater_tranquil_boots_2;item_greater_tranquil_boots_3;item_greater_tranquil_boots_4"
-    "UpgradeRecipe"                                       "item_recipe_greater_tranquil_boots"
 
     "precache"
     {
@@ -136,7 +137,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_damage_reduction"                        "10 15 20 25"
+        "passive_damage_reduction"                        "10 12 14 16"
       }
       "13"
       {

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots.txt
@@ -81,7 +81,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_movement_speed"                            "75 80 85 90"
+        "bonus_movement_speed"                            "70 75 80 85"
       }
       "02"
       {
@@ -146,7 +146,7 @@
       "14"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_tree_radius"                             "160"
+        "passive_tree_radius"                             "150"
       }
       "15"
       {

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots.txt
@@ -47,7 +47,7 @@
     "AbilityTextureName"                                  "custom/greater_tranquils"
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "18"
+    "AbilityCooldown"                                     "18 17 16 15"
     "AbilityManaCost"                                     "75"
     "AbilitySharedCooldown"                               "greater_tranquils"
     "AbilityCastRange"                                    "600 650 700 750"
@@ -86,7 +86,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "2 5 9 14"
+        "bonus_armor"                                     "0"
       }
       "03"
       {
@@ -121,12 +121,52 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "hp_regen_amp"                                    "50"
+        "projectile_speed"                                "700"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "projectile_speed"                                "700"
+        "passive_hp_regen_amp"                            "20 22 24 26"
+      }
+      "11"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_heal_amp"                                "25 30 35 40"
+      }
+      "12"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_damage_reduction"                        "10 15 20 25"
+      }
+      "13"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_status_resistance"                       "10 15 20 25"
+      }
+      "14"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_tree_radius"                             "160"
+      }
+      "15"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_hp_regen_amp"                             "50"
+      }
+      "16"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_heal_amp"                                 "50"
+      }
+      "17"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "sprout_vision_range"                             "250"
+      }
+      "18"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "cooldown_tooltip"                                "18 17 16 15"
       }
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_2.txt
@@ -47,7 +47,7 @@
     "AbilityTextureName"                                  "custom/greater_tranquils_2"
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "18"
+    "AbilityCooldown"                                     "18 17 16 15"
     "AbilityManaCost"                                     "75"
     "AbilitySharedCooldown"                               "greater_tranquils"
     "AbilityCastRange"                                    "600 650 700 750"
@@ -86,7 +86,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "2 5 9 14"
+        "bonus_armor"                                     "0"
       }
       "03"
       {
@@ -121,12 +121,52 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "hp_regen_amp"                                    "50"
+        "projectile_speed"                                "700"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "projectile_speed"                                "700"
+        "passive_hp_regen_amp"                            "20 22 24 26"
+      }
+      "11"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_heal_amp"                                "25 30 35 40"
+      }
+      "12"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_damage_reduction"                        "10 15 20 25"
+      }
+      "13"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_status_resistance"                       "10 15 20 25"
+      }
+      "14"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_tree_radius"                             "160"
+      }
+      "15"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_hp_regen_amp"                             "50"
+      }
+      "16"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_heal_amp"                                 "50"
+      }
+      "17"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "sprout_vision_range"                             "250"
+      }
+      "18"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "cooldown_tooltip"                                "18 17 16 15"
       }
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_2.txt
@@ -81,7 +81,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_movement_speed"                            "75 80 85 90"
+        "bonus_movement_speed"                            "70 75 80 85"
       }
       "02"
       {
@@ -146,7 +146,7 @@
       "14"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_tree_radius"                             "160"
+        "passive_tree_radius"                             "150"
       }
       "15"
       {

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_2.txt
@@ -11,6 +11,7 @@
     "BaseClass"                                           "item_datadriven"
     "Model"                                               "models/props_gameplay/recipe.vmdl"
     "AbilityTextureName"                                  "custom/recipe/recipe_3"
+
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCorePointCost"                                   "0"
@@ -45,6 +46,7 @@
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "AbilityTextureName"                                  "custom/greater_tranquils_2"
+
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "18 17 16 15"
@@ -64,7 +66,6 @@
     "MaxUpgradeLevel"                                     "4"
     "ItemBaseLevel"                                       "2"
     "UpgradesItems"                                       "item_greater_tranquil_boots_2;item_greater_tranquil_boots_3;item_greater_tranquil_boots_4"
-    "UpgradeRecipe"                                       "item_recipe_greater_tranquil_boots"
 
     "precache"
     {
@@ -136,7 +137,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_damage_reduction"                        "10 15 20 25"
+        "passive_damage_reduction"                        "10 12 14 16"
       }
       "13"
       {

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_3.txt
@@ -11,6 +11,7 @@
     "BaseClass"                                           "item_datadriven"
     "Model"                                               "models/props_gameplay/recipe.vmdl"
     "AbilityTextureName"                                  "custom/recipe/recipe_4"
+
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCorePointCost"                                   "0"
@@ -45,6 +46,7 @@
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "AbilityTextureName"                                  "custom/greater_tranquils_3"
+
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "18 17 16 15"
@@ -64,7 +66,6 @@
     "MaxUpgradeLevel"                                     "4"
     "ItemBaseLevel"                                       "3"
     "UpgradesItems"                                       "item_greater_tranquil_boots_3;item_greater_tranquil_boots_4"
-    "UpgradeRecipe"                                       "item_recipe_greater_tranquil_boots"
 
     "precache"
     {
@@ -136,7 +137,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_damage_reduction"                        "10 15 20 25"
+        "passive_damage_reduction"                        "10 12 14 16"
       }
       "13"
       {

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_3.txt
@@ -81,7 +81,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_movement_speed"                            "75 80 85 90"
+        "bonus_movement_speed"                            "70 75 80 85"
       }
       "02"
       {
@@ -146,7 +146,7 @@
       "14"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_tree_radius"                             "160"
+        "passive_tree_radius"                             "150"
       }
       "15"
       {

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_3.txt
@@ -47,7 +47,7 @@
     "AbilityTextureName"                                  "custom/greater_tranquils_3"
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "18"
+    "AbilityCooldown"                                     "18 17 16 15"
     "AbilityManaCost"                                     "75"
     "AbilitySharedCooldown"                               "greater_tranquils"
     "AbilityCastRange"                                    "600 650 700 750"
@@ -86,7 +86,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "2 5 9 14"
+        "bonus_armor"                                     "0"
       }
       "03"
       {
@@ -121,12 +121,52 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "hp_regen_amp"                                    "50"
+        "projectile_speed"                                "700"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "projectile_speed"                                "700"
+        "passive_hp_regen_amp"                            "20 22 24 26"
+      }
+      "11"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_heal_amp"                                "25 30 35 40"
+      }
+      "12"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_damage_reduction"                        "10 15 20 25"
+      }
+      "13"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_status_resistance"                       "10 15 20 25"
+      }
+      "14"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_tree_radius"                             "160"
+      }
+      "15"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_hp_regen_amp"                             "50"
+      }
+      "16"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_heal_amp"                                 "50"
+      }
+      "17"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "sprout_vision_range"                             "250"
+      }
+      "18"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "cooldown_tooltip"                                "18 17 16 15"
       }
     }
   }

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_4.txt
@@ -82,7 +82,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_movement_speed"                            "75 80 85 90"
+        "bonus_movement_speed"                            "70 75 80 85"
       }
       "02"
       {
@@ -147,7 +147,7 @@
       "14"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_tree_radius"                             "160"
+        "passive_tree_radius"                             "150"
       }
       "15"
       {

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_4.txt
@@ -11,6 +11,7 @@
     "BaseClass"                                           "item_datadriven"
     "Model"                                               "models/props_gameplay/recipe.vmdl"
     "AbilityTextureName"                                  "custom/recipe/recipe_5"
+
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCorePointCost"                                   "0"
@@ -46,6 +47,7 @@
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_BOTH"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "AbilityTextureName"                                  "custom/greater_tranquils_4"
+
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "18 17 16 15"
@@ -65,7 +67,6 @@
     "MaxUpgradeLevel"                                     "4"
     "ItemBaseLevel"                                       "4"
     "UpgradesItems"                                       "item_greater_tranquil_boots_4"
-    "UpgradeRecipe"                                       "item_recipe_greater_tranquil_boots"
 
     "precache"
     {
@@ -137,7 +138,7 @@
       "12"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "passive_damage_reduction"                        "10 15 20 25"
+        "passive_damage_reduction"                        "10 12 14 16"
       }
       "13"
       {

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_4.txt
@@ -48,7 +48,7 @@
     "AbilityTextureName"                                  "custom/greater_tranquils_4"
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "18"
+    "AbilityCooldown"                                     "18 17 16 15"
     "AbilityManaCost"                                     "75"
     "AbilitySharedCooldown"                               "greater_tranquils"
     "AbilityCastRange"                                    "600 650 700 750"
@@ -87,7 +87,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "2 5 9 14"
+        "bonus_armor"                                     "0"
       }
       "03"
       {
@@ -122,12 +122,52 @@
       "09"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "hp_regen_amp"                                    "50"
+        "projectile_speed"                                "700"
       }
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "projectile_speed"                                "700"
+        "passive_hp_regen_amp"                            "20 22 24 26"
+      }
+      "11"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_heal_amp"                                "25 30 35 40"
+      }
+      "12"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_damage_reduction"                        "10 15 20 25"
+      }
+      "13"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_status_resistance"                       "10 15 20 25"
+      }
+      "14"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_tree_radius"                             "160"
+      }
+      "15"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_hp_regen_amp"                             "50"
+      }
+      "16"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_heal_amp"                                 "50"
+      }
+      "17"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "sprout_vision_range"                             "250"
+      }
+      "18"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "cooldown_tooltip"                                "18 17 16 15"
       }
     }
   }


### PR DESCRIPTION
* Greater Tranquil Boots cooldown reduced from 18 to 18/17/16/15 seconds.
* Greater Tranquil Boots no longer grants bonus armor.
* Greater Tranquil Boots now provides Tree Protection: 20/22/24/26% bonus hp regen amp, 25/30/35/40% bonus heal amp, 10/12/14/16% bonus dmg reduction and 10/15/20/25% bonus status resistance when near trees (150 radius). (Damage reduction works against all damage types. If needed dmg reduction will be nerfed to only reduce physical dmg)
* Greater Tranquil Boots sprout now provides 250 ground vision.
* Greater Tranquil Boots Tranquility buff now also provides 50% heal amp (heals more and receives more healing).
* Greater Tranquil Boots bonus movement speed reduced from 75/80/85/90 to 70/75/80/85.