### PR TITLE
Adjust Final Duel comeback compensation

### DIFF
--- a/game/scripts/vscripts/components/duels/final-duel.lua
+++ b/game/scripts/vscripts/components/duels/final-duel.lua
@@ -69,6 +69,7 @@ function FinalDuel:StartDuelHandler (keys)
   local badPoints = PointsManager:GetPoints(DOTA_TEAM_BADGUYS)
   self.goodCanWin = goodPoints >= limit
   self.badCanWin = badPoints >= limit
+  self.pointDifference = math.abs(goodPoints - badPoints)
 
   if self.isCurrentlyFinalDuel then
     local extraMessage = ""
@@ -122,7 +123,12 @@ function FinalDuel:EndDuelHandler (currentDuel)
   PointsManager:IncreaseLimit()
 
   -- Give points to winners as a comeback compensation
-  local pointAward = math.ceil(PlayerResource:SafeGetTeamPlayerCount() / 2)
+  local playerCount = PlayerResource:SafeGetTeamPlayerCount()
+  local pointAward = math.ceil(playerCount / 20) * self.pointDifference
+  -- Capping the reward
+  if pointAward > playerCount then
+    pointAward = playerCount
+  end
   -- If the loser is DOTA_TEAM_BADGUYS and they had a chance to win, give points to DOTA_TEAM_GOODGUYS
   if loser == "bad" and self.badCanWin then
     PointsManager:AddPoints(DOTA_TEAM_GOODGUYS, pointAward)


### PR DESCRIPTION
* Point Award for winning a final duel changed from _playercount / 2_ to **playercount x score_difference / 20**.
* Capped the final duel point award to **playercount**. (6 players -> 6 points, 10 players -> 10 points). This is possible only if score difference is >= 20.