### PR TITLE
Giant Form buffs

### DIFF
--- a/game/scripts/npc/items/custom/item_giant_form.txt
+++ b/game/scripts/npc/items/custom/item_giant_form.txt
@@ -83,7 +83,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "20 40"
+        "bonus_strength"                                  "70 95"
       }
       "03"
       {
@@ -98,7 +98,7 @@
       "05" // percentage attack speed reduction
       {
         "var_type"                                        "FIELD_INTEGER"
-        "giant_attack_speed_reduction"                    "50"
+        "giant_attack_speed_reduction"                    "30"
       }
       "06" // doesn't work on ranged heroes
       {
@@ -118,7 +118,7 @@
       "09"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "duration"                                        "6.0"
+        "duration"                                        "8.0"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_giant_form_2.txt
+++ b/game/scripts/npc/items/custom/item_giant_form_2.txt
@@ -82,7 +82,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_strength"                                  "20 40"
+        "bonus_strength"                                  "70 95"
       }
       "03"
       {
@@ -97,7 +97,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "giant_attack_speed_reduction"                    "50"
+        "giant_attack_speed_reduction"                    "30"
       }
       "06"
       {
@@ -117,7 +117,7 @@
       "09"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "duration"                                        "6.0"
+        "duration"                                        "8.0"
       }
     }
   }


### PR DESCRIPTION
* Giant Form bonus strength increased from 20/40 to 70/95.
* Giant Form active attack speed reduction decreased from 50% to 30%. (This means that max attack speed while under Giant Form is increased from 350 to 490).
* Giant Form active duration increased from 6 to 8 seconds.