### PR TITLE
Another Offside update

### DIFF
--- a/game/resource/English/modifier/tooltip_modifier_offsides.txt
+++ b/game/resource/English/modifier/tooltip_modifier_offsides.txt
@@ -2,4 +2,4 @@
 "dota_tooltip_modifier_offside_description"         "You grow weaker and weaker the longer you spend on the enemy side of the map"
 
 "dota_tooltip_modifier_onside_buff"                     "Offsides Buff"
-"dota_tooltip_modifier_onside_buff_description"         "An enemy hero is in too deep, have some bonus armor"
+"dota_tooltip_modifier_onside_buff_description"         "An enemy hero is in too deep, have some bonus armor and magic resistance."

--- a/game/scripts/vscripts/modifiers/modifier_onside_buff.lua
+++ b/game/scripts/vscripts/modifiers/modifier_onside_buff.lua
@@ -1,11 +1,11 @@
 modifier_onside_buff = class(ModifierBaseClass)
 
 --------------------------------------------------------------------
---damage reduction
+
 function modifier_onside_buff:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS,
-    --MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS,
+    MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS,
 	}
 end
 
@@ -23,19 +23,18 @@ end
 
 function modifier_onside_buff:GetModifierPhysicalArmorBonus()
   local stackCount = self:GetElapsedTime()
-  if stackCount >= 10 then
+  if stackCount >= 8 then
     return 10--(0.1 * (stackCount - 10)^2)) -- (multiplier * (stackcount - seconds till active (equal to stackCount >= number)))
   else
     return 5
   end
 end
---[[
-function modifier_onside:GetModifierMagicalResistanceBonus()
+
+function modifier_onside_buff:GetModifierMagicalResistanceBonus()
   local stackCount = self:GetElapsedTime()
-  if stackCount >=10 then
+  if stackCount >= 8 then
     return 25
   else
-    return 10
+    return 15
   end
 end
-]]


### PR DESCRIPTION
* Optimized offside modifier code when parent is dead. -> should be less laggy.
* Made sure that offside modifiers don't get removed on death.
* Fixed offside penalty not doing damage when number of stacks is exactly 8.
* Fixed offside protection buff not being applied to spell-immune heroes.
* Maybe fixed offside protection buff not being applied to invulnerable and banished/hidden heroes. I say maybe because Dota 2 API sometimes doesn't allow applying modifiers to invulnerable enemies.
* Fixed offside protection buff being applied to bosses.
* Fixed offside penalty increasing the number of stacks while the hero is dead. Number of stacks now doesn't change while the hero is dead. The hero will respawn with the same number of stacks it died with.
* Fixed offside protection buff not providing 10 armor when the enemy has 8 or 9 stacks.
* Offside protection buff now also provides 15% magic resistance. If the enemy has more than 8 stacks, bonus magic resistance is increased to 25%.