### PR TITLE
Cleaver damage against creeps

### DIFF
--- a/game/scripts/npc/items/item_bfury.txt
+++ b/game/scripts/npc/items/item_bfury.txt
@@ -75,7 +75,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cleave_damage_percent_creep"                     "30 50 70 90 110" //OAA
+        "cleave_damage_percent_creep"                     "40 60 80 100 120"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_bfury_2.txt
+++ b/game/scripts/npc/items/item_bfury_2.txt
@@ -80,7 +80,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cleave_damage_percent_creep"                     "30 50 70 90 110" //OAA
+        "cleave_damage_percent_creep"                     "40 60 80 100 120"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_bfury_3.txt
+++ b/game/scripts/npc/items/item_bfury_3.txt
@@ -80,7 +80,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cleave_damage_percent_creep"                     "30 50 70 90 110" //OAA
+        "cleave_damage_percent_creep"                     "40 60 80 100 120"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_bfury_4.txt
+++ b/game/scripts/npc/items/item_bfury_4.txt
@@ -81,7 +81,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cleave_damage_percent_creep"                     "30 50 70 90 110" //OAA
+        "cleave_damage_percent_creep"                     "40 60 80 100 120"
       }
       "06"
       {

--- a/game/scripts/npc/items/item_bfury_5.txt
+++ b/game/scripts/npc/items/item_bfury_5.txt
@@ -81,7 +81,7 @@
       "05"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "cleave_damage_percent_creep"                     "30 50 70 90 110" //OAA
+        "cleave_damage_percent_creep"                     "40 60 80 100 120"
       }
       "06"
       {


### PR DESCRIPTION
There is no reason for this to be nerfed anymore. This is a remnant from a time when cleave damage was pure and when first capture point was at 5 minutes. This change can't hurt, it can only make cleaver better against some heroes with summons (like NP) and better against some bosses.