### PR TITLE
Duel Runes Update

### DIFF
--- a/game/resource/English/modifier/tooltip_modifier_duel_rune_hill.txt
+++ b/game/resource/English/modifier/tooltip_modifier_duel_rune_hill.txt
@@ -1,8 +1,11 @@
 //=============================================================================
-// Duel highground rune stuff
+// Duel "highground" rune stuff
 //=============================================================================
-"DOTA_Tooltip_modifier_duel_rune_hill"                  "High Ground Advantage"
-"DOTA_Tooltip_modifier_duel_rune_hill_Description"      "By holding the highground in a duel you gain rune effects and powerful buffs. Counter resets if an enemy hero gets near you or you take damage from any source."
+"DOTA_Tooltip_modifier_duel_rune_hill"                  "Rune Zone Advantage"
+"DOTA_Tooltip_modifier_duel_rune_hill_Description"      "When standing in the marked zone in a duel you gain rune effects and powerful buffs. Counter resets if an enemy hero gets near you or you take damage from a non-neutral source."
 
 "DOTA_Tooltip_modifier_rune_hill_tripledamage"                  "Triple Damage"
 "DOTA_Tooltip_modifier_rune_hill_tripledamage_Description"      "Double damage wasn't enough"
+
+"DOTA_Tooltip_modifier_rune_hill_super_sight"                   "Super Sight"
+"DOTA_Tooltip_modifier_rune_hill_super_sight_Description"       "True Sight and unobstructed vision"

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -121,7 +121,7 @@ end
 function Duels:RegisterZone(zoneName)
   self.zones = self.zones or {}
   local zoneExists = Entities:FindAllByName(zoneName)
-  if zoneExists and #zoneExists > 0  then
+  if zoneExists and #zoneExists > 0 then
     table.insert(
       self.zones,
       ZoneControl:CreateZone(zoneName, {

--- a/game/scripts/vscripts/components/duels/runes.lua
+++ b/game/scripts/vscripts/components/duels/runes.lua
@@ -16,8 +16,7 @@ function DuelRunes:Init ()
       mode = ZONE_CONTROL_EXCLUSIVE_OUT,
       margin = 0,
       padding = 0,
-      players = {
-      }
+      players = {}
     })
 
     runeHill.onStartTouch(DuelRunes.StartTouch)
@@ -25,12 +24,12 @@ function DuelRunes:Init ()
   end
 
   Duels.onEnd(function()
+    DuelRunes.active = false
     Timers:RemoveTimer('DuelRunes')
   end)
 
   Duels.onStart(function()
     DuelRunes.active = false
-
     Timers:RemoveTimer('DuelRunes')
     Timers:CreateTimer('DuelRunes', {
       endTime = DUEL_RUNE_TIMER,

--- a/game/scripts/vscripts/libraries/basenpc.lua
+++ b/game/scripts/vscripts/libraries/basenpc.lua
@@ -38,7 +38,6 @@ if IsServer() then
       "modifier_item_shadow_amulet_fade",
       "modifier_item_invisibility_edge_windwalk",
       "modifier_item_silver_edge_windwalk",
-      "modifier_rune_invis",
       "modifier_item_blade_mail_reflect",
       "modifier_item_lotus_orb_active",
       "modifier_item_sphere_target",               -- Linken's Sphere transferred buff
@@ -148,6 +147,12 @@ if IsServer() then
       "modifier_windrunner_windrun_invis",
       "modifier_alpha_invisibility_oaa_buff",   -- Neutral Alpha Wolf invisibility buff
     }
+
+    local undispellable_rune_modifiers = {
+      "modifier_rune_invis",
+      "modifier_rune_hill_tripledamage",
+      "modifier_rune_hill_super_sight",
+    }
     -- These are mostly transformation buffs, add them to the list above if they don't crash or break the ability and if fair
     local problematic_modifiers = {
       "modifier_abaddon_borrowed_time",         -- transformation modifier and an ultimate
@@ -201,6 +206,7 @@ if IsServer() then
     RemoveTableOfModifiersFromUnit(self, undispellable_item_debuffs)
     RemoveTableOfModifiersFromUnit(self, undispellable_ability_debuffs)
     RemoveTableOfModifiersFromUnit(self, undispellable_ability_buffs)
+    RemoveTableOfModifiersFromUnit(self, undispellable_rune_modifiers)
 
     -- Dispel stuff
     local BuffsCreatedThisFrameOnly = false

--- a/game/scripts/vscripts/modifiers/modifier_duel_rune_hill.lua
+++ b/game/scripts/vscripts/modifiers/modifier_duel_rune_hill.lua
@@ -1,5 +1,6 @@
 LinkLuaModifier('modifier_duel_rune_hill_enemy', 'modifiers/modifier_duel_rune_hill.lua', LUA_MODIFIER_MOTION_NONE)
 LinkLuaModifier('modifier_rune_hill_tripledamage', 'modifiers/modifier_rune_hill_tripledamage.lua', LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier('modifier_rune_hill_super_sight', 'modifiers/modifier_rune_hill_super_sight.lua', LUA_MODIFIER_MOTION_NONE)
 
 modifier_duel_rune_hill = class(ModifierBaseClass)
 modifier_duel_rune_hill_enemy = class(ModifierBaseClass)
@@ -9,6 +10,9 @@ function modifier_duel_rune_hill_enemy:IsHidden()
 end
 
 function modifier_duel_rune_hill:OnCreated()
+  if not IsServer() then
+    return
+  end
   self:StartIntervalThink(0.1)
   self:SetStackCount(0)
 end
@@ -29,11 +33,11 @@ function modifier_duel_rune_hill:GetAuraSearchTeam()
 end
 
 function modifier_duel_rune_hill:GetAuraSearchFlags()
-  return bit.bor(DOTA_UNIT_TARGET_FLAG_INVULNERABLE, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES)
+  return bit.bor(DOTA_UNIT_TARGET_FLAG_INVULNERABLE, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, DOTA_UNIT_TARGET_FLAG_OUT_OF_WORLD)
 end
 
 function modifier_duel_rune_hill:GetAuraRadius()
-  return 2000
+  return 1200
 end
 
 function modifier_duel_rune_hill:GetModifierAura()
@@ -61,13 +65,13 @@ function modifier_duel_rune_hill:DeclareFunctions()
 end
 
 function modifier_duel_rune_hill:OnIntervalThink()
-  local unit = self:GetCaster() or self:GetParent()
-
   if not IsServer() then
     return
   end
 
-  if unit:IsClone() or unit:IsTempestDouble() then
+  local unit = self:GetParent()
+
+  if unit:IsClone() or unit:IsTempestDouble() or unit:IsInvulnerable() or unit:IsOutOfGame() then
     return
   end
 
@@ -76,14 +80,16 @@ function modifier_duel_rune_hill:OnIntervalThink()
     return
   end
 
-  if self:GetStackCount() == 130 then
+  if self:GetStackCount() == 200 then
+    return
+  end
+
+  if not DuelRunes or not DuelRunes.active then
+    self:SetStackCount(0)
     return
   end
 
   local stackCount = self:GetStackCount() + 1
-  if not DuelRunes or not DuelRunes.active then
-    stackCount = 0
-  end
 
   local rewardTable = {
     [30] = "modifier_rune_regen",
@@ -92,26 +98,28 @@ function modifier_duel_rune_hill:OnIntervalThink()
     [100] = "modifier_rune_doubledamage",
     [110] = "modifier_rune_invis",
     [120] = "modifier_rune_regen",
-    [130] = "modifier_rune_hill_tripledamage",
+    [130] = "modifier_rune_arcane",
+    [150] = "modifier_rune_hill_tripledamage",
+    [200] = "modifier_rune_hill_super_sight",
   }
 
   self:SetStackCount(stackCount)
 
   if rewardTable[stackCount] ~= nil and unit.AddNewModifier then
-    unit:AddNewModifier(unit, nil, rewardTable[stackCount], {
-      duration = 60
-    })
+    unit:AddNewModifier(unit, nil, rewardTable[stackCount], { duration = 50 })
   end
 
   local particleTable = {
-    [1]  = "particles/econ/items/tinker/boots_of_travel/teleport_end_bots_spiral_b.vpcf",
+    [1] = "particles/econ/items/tinker/boots_of_travel/teleport_end_bots_spiral_b.vpcf",
     [30] = "particles/items2_fx/mekanism.vpcf",
     [80] = "particles/units/heroes/hero_phantom_lancer/phantom_lancer_doppleganger_illlmove.vpcf",
     [90] = "particles/items2_fx/mekanism.vpcf",
-    [100]= "particles/econ/items/tinker/boots_of_travel/teleport_end_bots_flare.vpcf",
-    [110]= "particles/econ/items/gyrocopter/hero_gyrocopter_gyrotechnics/gyro_guided_missle_explosion_smoke.vpcf",
-    [120]= "particles/items2_fx/mekanism.vpcf",
-    [130]= "particles/econ/items/tinker/boots_of_travel/teleport_end_bots_flare.vpcf",
+    [100] = "particles/econ/items/tinker/boots_of_travel/teleport_end_bots_flare.vpcf",
+    [110] = "particles/econ/items/gyrocopter/hero_gyrocopter_gyrotechnics/gyro_guided_missle_explosion_smoke.vpcf",
+    [120] = "particles/items2_fx/mekanism.vpcf",
+    [130] = "particles/items2_fx/mekanism.vpcf",
+    [150] = "particles/econ/items/tinker/boots_of_travel/teleport_end_bots_flare.vpcf",
+    [200] = "particles/econ/items/tinker/boots_of_travel/teleport_end_bots_flare.vpcf",
   }
 
   if particleTable[stackCount] ~= nil and unit then
@@ -122,7 +130,15 @@ function modifier_duel_rune_hill:OnIntervalThink()
 end
 
 function modifier_duel_rune_hill:OnTakeDamage(keys)
+  if not IsServer() then
+    return
+  end
+
   if keys.unit ~= self:GetParent() then
+    return
+  end
+
+  if keys.attacker and keys.attacker:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
     return
   end
 

--- a/game/scripts/vscripts/modifiers/modifier_rune_hill_super_sight.lua
+++ b/game/scripts/vscripts/modifiers/modifier_rune_hill_super_sight.lua
@@ -1,0 +1,66 @@
+
+modifier_rune_hill_super_sight = class(ModifierBaseClass)
+
+function modifier_rune_hill_super_sight:IsHidden()
+  return false
+end
+
+function modifier_rune_hill_super_sight:IsPurgable()
+  return false
+end
+
+function modifier_rune_hill_super_sight:GetTexture()
+  return "item_gem"
+end
+
+function modifier_rune_hill_super_sight:OnCreated()
+  if not IsServer() then
+    return
+  end
+  self:StartIntervalThink(0.1)
+end
+
+function modifier_rune_hill_super_sight:OnIntervalThink()
+  if not IsServer() then
+    return
+  end
+
+  if not Duels:IsActive() then
+    self:StartIntervalThink(-1)
+    self:Destroy()
+    return
+  end
+end
+
+-- Flying Vision
+function modifier_rune_hill_super_sight:CheckState()
+  local state = {
+    [MODIFIER_STATE_FORCED_FLYING_VISION] = true,
+  }
+  return state
+end
+
+-- TrueSight part:
+function modifier_rune_hill_super_sight:IsAura()
+  return true
+end
+
+function modifier_rune_hill_super_sight:GetAuraSearchTeam()
+  return DOTA_UNIT_TARGET_TEAM_ENEMY
+end
+
+function modifier_rune_hill_super_sight:GetAuraSearchType()
+  return DOTA_UNIT_TARGET_ALL
+end
+
+function modifier_rune_hill_super_sight:GetAuraSearchFlags()
+  return bit.bor(DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, DOTA_UNIT_TARGET_FLAG_INVULNERABLE)
+end
+
+function modifier_rune_hill_super_sight:GetModifierAura()
+  return "modifier_truesight"
+end
+
+function modifier_rune_hill_super_sight:GetAuraRadius()
+  return 800
+end

--- a/game/scripts/vscripts/modifiers/modifier_rune_hill_super_sight.lua
+++ b/game/scripts/vscripts/modifiers/modifier_rune_hill_super_sight.lua
@@ -9,6 +9,14 @@ function modifier_rune_hill_super_sight:IsPurgable()
   return false
 end
 
+function modifier_rune_hill_super_sight:GetEffectName()
+  return "particles/econ/courier/courier_greevil_white/courier_greevil_white_ambient_3.vpcf"
+end
+
+function modifier_rune_hill_super_sight:GetEffectAttachType()
+  return PATTACH_ABSORIGIN_FOLLOW
+end
+
 function modifier_rune_hill_super_sight:GetTexture()
   return "item_gem"
 end

--- a/game/scripts/vscripts/modifiers/modifier_rune_hill_tripledamage.lua
+++ b/game/scripts/vscripts/modifiers/modifier_rune_hill_tripledamage.lua
@@ -1,6 +1,39 @@
 
 modifier_rune_hill_tripledamage = class(ModifierBaseClass)
 
+function modifier_rune_hill_tripledamage:IsHidden()
+  return false
+end
+
+function modifier_rune_hill_tripledamage:IsPurgable()
+  return false
+end
+
+function modifier_rune_hill_tripledamage:OnCreated()
+  if not IsServer() then
+    return
+  end
+  self:StartIntervalThink(0.1)
+end
+
+function modifier_rune_hill_tripledamage:OnIntervalThink()
+  if not IsServer() then
+    return
+  end
+
+  if not Duels:IsActive() then
+    self:StartIntervalThink(-1)
+    self:Destroy()
+    return
+  end
+
+  local parent = self:GetParent()
+
+  if parent:HasModifier("modifier_rune_doubledamage") then
+    parent:RemoveModifierByName("modifier_rune_doubledamage")
+  end
+end
+
 function modifier_rune_hill_tripledamage:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE
@@ -8,7 +41,7 @@ function modifier_rune_hill_tripledamage:DeclareFunctions()
 end
 
 function modifier_rune_hill_tripledamage:GetModifierBaseDamageOutgoing_Percentage()
-  return 100
+  return 200
 end
 
 function modifier_rune_hill_tripledamage:GetTexture()

--- a/game/scripts/vscripts/modifiers/modifier_rune_hill_tripledamage.lua
+++ b/game/scripts/vscripts/modifiers/modifier_rune_hill_tripledamage.lua
@@ -44,6 +44,14 @@ function modifier_rune_hill_tripledamage:GetModifierBaseDamageOutgoing_Percentag
   return 200
 end
 
+function modifier_rune_hill_tripledamage:GetEffectName()
+  return "particles/generic_gameplay/rune_doubledamage_owner.vpcf"
+end
+
+function modifier_rune_hill_tripledamage:GetEffectAttachType()
+  return PATTACH_ABSORIGIN_FOLLOW
+end
+
 function modifier_rune_hill_tripledamage:GetTexture()
   return "rune_doubledamage"
 end


### PR DESCRIPTION
* Duel rune zones will no longer be active when duels are not in progress.
* Disabled all modifier code related to duel runes working clientside. It's only on the server now.
* Duel Rune counter will no longer tick if the unit on the zone is invulnerable or banished.
* Triple Damage now requires 150 stacks instead of 130.
* Triple Damage is now undispellable.
* Triple Damage now dispels Double Damage buff to avoid confusion of having 2 buffs with the same icon that basically do the same thing.
* New Duel Rune: **Arcane Rune**, needs 130 stacks. (like old Triple Damage)
* New Duel Rune: **Super Sight**, needs 200 stacks (it requires around 20 seconds of standing in the zone). Super Sight provides true sight and unobstructed vision.
* Duel Runes duration reduced from 60 to 50 seconds.
* Duel Runes counter is no longer reset when taking damage from neutrals.
* Updated Duel Runes tooltips - it's not the high-ground advantage in every duel arena.