### PR TITLE
Radiance aura buffs

### DIFF
--- a/game/scripts/npc/items/item_radiance.txt
+++ b/game/scripts/npc/items/item_radiance.txt
@@ -36,10 +36,12 @@
     "ID"                                                  "137"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_TOGGLE"
     "AbilityTextureName"                                  "custom/radiance_1"
+
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "1"
+
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "5100"
@@ -48,6 +50,7 @@
     "ItemAliases"                                         "radiance"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_TEAMMATES | DECLARE_PURCHASES_IN_SPEECH | DECLARE_PURCHASES_TO_SPECTATORS"
     "UpgradesItems"                                       "item_radiance;item_radiance_2;item_radiance_3;item_radiance_4"
+
     // Special
     //-------------------------------------------------------------------------------------------------------------
     "AbilitySpecial"
@@ -70,12 +73,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "blind_pct"                                       "17"
+        "blind_pct"                                       "17 18 19 20 21"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_radius"                                     "700"
+        "aura_radius"                                     "700 750 800 850 900"
       }
     }
   }

--- a/game/scripts/npc/items/item_radiance_2.txt
+++ b/game/scripts/npc/items/item_radiance_2.txt
@@ -39,10 +39,12 @@
     "BaseClass"                                           "item_radiance"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_TOGGLE"
     "AbilityTextureName"                                  "custom/radiance_2"
+
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "2"
+
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "6601"
@@ -74,12 +76,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "blind_pct"                                       "17"
+        "blind_pct"                                       "17 18 19 20 21"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_radius"                                     "700"
+        "aura_radius"                                     "700 750 800 850 900"
       }
     }
   }

--- a/game/scripts/npc/items/item_radiance_3.txt
+++ b/game/scripts/npc/items/item_radiance_3.txt
@@ -39,10 +39,12 @@
     "BaseClass"                                           "item_radiance"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_TOGGLE"
     "AbilityTextureName"                                  "custom/radiance_3"
+
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "3"
+
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "10102"
@@ -74,12 +76,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "blind_pct"                                       "17"
+        "blind_pct"                                       "17 18 19 20 21"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_radius"                                     "700"
+        "aura_radius"                                     "700 750 800 850 900"
       }
     }
   }

--- a/game/scripts/npc/items/item_radiance_4.txt
+++ b/game/scripts/npc/items/item_radiance_4.txt
@@ -39,10 +39,12 @@
     "BaseClass"                                           "item_radiance"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_TOGGLE"
     "AbilityTextureName"                                  "custom/radiance_4"
+
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "4"
+
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "18103"
@@ -74,12 +76,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "blind_pct"                                       "17"
+        "blind_pct"                                       "17 18 19 20 21"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_radius"                                     "700"
+        "aura_radius"                                     "700 750 800 850 900"
       }
     }
   }

--- a/game/scripts/npc/items/item_radiance_5.txt
+++ b/game/scripts/npc/items/item_radiance_5.txt
@@ -39,10 +39,12 @@
     "BaseClass"                                           "item_radiance"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_TOGGLE"
     "AbilityTextureName"                                  "custom/radiance_5"
+
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "MaxUpgradeLevel"                                     "5"
     "ItemBaseLevel"                                       "5"
+
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "38104"
@@ -73,12 +75,12 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "blind_pct"                                       "17"
+        "blind_pct"                                       "17 18 19 20 21"
       }
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "aura_radius"                                     "700"
+        "aura_radius"                                     "700 750 800 850 900"
       }
     }
   }


### PR DESCRIPTION
* Radiance Aura miss chance increased from 17% to 17/18/19/20/21%.
* Radiance Aura radius increased from 700 to 700/750/800/850/900.