### PR TITLE
Octarine Buffs

### DIFF
--- a/game/scripts/npc/items/item_octarine_core.txt
+++ b/game/scripts/npc/items/item_octarine_core.txt
@@ -47,7 +47,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_cooldown"                                  "25"
+        "bonus_cooldown"                                  "25 27 29 31 33" //OAA
       }
       "02"
       {

--- a/game/scripts/npc/items/item_octarine_core_2.txt
+++ b/game/scripts/npc/items/item_octarine_core_2.txt
@@ -51,7 +51,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_cooldown"                                  "25"
+        "bonus_cooldown"                                  "25 27 29 31 33" //OAA
       }
       "02"
       {

--- a/game/scripts/npc/items/item_octarine_core_3.txt
+++ b/game/scripts/npc/items/item_octarine_core_3.txt
@@ -51,7 +51,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_cooldown"                                  "25"
+        "bonus_cooldown"                                  "25 27 29 31 33" //OAA
       }
       "02"
       {

--- a/game/scripts/npc/items/item_octarine_core_4.txt
+++ b/game/scripts/npc/items/item_octarine_core_4.txt
@@ -51,7 +51,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_cooldown"                                  "25"
+        "bonus_cooldown"                                  "25 27 29 31 33" //OAA
       }
       "02"
       {

--- a/game/scripts/npc/items/item_octarine_core_5.txt
+++ b/game/scripts/npc/items/item_octarine_core_5.txt
@@ -52,7 +52,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_cooldown"                                  "25"
+        "bonus_cooldown"                                  "25 27 29 31 33" //OAA
       }
       "02"
       {


### PR DESCRIPTION
With the recent changes to how CDR works, it seems many players are no longer favoring Octarine. Octarine CDR doesn't stack with other CDR items or abilities and thus many players opt for something different. This used to scale even when it could be stacked with others and the change to 25 was when cast range was added, but now with the recent changes one can argue we could change it back.