### PR TITLE
Remove item tree abuse

### DIFF
--- a/game/scripts/npc/items/custom/item_ghost_king_bar.txt
+++ b/game/scripts/npc/items/custom/item_ghost_king_bar.txt
@@ -57,7 +57,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "100"
-    "ItemCost"                                            "7402"
+    "ItemCost"                                            "9302"
     "ItemShopTags"                                        "agi;str;int;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"

--- a/game/scripts/npc/items/custom/item_ghost_king_bar.txt
+++ b/game/scripts/npc/items/custom/item_ghost_king_bar.txt
@@ -26,7 +26,6 @@
     "ItemRequirements"
     {
       "01"                                                "item_ethereal_blade_2;item_upgrade_core_2"
-      "02"                                                "item_holy_locket_2;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/custom/item_ghost_king_bar_2.txt
+++ b/game/scripts/npc/items/custom/item_ghost_king_bar_2.txt
@@ -58,7 +58,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "100"
-    "ItemCost"                                            "15403"
+    "ItemCost"                                            "17303"
     "ItemShopTags"                                        "agi;str;int;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"

--- a/game/scripts/npc/items/custom/item_ghost_king_bar_3.txt
+++ b/game/scripts/npc/items/custom/item_ghost_king_bar_3.txt
@@ -57,7 +57,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "100"
-    "ItemCost"                                            "35404"
+    "ItemCost"                                            "37304"
     "ItemShopTags"                                        "agi;str;int;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"

--- a/game/scripts/npc/items/custom/item_heart_transplant.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant.txt
@@ -26,7 +26,7 @@
     {
       "01"                                                "item_heart_3;item_upgrade_core_3"
       //"02"                                                "item_crimson_guard_3;item_upgrade_core_3"
-      "03"                                                "item_regen_crystal_1;item_upgrade_core_3"
+      "02"                                                "item_regen_crystal_1;item_upgrade_core_3"
     }
   }
 
@@ -58,7 +58,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "200"
-    "ItemCost"                                            "16603"
+    "ItemCost"                                            "17303"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemShopTags"                                        "armor;regen_mana;hard_to_tag"
     "ItemQuality"                                         "rare"

--- a/game/scripts/npc/items/custom/item_heart_transplant.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant.txt
@@ -25,7 +25,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_heart_3;item_upgrade_core_3"
-      "02"                                                "item_crimson_guard_3;item_upgrade_core_3"
+      //"02"                                                "item_crimson_guard_3;item_upgrade_core_3"
       "03"                                                "item_regen_crystal_1;item_upgrade_core_3"
     }
   }

--- a/game/scripts/npc/items/custom/item_heart_transplant_2.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant_2.txt
@@ -57,7 +57,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "200"
-    "ItemCost"                                            "36604"
+    "ItemCost"                                            "37304"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemShopTags"                                        "armor;regen_mana;hard_to_tag"
     "ItemQuality"                                         "rare"

--- a/game/scripts/npc/items/custom/item_reduction_orb_3.txt
+++ b/game/scripts/npc/items/custom/item_reduction_orb_3.txt
@@ -26,8 +26,8 @@
     {
       "01"                                                "item_heart_4;item_upgrade_core_4"
       //"02"                                                "item_crimson_guard_4;item_upgrade_core_4"
-      "03"                                                "item_regen_crystal_2;item_upgrade_core_4"
-      "04"                                                "item_heart_transplant;item_upgrade_core_4"
+      "02"                                                "item_regen_crystal_2;item_upgrade_core_4"
+      "03"                                                "item_heart_transplant;item_upgrade_core_4"
     }
   }
 
@@ -57,7 +57,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "36604"
+    "ItemCost"                                            "37304"
     "ItemShopTags"                                        "defense;support;mobility;hard_to_tag"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "Reduction orb"

--- a/game/scripts/npc/items/custom/item_reduction_orb_3.txt
+++ b/game/scripts/npc/items/custom/item_reduction_orb_3.txt
@@ -25,7 +25,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_heart_4;item_upgrade_core_4"
-      "02"                                                "item_crimson_guard_4;item_upgrade_core_4"
+      //"02"                                                "item_crimson_guard_4;item_upgrade_core_4"
       "03"                                                "item_regen_crystal_2;item_upgrade_core_4"
       "04"                                                "item_heart_transplant;item_upgrade_core_4"
     }

--- a/game/scripts/npc/items/custom/item_reflection_shard_1.txt
+++ b/game/scripts/npc/items/custom/item_reflection_shard_1.txt
@@ -24,8 +24,8 @@
     "ItemResult"                                          "item_reflection_shard_1"
     "ItemRequirements"
     {
-      "01"                                                "item_sphere;item_upgrade_core"
-      "02"                                                "item_lotus_orb;item_upgrade_core"
+      "01"                                                "item_lotus_orb;item_upgrade_core"
+      "02"                                                "item_sphere;item_upgrade_core"
     }
   }
 

--- a/game/scripts/npc/items/custom/item_regen_crystal_1.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_1.txt
@@ -53,7 +53,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "75"
-    "ItemCost"                                            "8602"
+    "ItemCost"                                            "9302"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "regen crystal"

--- a/game/scripts/npc/items/custom/item_regen_crystal_1.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_1.txt
@@ -25,7 +25,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_heart_2;item_upgrade_core_2"
-      "02"                                                "item_crimson_guard_2;item_upgrade_core_2"
+      //"02"                                                "item_crimson_guard_2;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/custom/item_regen_crystal_2.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_2.txt
@@ -54,7 +54,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "75"
-    "ItemCost"                                            "16603"
+    "ItemCost"                                            "17303"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "regen crystal 2"

--- a/game/scripts/npc/items/custom/item_regen_crystal_3.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_3.txt
@@ -55,7 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "75"
-    "ItemCost"                                            "36604"
+    "ItemCost"                                            "37304"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "regen crystal 3"

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves_2.txt
@@ -54,7 +54,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "0"
-    "ItemCost"                                            "5927"
+    "ItemCost"                                            "8702"
     "ItemShopTags"                                        "int;armor;regen_health;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "greater guardian greaves 2;guardian greaves 2;ggg 2"

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves_2.txt
@@ -25,10 +25,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_guardian_greaves;item_upgrade_core_2"
-      "02"                                                "item_greater_tranquil_boots;item_upgrade_core_2"
-      "03"                                                "item_greater_travel_boots;item_upgrade_core_2"
-      "04"                                                "item_greater_phase_boots;item_upgrade_core_2"
-      "05"                                                "item_greater_power_treads;item_upgrade_core_2"
+      //"02"                                                "item_greater_tranquil_boots;item_upgrade_core_2"
+      //"03"                                                "item_greater_travel_boots;item_upgrade_core_2"
+      //"04"                                                "item_greater_phase_boots;item_upgrade_core_2"
+      //"05"                                                "item_greater_power_treads;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves_3.txt
@@ -25,10 +25,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_guardian_greaves_2;item_upgrade_core_3"
-      "02"                                                "item_greater_tranquil_boots_2;item_upgrade_core_3"
-      "03"                                                "item_greater_travel_boots_2;item_upgrade_core_3"
-      "04"                                                "item_greater_phase_boots_2;item_upgrade_core_3"
-      "05"                                                "item_greater_power_treads_2;item_upgrade_core_3"
+      //"02"                                                "item_greater_tranquil_boots_2;item_upgrade_core_3"
+      //"03"                                                "item_greater_travel_boots_2;item_upgrade_core_3"
+      //"04"                                                "item_greater_phase_boots_2;item_upgrade_core_3"
+      //"05"                                                "item_greater_power_treads_2;item_upgrade_core_3"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves_3.txt
@@ -54,7 +54,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "0"
-    "ItemCost"                                            "13928"
+    "ItemCost"                                            "16703"
     "ItemShopTags"                                        "int;armor;regen_health;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "greater guardian greaves 3;guardian greaves 3;ggg 3"

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves_4.txt
@@ -55,7 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "0"
-    "ItemCost"                                            "33929"
+    "ItemCost"                                            "36704"
     "ItemShopTags"                                        "int;armor;regen_health;hard_to_tag"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "greater guardian greaves 4;guardian greaves 4;ggg 4"

--- a/game/scripts/npc/items/farming/item_greater_guardian_greaves_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_guardian_greaves_4.txt
@@ -25,11 +25,11 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_guardian_greaves_3;item_upgrade_core_4"
-      "02"                                                "item_greater_tranquil_boots_3;item_upgrade_core_4"
-      "03"                                                "item_greater_travel_boots_3;item_upgrade_core_4"
-      "04"                                                "item_greater_phase_boots_3;item_upgrade_core_4"
-      "05"                                                "item_greater_power_treads_3;item_upgrade_core_4"
-      "06"                                                "item_sonic;item_upgrade_core_4"
+      //"02"                                                "item_greater_tranquil_boots_3;item_upgrade_core_4"
+      //"03"                                                "item_greater_travel_boots_3;item_upgrade_core_4"
+      //"04"                                                "item_greater_phase_boots_3;item_upgrade_core_4"
+      //"05"                                                "item_greater_power_treads_3;item_upgrade_core_4"
+      //"06"                                                "item_sonic;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_phase_boots_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_phase_boots_2.txt
@@ -25,10 +25,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_phase_boots;item_upgrade_core_2"
-      "02"                                                "item_greater_power_treads;item_upgrade_core_2"
-      "03"                                                "item_greater_tranquil_boots;item_upgrade_core_2"
-      "04"                                                "item_greater_travel_boots;item_upgrade_core_2"
-      "05"                                                "item_greater_guardian_greaves;item_upgrade_core_2"
+      //"02"                                                "item_greater_power_treads;item_upgrade_core_2"
+      //"03"                                                "item_greater_tranquil_boots;item_upgrade_core_2"
+      //"04"                                                "item_greater_travel_boots;item_upgrade_core_2"
+      //"05"                                                "item_greater_guardian_greaves;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_phase_boots_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_phase_boots_3.txt
@@ -25,10 +25,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_phase_boots_2;item_upgrade_core_3"
-      "02"                                                "item_greater_power_treads_2;item_upgrade_core_3"
-      "03"                                                "item_greater_tranquil_boots_2;item_upgrade_core_3"
-      "04"                                                "item_greater_travel_boots_2;item_upgrade_core_3"
-      "05"                                                "item_greater_guardian_greaves_2;item_upgrade_core_3"
+      //"02"                                                "item_greater_power_treads_2;item_upgrade_core_3"
+      //"03"                                                "item_greater_tranquil_boots_2;item_upgrade_core_3"
+      //"04"                                                "item_greater_travel_boots_2;item_upgrade_core_3"
+      //"05"                                                "item_greater_guardian_greaves_2;item_upgrade_core_3"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_phase_boots_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_phase_boots_4.txt
@@ -25,11 +25,11 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_phase_boots_3;item_upgrade_core_4"
-      "02"                                                "item_greater_power_treads_3;item_upgrade_core_4"
-      "03"                                                "item_greater_tranquil_boots_3;item_upgrade_core_4"
-      "04"                                                "item_greater_travel_boots_3;item_upgrade_core_4"
-      "05"                                                "item_greater_guardian_greaves_3;item_upgrade_core_4"
-      "06"                                                "item_sonic;item_upgrade_core_4"
+      //"02"                                                "item_greater_power_treads_3;item_upgrade_core_4"
+      //"03"                                                "item_greater_tranquil_boots_3;item_upgrade_core_4"
+      //"04"                                                "item_greater_travel_boots_3;item_upgrade_core_4"
+      //"05"                                                "item_greater_guardian_greaves_3;item_upgrade_core_4"
+      //"06"                                                "item_sonic;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_power_treads.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads.txt
@@ -47,7 +47,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "2426"
+    "ItemCost"                                            "2901"
     "ItemShopTags"                                        "attack_speed;move_speed;int;agi;str"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "greater power treads;power treads;treads"

--- a/game/scripts/npc/items/farming/item_greater_power_treads.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads.txt
@@ -24,10 +24,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_power_treads;item_upgrade_core"
-      "02"                                                "item_phase_boots;item_upgrade_core"
-      "03"                                                "item_tranquil_boots;item_upgrade_core"
-      "04"                                                "item_travel_boots_oaa;item_upgrade_core"
-      "05"                                                "item_arcane_boots;item_upgrade_core"
+      //"02"                                                "item_phase_boots;item_upgrade_core"
+      //"03"                                                "item_tranquil_boots;item_upgrade_core"
+      //"04"                                                "item_travel_boots_oaa;item_upgrade_core"
+      //"05"                                                "item_arcane_boots;item_upgrade_core"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_power_treads_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads_2.txt
@@ -24,10 +24,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_power_treads;item_upgrade_core_2"
-      "02"                                                "item_greater_phase_boots;item_upgrade_core_2"
-      "03"                                                "item_greater_tranquil_boots;item_upgrade_core_2"
-      "04"                                                "item_greater_travel_boots;item_upgrade_core_2"
-      "05"                                                "item_greater_guardian_greaves;item_upgrade_core_2"
+      //"02"                                                "item_greater_phase_boots;item_upgrade_core_2"
+      //"03"                                                "item_greater_tranquil_boots;item_upgrade_core_2"
+      //"04"                                                "item_greater_travel_boots;item_upgrade_core_2"
+      //"05"                                                "item_greater_guardian_greaves;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_power_treads_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads_2.txt
@@ -47,7 +47,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "5927"
+    "ItemCost"                                            "6402"
     "ItemShopTags"                                        "attack_speed;move_speed;int;agi;str"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "greater power treads 2;power treads 2;treads 2"

--- a/game/scripts/npc/items/farming/item_greater_power_treads_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads_3.txt
@@ -24,10 +24,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_power_treads_2;item_upgrade_core_3"
-      "02"                                                "item_greater_phase_boots_2;item_upgrade_core_3"
-      "03"                                                "item_greater_tranquil_boots_2;item_upgrade_core_3"
-      "04"                                                "item_greater_travel_boots_2;item_upgrade_core_3"
-      "05"                                                "item_greater_guardian_greaves_2;item_upgrade_core_3"
+      //"02"                                                "item_greater_phase_boots_2;item_upgrade_core_3"
+      //"03"                                                "item_greater_tranquil_boots_2;item_upgrade_core_3"
+      //"04"                                                "item_greater_travel_boots_2;item_upgrade_core_3"
+      //"05"                                                "item_greater_guardian_greaves_2;item_upgrade_core_3"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_power_treads_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads_3.txt
@@ -47,7 +47,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "13928"
+    "ItemCost"                                            "14403"
     "ItemShopTags"                                        "attack_speed;move_speed;int;agi;str"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "greater power treads 3;power treads 3;treads 3"

--- a/game/scripts/npc/items/farming/item_greater_power_treads_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads_4.txt
@@ -48,7 +48,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "33929"
+    "ItemCost"                                            "34404"
     "ItemShopTags"                                        "attack_speed;move_speed;int;agi;str"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "greater power treads 4;power treads 4;treads 4"

--- a/game/scripts/npc/items/farming/item_greater_power_treads_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_power_treads_4.txt
@@ -24,11 +24,11 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_power_treads_3;item_upgrade_core_4"
-      "02"                                                "item_greater_phase_boots_3;item_upgrade_core_4"
-      "03"                                                "item_greater_tranquil_boots_3;item_upgrade_core_4"
-      "04"                                                "item_greater_travel_boots_3;item_upgrade_core_4"
-      "05"                                                "item_greater_guardian_greaves_3;item_upgrade_core_4"
-      "06"                                                "item_sonic;item_upgrade_core_4"
+      //"02"                                                "item_greater_phase_boots_3;item_upgrade_core_4"
+      //"03"                                                "item_greater_tranquil_boots_3;item_upgrade_core_4"
+      //"04"                                                "item_greater_travel_boots_3;item_upgrade_core_4"
+      //"05"                                                "item_greater_guardian_greaves_3;item_upgrade_core_4"
+      //"06"                                                "item_sonic;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots.txt
@@ -25,10 +25,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_tranquil_boots;item_upgrade_core"
-      "02"                                                "item_travel_boots_oaa;item_upgrade_core"
-      "03"                                                "item_phase_boots;item_upgrade_core"
-      "04"                                                "item_power_treads;item_upgrade_core"
-      "05"                                                "item_arcane_boots;item_upgrade_core"
+      //"02"                                                "item_travel_boots_oaa;item_upgrade_core"
+      //"03"                                                "item_phase_boots;item_upgrade_core"
+      //"04"                                                "item_power_treads;item_upgrade_core"
+      //"05"                                                "item_arcane_boots;item_upgrade_core"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_2.txt
@@ -25,10 +25,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_tranquil_boots;item_upgrade_core_2"
-      "02"                                                "item_greater_travel_boots;item_upgrade_core_2"
-      "03"                                                "item_greater_phase_boots;item_upgrade_core_2"
-      "04"                                                "item_greater_power_treads;item_upgrade_core_2"
-      "05"                                                "item_greater_guardian_greaves;item_upgrade_core_2"
+      //"02"                                                "item_greater_travel_boots;item_upgrade_core_2"
+      //"03"                                                "item_greater_phase_boots;item_upgrade_core_2"
+      //"04"                                                "item_greater_power_treads;item_upgrade_core_2"
+      //"05"                                                "item_greater_guardian_greaves;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_3.txt
@@ -25,10 +25,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_tranquil_boots_2;item_upgrade_core_3"
-      "02"                                                "item_greater_travel_boots_2;item_upgrade_core_3"
-      "03"                                                "item_greater_phase_boots_2;item_upgrade_core_3"
-      "04"                                                "item_greater_power_treads_2;item_upgrade_core_3"
-      "05"                                                "item_greater_guardian_greaves_2;item_upgrade_core_3"
+      //"02"                                                "item_greater_travel_boots_2;item_upgrade_core_3"
+      //"03"                                                "item_greater_phase_boots_2;item_upgrade_core_3"
+      //"04"                                                "item_greater_power_treads_2;item_upgrade_core_3"
+      //"05"                                                "item_greater_guardian_greaves_2;item_upgrade_core_3"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_tranquil_boots_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_tranquil_boots_4.txt
@@ -25,11 +25,11 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_tranquil_boots_3;item_upgrade_core_4"
-      "02"                                                "item_greater_travel_boots_3;item_upgrade_core_4"
-      "03"                                                "item_greater_phase_boots_3;item_upgrade_core_4"
-      "04"                                                "item_greater_power_treads_3;item_upgrade_core_4"
-      "05"                                                "item_greater_guardian_greaves_3;item_upgrade_core_4"
-      "06"                                                "item_sonic;item_upgrade_core_4"
+      //"02"                                                "item_greater_travel_boots_3;item_upgrade_core_4"
+      //"03"                                                "item_greater_phase_boots_3;item_upgrade_core_4"
+      //"04"                                                "item_greater_power_treads_3;item_upgrade_core_4"
+      //"05"                                                "item_greater_guardian_greaves_3;item_upgrade_core_4"
+      //"06"                                                "item_sonic;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_travel_boots.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots.txt
@@ -25,10 +25,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_travel_boots_oaa;item_upgrade_core"
-      "02"                                                "item_tranquil_boots;item_upgrade_core"
-      "03"                                                "item_phase_boots;item_upgrade_core"
-      "04"                                                "item_power_treads;item_upgrade_core"
-      "05"                                                "item_arcane_boots;item_upgrade_core"
+      //"02"                                                "item_tranquil_boots;item_upgrade_core"
+      //"03"                                                "item_phase_boots;item_upgrade_core"
+      //"04"                                                "item_power_treads;item_upgrade_core"
+      //"05"                                                "item_arcane_boots;item_upgrade_core"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_travel_boots.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots.txt
@@ -57,7 +57,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "75"
-    "ItemCost"                                            "2426"
+    "ItemCost"                                            "2551"
     "ItemShopTags"                                        "teleport;move_speed"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "bot;boots of travel;greater boots of travel"

--- a/game/scripts/npc/items/farming/item_greater_travel_boots_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots_2.txt
@@ -25,10 +25,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_travel_boots;item_upgrade_core_2"
-      "02"                                                "item_greater_tranquil_boots;item_upgrade_core_2"
-      "03"                                                "item_greater_phase_boots;item_upgrade_core_2"
-      "04"                                                "item_greater_power_treads;item_upgrade_core_2"
-      "05"                                                "item_greater_guardian_greaves;item_upgrade_core_2"
+      //"02"                                                "item_greater_tranquil_boots;item_upgrade_core_2"
+      //"03"                                                "item_greater_phase_boots;item_upgrade_core_2"
+      //"04"                                                "item_greater_power_treads;item_upgrade_core_2"
+      //"05"                                                "item_greater_guardian_greaves;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_travel_boots_2.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots_2.txt
@@ -58,7 +58,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "75"
-    "ItemCost"                                            "5927"
+    "ItemCost"                                            "6052"
     "ItemShopTags"                                        "teleport;move_speed"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "bot 2;boots of travel 2;greater boots of travel 2"

--- a/game/scripts/npc/items/farming/item_greater_travel_boots_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots_3.txt
@@ -25,10 +25,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_travel_boots_2;item_upgrade_core_3"
-      "02"                                                "item_greater_tranquil_boots_2;item_upgrade_core_3"
-      "03"                                                "item_greater_phase_boots_2;item_upgrade_core_3"
-      "04"                                                "item_greater_power_treads_2;item_upgrade_core_3"
-      "05"                                                "item_greater_guardian_greaves_2;item_upgrade_core_3"
+      //"02"                                                "item_greater_tranquil_boots_2;item_upgrade_core_3"
+      //"03"                                                "item_greater_phase_boots_2;item_upgrade_core_3"
+      //"04"                                                "item_greater_power_treads_2;item_upgrade_core_3"
+      //"05"                                                "item_greater_guardian_greaves_2;item_upgrade_core_3"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_travel_boots_3.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots_3.txt
@@ -58,7 +58,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "75"
-    "ItemCost"                                            "13928"
+    "ItemCost"                                            "14053"
     "ItemShopTags"                                        "teleport;move_speed"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "bot 3;boots of travel 3;greater boots of travel 3"

--- a/game/scripts/npc/items/farming/item_greater_travel_boots_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots_4.txt
@@ -25,11 +25,11 @@
     "ItemRequirements"
     {
       "01"                                                "item_greater_travel_boots_3;item_upgrade_core_4"
-      "02"                                                "item_greater_tranquil_boots_3;item_upgrade_core_4"
-      "03"                                                "item_greater_phase_boots_3;item_upgrade_core_4"
-      "04"                                                "item_greater_power_treads_3;item_upgrade_core_4"
-      "05"                                                "item_greater_guardian_greaves_3;item_upgrade_core_4"
-      "06"                                                "item_sonic;item_upgrade_core_4"
+      //"02"                                                "item_greater_tranquil_boots_3;item_upgrade_core_4"
+      //"03"                                                "item_greater_phase_boots_3;item_upgrade_core_4"
+      //"04"                                                "item_greater_power_treads_3;item_upgrade_core_4"
+      //"05"                                                "item_greater_guardian_greaves_3;item_upgrade_core_4"
+      //"06"                                                "item_sonic;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/farming/item_greater_travel_boots_4.txt
+++ b/game/scripts/npc/items/farming/item_greater_travel_boots_4.txt
@@ -59,7 +59,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "75"
-    "ItemCost"                                            "33929"
+    "ItemCost"                                            "34054"
     "ItemShopTags"                                        "teleport;move_speed"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "bot 4;boots of travel 4;greater boots of travel 4"

--- a/game/scripts/npc/items/item_diffusal_blade_2.txt
+++ b/game/scripts/npc/items/item_diffusal_blade_2.txt
@@ -55,7 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "0"
-    "ItemCost"                                            "3901"
+    "ItemCost"                                            "4651"
     "ItemShopTags"                                        "agi;int;unique;hard_to_tag"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "diffusal blade 2;diffusal 2"

--- a/game/scripts/npc/items/item_diffusal_blade_2.txt
+++ b/game/scripts/npc/items/item_diffusal_blade_2.txt
@@ -25,7 +25,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_diffusal_blade;item_upgrade_core"
-      "02"                                                "item_mage_slayer;item_upgrade_core"
+      //"02"                                                "item_mage_slayer;item_upgrade_core"
     }
   }
 

--- a/game/scripts/npc/items/item_diffusal_blade_3.txt
+++ b/game/scripts/npc/items/item_diffusal_blade_3.txt
@@ -55,7 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "0"
-    "ItemCost"                                            "7402"
+    "ItemCost"                                            "8152"
     "ItemShopTags"                                        "agi;int;unique;hard_to_tag"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "diffusal blade 3;diffusal 3"

--- a/game/scripts/npc/items/item_diffusal_blade_3.txt
+++ b/game/scripts/npc/items/item_diffusal_blade_3.txt
@@ -25,7 +25,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_diffusal_blade_2;item_upgrade_core_2"
-      "02"                                                "item_mage_slayer_2;item_upgrade_core_2"
+      //"02"                                                "item_mage_slayer_2;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/item_diffusal_blade_4.txt
+++ b/game/scripts/npc/items/item_diffusal_blade_4.txt
@@ -55,7 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "0"
-    "ItemCost"                                            "15403"
+    "ItemCost"                                            "16153"
     "ItemShopTags"                                        "agi;int;unique;hard_to_tag"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "diffusal blade 4;diffusal 4"

--- a/game/scripts/npc/items/item_diffusal_blade_4.txt
+++ b/game/scripts/npc/items/item_diffusal_blade_4.txt
@@ -25,7 +25,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_diffusal_blade_3;item_upgrade_core_3"
-      "02"                                                "item_mage_slayer_3;item_upgrade_core_3"
+      //"02"                                                "item_mage_slayer_3;item_upgrade_core_3"
     }
   }
 

--- a/game/scripts/npc/items/item_diffusal_blade_5.txt
+++ b/game/scripts/npc/items/item_diffusal_blade_5.txt
@@ -25,7 +25,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_diffusal_blade_4;item_upgrade_core_4"
-      "02"                                                "item_mage_slayer_4;item_upgrade_core_4"
+      //"02"                                                "item_mage_slayer_4;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/item_diffusal_blade_5.txt
+++ b/game/scripts/npc/items/item_diffusal_blade_5.txt
@@ -55,7 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "0"
-    "ItemCost"                                            "35404"
+    "ItemCost"                                            "36154"
     "ItemShopTags"                                        "agi;int;unique;hard_to_tag"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "diffusal blade 5;diffusal 5"

--- a/game/scripts/npc/items/item_heart_2.txt
+++ b/game/scripts/npc/items/item_heart_2.txt
@@ -25,7 +25,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_heart_oaa;item_upgrade_core"
-      "02"                                                "item_crimson_guard;item_upgrade_core"
+      //"02"                                                "item_crimson_guard;item_upgrade_core"
     }
   }
 

--- a/game/scripts/npc/items/item_heart_2.txt
+++ b/game/scripts/npc/items/item_heart_2.txt
@@ -58,7 +58,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCorePointCost"                                   "2"
-    "ItemCost"                                            "5101"
+    "ItemCost"                                            "5801"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "hot 2;heart of tarrasque 2;heart 2"

--- a/game/scripts/npc/items/item_heart_3.txt
+++ b/game/scripts/npc/items/item_heart_3.txt
@@ -58,7 +58,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCorePointCost"                                   "6"
-    "ItemCost"                                            "8602"
+    "ItemCost"                                            "9302"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "hot 3;heart of tarrasque 3;heart 3"

--- a/game/scripts/npc/items/item_heart_3.txt
+++ b/game/scripts/npc/items/item_heart_3.txt
@@ -25,7 +25,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_heart_2;item_upgrade_core_2"
-      "02"                                                "item_crimson_guard_2;item_upgrade_core_2"
+      //"02"                                                "item_crimson_guard_2;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/item_heart_4.txt
+++ b/game/scripts/npc/items/item_heart_4.txt
@@ -26,7 +26,7 @@
     {
       "01"                                                "item_heart_3;item_upgrade_core_3"
       //"02"                                                "item_crimson_guard_3;item_upgrade_core_3"
-      "03"                                                "item_regen_crystal_1;item_upgrade_core_3"
+      "02"                                                "item_regen_crystal_1;item_upgrade_core_3"
     }
   }
 
@@ -59,7 +59,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCorePointCost"                                   "14"
-    "ItemCost"                                            "16603"
+    "ItemCost"                                            "17303"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "hot 4;heart of tarrasque 4;heart 4"

--- a/game/scripts/npc/items/item_heart_4.txt
+++ b/game/scripts/npc/items/item_heart_4.txt
@@ -25,7 +25,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_heart_3;item_upgrade_core_3"
-      "02"                                                "item_crimson_guard_3;item_upgrade_core_3"
+      //"02"                                                "item_crimson_guard_3;item_upgrade_core_3"
       "03"                                                "item_regen_crystal_1;item_upgrade_core_3"
     }
   }

--- a/game/scripts/npc/items/item_heart_5.txt
+++ b/game/scripts/npc/items/item_heart_5.txt
@@ -25,7 +25,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_heart_4;item_upgrade_core_4"
-      "02"                                                "item_crimson_guard_4;item_upgrade_core_4"
+      //"02"                                                "item_crimson_guard_4;item_upgrade_core_4"
       "03"                                                "item_regen_crystal_2;item_upgrade_core_4"
       "04"                                                "item_heart_transplant;item_upgrade_core_4"
     }

--- a/game/scripts/npc/items/item_heart_5.txt
+++ b/game/scripts/npc/items/item_heart_5.txt
@@ -26,8 +26,8 @@
     {
       "01"                                                "item_heart_4;item_upgrade_core_4"
       //"02"                                                "item_crimson_guard_4;item_upgrade_core_4"
-      "03"                                                "item_regen_crystal_2;item_upgrade_core_4"
-      "04"                                                "item_heart_transplant;item_upgrade_core_4"
+      "02"                                                "item_regen_crystal_2;item_upgrade_core_4"
+      "03"                                                "item_heart_transplant;item_upgrade_core_4"
     }
   }
 
@@ -59,7 +59,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCorePointCost"                                   "30"
-    "ItemCost"                                            "36604"
+    "ItemCost"                                            "37304"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
     "ItemAliases"                                         "hot 5;heart of tarrasque 5;heart 5"

--- a/game/scripts/npc/items/item_heavens_halberd_2.txt
+++ b/game/scripts/npc/items/item_heavens_halberd_2.txt
@@ -55,7 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "100"
-    "ItemCost"                                            "3901"
+    "ItemCost"                                            "4851"
     "ItemShopTags"                                        "str;damage;evasion"
     "ItemQuality"                                         "artifact"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"

--- a/game/scripts/npc/items/item_heavens_halberd_2.txt
+++ b/game/scripts/npc/items/item_heavens_halberd_2.txt
@@ -25,8 +25,8 @@
     "ItemRequirements"
     {
       "01"                                                "item_heavens_halberd;item_upgrade_core"
-      "02"                                                "item_echo_sabre;item_upgrade_core"
-      "03"                                                "item_pull_staff;item_upgrade_core"
+      //"02"                                                "item_echo_sabre;item_upgrade_core"
+      //"03"                                                "item_pull_staff;item_upgrade_core"
     }
   }
 

--- a/game/scripts/npc/items/item_heavens_halberd_3.txt
+++ b/game/scripts/npc/items/item_heavens_halberd_3.txt
@@ -55,7 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "100"
-    "ItemCost"                                            "7402"
+    "ItemCost"                                            "8352"
     "ItemShopTags"                                        "str;damage;evasion"
     "ItemQuality"                                         "artifact"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"

--- a/game/scripts/npc/items/item_heavens_halberd_3.txt
+++ b/game/scripts/npc/items/item_heavens_halberd_3.txt
@@ -25,8 +25,8 @@
     "ItemRequirements"
     {
       "01"                                                "item_heavens_halberd_2;item_upgrade_core_2"
-      "02"                                                "item_echo_sabre_2;item_upgrade_core_2"
-      "03"                                                "item_pull_staff_2;item_upgrade_core_2"
+      //"02"                                                "item_echo_sabre_2;item_upgrade_core_2"
+      //"03"                                                "item_pull_staff_2;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/item_heavens_halberd_4.txt
+++ b/game/scripts/npc/items/item_heavens_halberd_4.txt
@@ -55,7 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "100"
-    "ItemCost"                                            "15403"
+    "ItemCost"                                            "16353"
     "ItemShopTags"                                        "str;damage;evasion"
     "ItemQuality"                                         "artifact"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"

--- a/game/scripts/npc/items/item_heavens_halberd_4.txt
+++ b/game/scripts/npc/items/item_heavens_halberd_4.txt
@@ -25,8 +25,8 @@
     "ItemRequirements"
     {
       "01"                                                "item_heavens_halberd_3;item_upgrade_core_3"
-      "02"                                                "item_echo_sabre_3;item_upgrade_core_3"
-      "03"                                                "item_pull_staff_3;item_upgrade_core_3"
+      //"02"                                                "item_echo_sabre_3;item_upgrade_core_3"
+      //"03"                                                "item_pull_staff_3;item_upgrade_core_3"
     }
   }
 

--- a/game/scripts/npc/items/item_heavens_halberd_5.txt
+++ b/game/scripts/npc/items/item_heavens_halberd_5.txt
@@ -25,8 +25,8 @@
     "ItemRequirements"
     {
       "01"                                                "item_heavens_halberd_4;item_upgrade_core_4"
-      "02"                                                "item_echo_sabre_4;item_upgrade_core_4"
-      "03"                                                "item_pull_staff_4;item_upgrade_core_4"
+      //"02"                                                "item_echo_sabre_4;item_upgrade_core_4"
+      //"03"                                                "item_pull_staff_4;item_upgrade_core_4"
     }
   }
 

--- a/game/scripts/npc/items/item_heavens_halberd_5.txt
+++ b/game/scripts/npc/items/item_heavens_halberd_5.txt
@@ -55,7 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "AbilityManaCost"                                     "100"
-    "ItemCost"                                            "35404"
+    "ItemCost"                                            "36354"
     "ItemShopTags"                                        "str;damage;evasion"
     "ItemQuality"                                         "artifact"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"

--- a/game/scripts/npc/items/item_mage_slayer_2.txt
+++ b/game/scripts/npc/items/item_mage_slayer_2.txt
@@ -26,7 +26,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_mage_slayer;item_upgrade_core"
-      "02"                                                "item_diffusal_blade;item_upgrade_core"
+      //"02"                                                "item_diffusal_blade;item_upgrade_core"
     }
   }
 

--- a/game/scripts/npc/items/item_mage_slayer_3.txt
+++ b/game/scripts/npc/items/item_mage_slayer_3.txt
@@ -26,7 +26,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_mage_slayer_2;item_upgrade_core_2"
-      "02"                                                "item_diffusal_blade_2;item_upgrade_core_2"
+      //"02"                                                "item_diffusal_blade_2;item_upgrade_core_2"
     }
   }
 

--- a/game/scripts/npc/items/item_mage_slayer_4.txt
+++ b/game/scripts/npc/items/item_mage_slayer_4.txt
@@ -26,7 +26,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_mage_slayer_3;item_upgrade_core_3"
-      "02"                                                "item_diffusal_blade_3;item_upgrade_core_3"
+      //"02"                                                "item_diffusal_blade_3;item_upgrade_core_3"
     }
   }
 

--- a/game/scripts/npc/items/item_mage_slayer_5.txt
+++ b/game/scripts/npc/items/item_mage_slayer_5.txt
@@ -26,7 +26,7 @@
     "ItemRequirements"
     {
       "01"                                                "item_mage_slayer_4;item_upgrade_core_4"
-      "02"                                                "item_diffusal_blade_4;item_upgrade_core_4"
+      //"02"                                                "item_diffusal_blade_4;item_upgrade_core_4"
     }
   }
 


### PR DESCRIPTION
You could print money by buying cheap level 1 items and upgrading them to more expensive level 2 items in their tree.

Also removed crimson guard building into custom items now that heart and cg are separate. 
