### PR TITLE
Assault Cuirass buffs

### DIFF
--- a/game/scripts/npc/items/item_assault.txt
+++ b/game/scripts/npc/items/item_assault.txt
@@ -64,7 +64,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "10 11 13 16 20"
+        "bonus_armor"                                     "10 11 12 13 14"
       }
       "03"
       {
@@ -79,12 +79,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_positive_armor"                             "5 6 7 8 9"
+        "aura_positive_armor"                             "5 6 8 11 15"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_negative_armor"                             "-5 -6 -7 -8 -9"
+        "aura_negative_armor"                             "-5 -6 -8 -11 -15"
       }
     }
   }

--- a/game/scripts/npc/items/item_assault_2.txt
+++ b/game/scripts/npc/items/item_assault_2.txt
@@ -67,7 +67,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "10 11 13 16 20"
+        "bonus_armor"                                     "10 11 12 13 14"
       }
       "03"
       {
@@ -82,12 +82,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_positive_armor"                             "5 6 7 8 9"
+        "aura_positive_armor"                             "5 6 8 11 15"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_negative_armor"                             "-5 -6 -7 -8 -9"
+        "aura_negative_armor"                             "-5 -6 -8 -11 -15"
       }
     }
   }

--- a/game/scripts/npc/items/item_assault_3.txt
+++ b/game/scripts/npc/items/item_assault_3.txt
@@ -66,7 +66,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "10 11 13 16 20"
+        "bonus_armor"                                     "10 11 12 13 14"
       }
       "03"
       {
@@ -81,12 +81,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_positive_armor"                             "5 6 7 8 9"
+        "aura_positive_armor"                             "5 6 8 11 15"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_negative_armor"                             "-5 -6 -7 -8 -9"
+        "aura_negative_armor"                             "-5 -6 -8 -11 -15"
       }
     }
   }

--- a/game/scripts/npc/items/item_assault_4.txt
+++ b/game/scripts/npc/items/item_assault_4.txt
@@ -66,7 +66,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "10 11 13 16 20"
+        "bonus_armor"                                     "10 11 12 13 14"
       }
       "03"
       {
@@ -81,12 +81,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_positive_armor"                             "5 6 7 8 9"
+        "aura_positive_armor"                             "5 6 8 11 15"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_negative_armor"                             "-5 -6 -7 -8 -9"
+        "aura_negative_armor"                             "-5 -6 -8 -11 -15"
       }
     }
   }

--- a/game/scripts/npc/items/item_assault_5.txt
+++ b/game/scripts/npc/items/item_assault_5.txt
@@ -66,7 +66,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_armor"                                     "10 11 13 16 20"
+        "bonus_armor"                                     "10 11 12 13 14"
       }
       "03"
       {
@@ -81,12 +81,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_positive_armor"                             "5 6 7 8 9"
+        "aura_positive_armor"                             "5 6 8 11 15"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_negative_armor"                             "-5 -6 -7 -8 -9"
+        "aura_negative_armor"                             "-5 -6 -8 -11 -15"
       }
     }
   }


### PR DESCRIPTION
* Assault Cuirass bonus armor reduced from 10/11/13/16/20 to 10/11/12/13/14.
* Assault Cuirass positive armor aura increased from 5/6/7/8/9 to 5/6/8/11/15.
* Assault Cuirass negative armor aura improved from -5/-6/-7/-8/-9 to -5/-6/-8/-11/-15.

Total armor is the same. Aura is just better now. If stacking negative armor items resurfaces as a meta, this item will need a rework or removal.