### PR TITLE
Fix for Abaddon's Borrowed Time talent

### DIFF
--- a/game/scripts/vscripts/abilities/oaa_abaddon_borrowed_time.lua
+++ b/game/scripts/vscripts/abilities/oaa_abaddon_borrowed_time.lua
@@ -8,6 +8,19 @@ function abaddon_borrowed_time_oaa:GetIntrinsicModifierName()
   return "modifier_oaa_borrowed_time_passive"
 end
 
+function abaddon_borrowed_time_oaa:GetCooldown(level)
+  local caster = self:GetCaster()
+  local base_cd = self.BaseClass.GetCooldown(self, level)
+
+  -- Let's see if Valve made FindAbilityByName available on the client
+  local talent = caster:FindAbilityByName("special_bonus_unique_abaddon_5")
+  if talent and talent:GetLevel() > 0 then
+    return base_cd - math.abs(talent:GetSpecialValueFor("value"))
+  end
+
+  return base_cd
+end
+
 function abaddon_borrowed_time_oaa:OnSpellStart()
   if IsServer() then
     local caster = self:GetCaster()


### PR DESCRIPTION
Fixed Abaddon's Level 20 Talent: ```-8s Borrowed Time Cooldown``` not working.