### PR TITLE
Update creep stacking and player colors

### DIFF
--- a/game/scripts/vscripts/components/creeps/creep_power.lua
+++ b/game/scripts/vscripts/components/creeps/creep_power.lua
@@ -22,15 +22,13 @@ function CreepPower:GetBasePowerForMinute (minute)
     }
   end
 
+  -- Lua tables start at 1; values[1] is minute;
   values[2] = self.numPlayersStatsFactor * values[2]
   values[3] = self.numPlayersStatsFactor * values[3]
   values[4] = self.numPlayersStatsFactor * values[4]
   values[5] = self.numPlayersStatsFactor * values[5]
   values[6] = self.BootGoldFactor * values[6]
   values[7] = self.numPlayersXPFactor * values[7]
-
-  DebugPrint("XP power level v1 is "..tostring(values[7]).." at minute "..tostring(values[1]))
-  DebugPrint("XP power level v2 is "..tostring(values[7]).." at "..tostring(HudTimer:GetGameTime()))
 
   return values
 end

--- a/game/scripts/vscripts/components/creeps/creep_power.lua
+++ b/game/scripts/vscripts/components/creeps/creep_power.lua
@@ -26,7 +26,7 @@ function CreepPower:GetBasePowerForMinute (minute)
   values[2] = self.numPlayersStatsFactor * values[2]
   values[3] = self.numPlayersStatsFactor * values[3]
   values[4] = self.numPlayersStatsFactor * values[4]
-  values[5] = self.numPlayersStatsFactor * values[5]
+  --values[5] = self.numPlayersStatsFactor * values[5] -- Don't scale armor
   values[6] = self.BootGoldFactor * values[6]
   values[7] = self.numPlayersXPFactor * values[7]
 

--- a/game/scripts/vscripts/components/creeps/creep_power.lua
+++ b/game/scripts/vscripts/components/creeps/creep_power.lua
@@ -22,12 +22,15 @@ function CreepPower:GetBasePowerForMinute (minute)
     }
   end
 
-  values[1] = self.numPlayersStatsFactor * values[1]
   values[2] = self.numPlayersStatsFactor * values[2]
   values[3] = self.numPlayersStatsFactor * values[3]
   values[4] = self.numPlayersStatsFactor * values[4]
-  values[5] = self.BootGoldFactor * values[5]
-  values[6] = self.numPlayersXPFactor * values[6]
+  values[5] = self.numPlayersStatsFactor * values[5]
+  values[6] = self.BootGoldFactor * values[6]
+  values[7] = self.numPlayersXPFactor * values[7]
+
+  DebugPrint("XP power level v1 is "..tostring(values[7]).." at minute "..tostring(values[1]))
+  DebugPrint("XP power level v2 is "..tostring(values[7]).." at "..tostring(HudTimer:GetGameTime()))
 
   return values
 end

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -1,6 +1,6 @@
 -- Taken from bb template
 if CreepCamps == nil then
-    Debug.EnabledModules['creeps:*'] = true
+    Debug.EnabledModules['creeps:*'] = false
     DebugPrint ( 'creating new CreepCamps object.' )
     CreepCamps = class({})
 end

--- a/game/scripts/vscripts/components/creeps/spawner.lua
+++ b/game/scripts/vscripts/components/creeps/spawner.lua
@@ -1,6 +1,6 @@
 -- Taken from bb template
 if CreepCamps == nil then
-    Debug.EnabledModules['creeps:*'] = false
+    Debug.EnabledModules['creeps:*'] = true
     DebugPrint ( 'creating new CreepCamps object.' )
     CreepCamps = class({})
 end
@@ -61,9 +61,11 @@ end
 
 function CreepCamps:CreepSpawnTimer ()
   -- scan for creep camps and spawn them
-  -- DebugPrint('[creeps/spawner] Spawning creeps')
+  DebugPrint('CreepCamps Spawning creeps')
   --DeepPrintTable(self.creep_upgrade_table)
   self.creep_upgrade_table = nil
+
+  DebugPrint("CreepPowerLevel at "..tostring(HudTimer:GetGameTime()).." is "..tostring(CreepPowerLevel))
 
   local camps = Entities:FindAllByName('creep_camp')
 
@@ -127,6 +129,9 @@ function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
         found = true
         -- Upgrade only if that unit was not upgraded already in the previous instance of SpawnCreepInCamp
         if not self:IsAlreadyUpgradedAtThisMinute(unit, CreepPowerLevel) then
+          DebugPrint("Standard Upgrade for "..unitProperties[NAME_ENUM].." with index "..tostring(unit:GetEntityIndex()).." at minute"..tostring(CreepPowerLevel))
+          DebugPrint("Old XP v1 for "..unitProperties[NAME_ENUM].." with index "..tostring(unit:GetEntityIndex()).." before minute"..tostring(CreepPowerLevel).." is: "..tostring(unitProperties[EXP_BOUNTY_ENUM]))
+          DebugPrint("Old XP v2 for "..unit:GetUnitName().." with index "..tostring(unit:GetEntityIndex()).." before minute"..tostring(CreepPowerLevel).." is: "..tostring(unit:GetDeathXP()))
           if unitProperties[NAME_ENUM] == "npc_dota_neutral_custom_black_dragon" then
             -- Change stats of the dragons in a unique way
             unitProperties = self:AddCreepPropertiesWithScale(unitProperties, 1.0, newCreepProperties, distributedScale)
@@ -136,6 +141,8 @@ function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
           end
           self:SetCreepPropertiesOnHandle(unit, unitProperties)
           self:MarkAsUpgradedAtThisMinute(unit, CreepPowerLevel, true)
+          DebugPrint("New XP v1 for "..unitProperties[NAME_ENUM].." with index "..tostring(unit:GetEntityIndex()).." at minute"..tostring(CreepPowerLevel).." is: "..tostring(unitProperties[EXP_BOUNTY_ENUM]))
+          DebugPrint("New XP v2 for "..unit:GetUnitName().." with index "..tostring(unit:GetEntityIndex()).." at minute"..tostring(CreepPowerLevel).." is: "..tostring(unit:GetDeathXP()))
         end
       end
     end
@@ -146,9 +153,14 @@ function CreepCamps:SpawnCreepInCamp (location, creepProperties, maximumUnits)
       for _, unit in pairs(units) do
         local unitProperties = self:GetCreepProperties(unit)
         if not self:IsAlreadyUpgradedAtThisMinute(unit, CreepPowerLevel) and not self:AlreadyDidDistributedScaleUpgrade(unit, CreepPowerLevel) then
+          DebugPrint("Distributed Upgrade for "..unitProperties[NAME_ENUM].." with index "..tostring(unit:GetEntityIndex()).." at minute"..tostring(CreepPowerLevel))
+          DebugPrint("Old XP v1 for "..unitProperties[NAME_ENUM].." with index "..tostring(unit:GetEntityIndex()).." before minute"..tostring(CreepPowerLevel).." is: "..tostring(unitProperties[EXP_BOUNTY_ENUM]))
+          DebugPrint("Old XP v2 for "..unit:GetUnitName().." with index "..tostring(unit:GetEntityIndex()).." before minute"..tostring(CreepPowerLevel).." is: "..tostring(unit:GetDeathXP()))
           unitProperties = self:UpgradeCreepProperties(unitProperties, unitProperties, distributedScale)
           self:SetCreepPropertiesOnHandle(unit, unitProperties)
           self:MarkAsUpgradedAtThisMinute(unit, CreepPowerLevel, false)
+          DebugPrint("New XP v1 for "..unitProperties[NAME_ENUM].." with index "..tostring(unit:GetEntityIndex()).." at minute"..tostring(CreepPowerLevel).." is: "..tostring(unitProperties[EXP_BOUNTY_ENUM]))
+          DebugPrint("New XP v2 for "..unit:GetUnitName().." with index "..tostring(unit:GetEntityIndex()).." at minute"..tostring(CreepPowerLevel).." is: "..tostring(unit:GetDeathXP()))
         end
       end
     end
@@ -193,7 +205,7 @@ function CreepCamps:AdjustCreepPropertiesByPowerLevel( creepProperties, powerLev
 
   adjustedCreepProperties[NAME_ENUM] = creepProperties[NAME_ENUM]
   adjustedCreepProperties[HEALTH_ENUM] = creepProperties[HEALTH_ENUM] * creepPowerTable[HEALTH_ENUM]
-  --adjustedCreepProperties[MANA_ENUM] = creepProperties[MANA_ENUM] * creepPowerTable[MANA_ENUM]
+  adjustedCreepProperties[MANA_ENUM] = creepProperties[MANA_ENUM]
   adjustedCreepProperties[DAMAGE_ENUM] = creepProperties[DAMAGE_ENUM] * creepPowerTable[DAMAGE_ENUM]
   adjustedCreepProperties[ARMOR_ENUM] = creepProperties[ARMOR_ENUM] * creepPowerTable[ARMOR_ENUM]
   adjustedCreepProperties[GOLD_BOUNTY_ENUM] = creepProperties[GOLD_BOUNTY_ENUM] * creepPowerTable[GOLD_BOUNTY_ENUM]
@@ -209,10 +221,9 @@ function CreepCamps:AddCreepPropertiesWithScale( propertiesOne, scaleOne, proper
   if addedCreepProperties[HEALTH_ENUM] > propertiesTwo[HEALTH_ENUM] * CREEP_POWER_MAX then
     addedCreepProperties[HEALTH_ENUM] = propertiesTwo[HEALTH_ENUM] * CREEP_POWER_MAX
   end
-  --addedCreepProperties[MANA_ENUM] = propertiesOne[MANA_ENUM] * scaleOne + propertiesTwo[MANA_ENUM] * scaleTwo
-  --if addedCreepProperties[MANA_ENUM] > propertiesTwo[MANA_ENUM] * CREEP_POWER_MAX then
-    --addedCreepProperties[MANA_ENUM] = propertiesTwo[MANA_ENUM] * CREEP_POWER_MAX
-  --end
+
+  addedCreepProperties[MANA_ENUM] = propertiesOne[MANA_ENUM]
+
   addedCreepProperties[DAMAGE_ENUM] = propertiesOne[DAMAGE_ENUM] * scaleOne + propertiesTwo[DAMAGE_ENUM] * scaleTwo
   if addedCreepProperties[DAMAGE_ENUM] > propertiesTwo[DAMAGE_ENUM] * CREEP_POWER_MAX then
     addedCreepProperties[DAMAGE_ENUM] = propertiesTwo[DAMAGE_ENUM] * CREEP_POWER_MAX
@@ -232,7 +243,7 @@ function CreepCamps:UpgradeCreepProperties(propertiesOne, propertiesTwo, scale)
 
   -- Never downgrade stats
   upgradedCreepProperties[HEALTH_ENUM] = math.max(propertiesOne[HEALTH_ENUM], propertiesTwo[HEALTH_ENUM] * scale)
-  --upgradedCreepProperties[MANA_ENUM] = math.max(propertiesOne[MANA_ENUM], propertiesTwo[MANA_ENUM] * scale)
+  upgradedCreepProperties[MANA_ENUM] = propertiesOne[MANA_ENUM]
   upgradedCreepProperties[DAMAGE_ENUM] = math.max(propertiesOne[DAMAGE_ENUM], propertiesTwo[DAMAGE_ENUM] * scale)
   upgradedCreepProperties[ARMOR_ENUM] = math.max(propertiesOne[ARMOR_ENUM], propertiesTwo[ARMOR_ENUM] * scale)
 
@@ -285,11 +296,6 @@ function CreepCamps:MarkAsUpgradedAtThisMinute(creepHandle, minute, found)
 
   if self.creep_upgrade_table[index][minute] == nil then
     self.creep_upgrade_table[index][minute] = {}
-  end
-
-  -- Clear table elements of the previous minute
-  if self.creep_upgrade_table[index][minute-1] ~= nil then
-    self.creep_upgrade_table[index][minute-1] = nil
   end
 
   if found then

--- a/game/scripts/vscripts/components/heroselection/heroselection.lua
+++ b/game/scripts/vscripts/components/heroselection/heroselection.lua
@@ -216,7 +216,6 @@ function HeroSelection:BuildBottlePass()
   CustomNetTables:SetTableValue( 'bottlepass', 'special_arcanas', special_arcanas )
 end
 
-
 function HeroSelection:OnBottleSelected (selectedBottle)
   if HeroSelection.SelectedBottle == nil then HeroSelection.SelectedBottle = {} end
   HeroSelection.SelectedBottle[selectedBottle.PlayerID] = selectedBottle.BottleId
@@ -388,9 +387,9 @@ function HeroSelection:ChooseBans ()
           DebugPrint('Only suggestion was ' .. choice)
         end
       end
-	else
+    else
       DebugPrint('Rolled 0, no bans!')
-	end
+    end
   else
     local skippedBans = 0
     while banCount < totalChoices / 2 do
@@ -819,8 +818,6 @@ function HeroSelection:EndStrategyTime ()
   HeroSelection.shouldBePaused = false
   HeroSelection:CheckPause()
 
-  -- GameRules:SetTimeOfDay(0.25)
-
   if self.isCM then
     PauseGame(true)
   end
@@ -828,7 +825,6 @@ function HeroSelection:EndStrategyTime ()
   -- OnGameInProgress first happens here, I think it's not needed to be here
   DebugPrint("Initializing modules in OnGameInProgress when hero selection is over.")
   GameMode:OnGameInProgress()
-  OnGameInProgressEvent()
 
   self.hasGivenStartingGold = true
   for _,hero in ipairs(self.spawnedHeroes) do

--- a/game/scripts/vscripts/events.lua
+++ b/game/scripts/vscripts/events.lua
@@ -40,7 +40,6 @@ function GameMode:OnGameRulesStateChange(keys)
   elseif newState == DOTA_GAMERULES_STATE_GAME_IN_PROGRESS then
     print("Modules in OnGameInProgress are trying to be initialized again when the state changes to DOTA_GAMERULES_STATE_GAME_IN_PROGRESS.")
     GameMode:OnGameInProgress()
-    OnGameInProgressEvent()
   end
 end
 

--- a/game/scripts/vscripts/internal/events.lua
+++ b/game/scripts/vscripts/internal/events.lua
@@ -34,22 +34,18 @@ function GameMode:_OnGameRulesStateChange(keys)
     GameMode:OnAllPlayersLoaded()
     OnHeroSelectionEvent(keys)
 
-    if USE_CUSTOM_TEAM_COLORS_FOR_PLAYERS then
-      for i=0,19 do
-        if PlayerResource:IsValidPlayer(i) then
-          local color = TEAM_COLORS[PlayerResource:GetTeam(i)]
-          if color then
-            PlayerResource:SetCustomPlayerColor(i, color[1], color[2], color[3])
-          end
-        end
-      end
-    end
+    -- if USE_CUSTOM_TEAM_COLORS_FOR_PLAYERS then
+      -- for i=0,19 do
+        -- if PlayerResource:IsValidPlayer(i) then
+          -- local color = TEAM_COLORS[PlayerResource:GetTeam(i)]
+          -- if color then
+            -- PlayerResource:SetCustomPlayerColor(i, color[1], color[2], color[3])
+          -- end
+        -- end
+      -- end
+    -- end
   elseif newState == DOTA_GAMERULES_STATE_GAME_IN_PROGRESS then
-    if not HeroSelection then
-      print("HeroSelection doesn't exist for some reason, -> initialize modules in OnGameInProgress when the state changes to DOTA_GAMERULES_STATE_GAME_IN_PROGRESS.")
-      GameMode:OnGameInProgress()
-      OnGameInProgressEvent()
-    end
+    OnGameInProgressEvent()
   end
 
   GameMode._reentrantCheck = true
@@ -103,11 +99,10 @@ function GameMode:_OnEntityKilled( keys )
       GameRules:SetGameWinner( killerTeam )
     end
 
-    --PlayerResource:GetTeamKills
-    if SHOW_KILLS_ON_TOPBAR then
-      GameRules:GetGameModeEntity():SetTopBarTeamValue ( DOTA_TEAM_BADGUYS, GetTeamHeroKills(DOTA_TEAM_BADGUYS) )
-      GameRules:GetGameModeEntity():SetTopBarTeamValue ( DOTA_TEAM_GOODGUYS, GetTeamHeroKills(DOTA_TEAM_GOODGUYS) )
-    end
+    -- if SHOW_KILLS_ON_TOPBAR then
+      -- GameRules:GetGameModeEntity():SetTopBarTeamValue ( DOTA_TEAM_BADGUYS, GetTeamHeroKills(DOTA_TEAM_BADGUYS) )
+      -- GameRules:GetGameModeEntity():SetTopBarTeamValue ( DOTA_TEAM_GOODGUYS, GetTeamHeroKills(DOTA_TEAM_GOODGUYS) )
+    -- end
 
     keys.killer = killerEntity
     keys.killed = killedUnit

--- a/game/scripts/vscripts/internal/gamemode.lua
+++ b/game/scripts/vscripts/internal/gamemode.lua
@@ -54,7 +54,7 @@ function GameMode:_InitGameMode()
   if USE_AUTOMATIC_PLAYERS_PER_TEAM then
     local num = math.floor(10 / MAX_NUMBER_OF_TEAMS)
     local count = 0
-    for team,number in pairs(TEAM_COLORS) do
+    for team, number in pairs(TEAM_COLORS) do
       if count >= MAX_NUMBER_OF_TEAMS then
         GameRules:SetCustomGameTeamMaxPlayers(team, 0)
       else
@@ -64,7 +64,7 @@ function GameMode:_InitGameMode()
     end
   else
     local count = 0
-    for team,number in pairs(CUSTOM_TEAM_PLAYER_COUNT) do
+    for team, number in pairs(CUSTOM_TEAM_PLAYER_COUNT) do
       if count >= MAX_NUMBER_OF_TEAMS then
         GameRules:SetCustomGameTeamMaxPlayers(team, 0)
       else
@@ -75,7 +75,7 @@ function GameMode:_InitGameMode()
   end
 
   if USE_CUSTOM_TEAM_COLORS then
-    for team,color in pairs(TEAM_COLORS) do
+    for team, color in pairs(TEAM_COLORS) do
       SetTeamCustomHealthbarColor(team, color[1], color[2], color[3])
     end
   end


### PR DESCRIPTION
* Reduced radius of camps from 600 to 400. (This means camps are easier to be stacked by players and there is less chance for camps to overlap)
* Fixed an edge case where full camps were stacking multiple times at the minute mark if the creeps in those camps are of the same type (e.g. all ghosts in 1 hard camp).
* Decreased the chance for those camps to have 1 creep that is worth more than Ancients, Corner Dragons, or Mini-Roshans. XP bounty would go to craizy numbers. 
* XP bounty of creeps is now being rounded down (math.floor) instead of being rounded up (math.ceil).
* Fixed OnGameInProgressEvent() being called in 3 different places instead of in only 1 place.
* Hopefully fixed player colors in the kill feed and chat this time.
* Disabled lines with SetTopBarTeamValue, it doesn't work since Diretide 2020 and we don't use it anyway.