### PR TITLE
Cleave Spark nerf

### DIFF
--- a/game/resource/English/modifier/tooltip_modifier_sparks.txt
+++ b/game/resource/English/modifier/tooltip_modifier_sparks.txt
@@ -1,5 +1,5 @@
 "DOTA_Tooltip_modifier_spark_cleave"                      "Cleave Spark"
-"DOTA_Tooltip_modifier_spark_cleave_Description"          "Deals 50%% of attack damage as physical damage to up to 4 random neutral creeps in 400 radius around the attacked target." // 50%% more gold from killing neutral creeps."
+"DOTA_Tooltip_modifier_spark_cleave_Description"          "Deals 35%% of attack damage as physical damage to up to 4 random neutral creeps in 400 radius around the attacked target." // 50%% more gold from killing neutral creeps."
 
 "DOTA_Tooltip_modifier_spark_gpm"                         "GPM Spark"
 //"DOTA_Tooltip_modifier_spark_gpm_Description"             "Grants %dMODIFIER_PROPERTY_TOOLTIP% gold per minute."

--- a/game/scripts/vscripts/modifiers/sparks/modifier_spark_cleave.lua
+++ b/game/scripts/vscripts/modifiers/sparks/modifier_spark_cleave.lua
@@ -73,8 +73,8 @@ function modifier_spark_cleave:OnAttackLanded(keys)
 
   -- Cleave Spark variables
   local splinter_radius = 400
-  local splinter_count = 4
-  local splinter_damage_percent = 50
+  local splinter_count = 5
+  local splinter_damage_percent = 35
 
   local originTarget = target:GetOrigin()
 
@@ -85,7 +85,7 @@ function modifier_spark_cleave:OnAttackLanded(keys)
     splinter_radius,
     DOTA_UNIT_TARGET_TEAM_ENEMY,
     DOTA_UNIT_TARGET_BASIC,
-    bit.bor(DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE, DOTA_UNIT_TARGET_FLAG_NO_INVIS),
+    bit.bor(DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, DOTA_UNIT_TARGET_FLAG_NO_INVIS),
     FIND_ANY_ORDER,
     false
   )


### PR DESCRIPTION
* Cleave/Splinter damage reduced from 50% to 35%.
* Cleave/Splinter number of units increased from 4 to 5.
* Cleave Spark will now work on neutral units hidden in fog of war.

Feel free to close the PR if you don't agree with this change.