### PR TITLE
small fix to techies PR

### DIFF
--- a/game/scripts/npc/abilities/techies_land_mines.txt
+++ b/game/scripts/npc/abilities/techies_land_mines.txt
@@ -45,7 +45,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "proximity_threshold"                             "1.6"
+        "proximity_threshold"                             "1.6 1.6 1.6 1.6 1.38 1.15"
       }
       "03"
       {


### PR DESCRIPTION
In further testing I have come to realized that the proximity threshold is what I intended to change alongside the delay as this meant techies mines didn't actually get changed on oaa levels other than in situations when techies had just put the mines down. This was not the intended effect. I've scaled the proximity threshold in accordance to how the original numbers were calculated. 1.6/1.75 is 0.91428571428 so I simply used that number and multiplied it by the new delay numbers than rounded to a whole number. Tell me if you want to take a different approach in calculations.