### PR TITLE
Luna buffs

### DIFF
--- a/game/scripts/npc/abilities/luna_eclipse.txt
+++ b/game/scripts/npc/abilities/luna_eclipse.txt
@@ -28,7 +28,7 @@
 
     // Time
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "120" //OAA
+    "AbilityCooldown"                                     "100" //OAA
     "AbilityDuration"                                     "3.6 5.4 7.2 9.0 10.8" //OAA
 
     // Cost
@@ -47,7 +47,7 @@
       "02" // max beams per unit without scepter
       {
         "var_type"                                        "FIELD_INTEGER"
-        "hit_count"                                       "5"
+        "hit_count"                                       "18"
       }
       "03"
       {

--- a/game/scripts/npc/abilities/talents/luna_talent3.txt
+++ b/game/scripts/npc/abilities/talents/luna_talent3.txt
@@ -1,0 +1,26 @@
+"DOTAAbilities"
+{
+  //=================================================================================================================
+  // Lunar Blessing Damage
+  //=================================================================================================================
+  "special_bonus_unique_luna_3"
+  {
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "ID"					"6682"														// unique ID number for this ability.  Do not change this once established or it will invalidate collected stats.
+    "AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
+    "AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"					"FIELD_INTEGER"
+        "value"				"70" //OAA
+        "ad_linked_ability"			"luna_lunar_blessing"
+      }
+    }
+  }
+}

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -627,6 +627,7 @@
 #base "abilities/talents/lich_talent7.txt"
 #base "abilities/talents/lina_talent3.txt"
 #base "abilities/talents/lone_druid_talent2.txt"
+#base "abilities/talents/luna_talent3.txt"
 #base "abilities/talents/mars_talent1.txt"
 #base "abilities/talents/medusa_talent1.txt"
 #base "abilities/talents/mirana_talent1.txt"


### PR DESCRIPTION
-Ult cd 120->100s, no hit_count limit without aghs
-25 Luna blessing talent 35 -> 70 damage


I was going to change the talent for eclipse cd but honestly I think its fine at 100s. Hit count without aghs gets increasingly stupid as it scales into oaa levels, I don't think it needs to exist but the case can be made for it scaling under beam count. Luna blessing is a shit ability and giving her 105 damage at level 25 seems fine (yes even with Visage Darkonius), not even good I don't think just fine. 

