### PR TITLE
Total Damage Block abilities and items update

### DIFF
--- a/game/scripts/vscripts/abilities/charger/boss_charger_super_armor.lua
+++ b/game/scripts/vscripts/abilities/charger/boss_charger_super_armor.lua
@@ -24,6 +24,7 @@ if IsServer() then
     local parent = self:GetParent()
     ability.shieldParticleName = "particles/charger/charger_super_armor_shield.vpcf"
     ability.shieldParticle = ParticleManager:CreateParticle(ability.shieldParticleName, PATTACH_OVERHEAD_FOLLOW, parent)
+    -- shieldParticle is released and destroyed when modifier_boss_charger_pillar_debuff is created
   end
 end
 
@@ -33,10 +34,24 @@ function modifier_boss_charger_super_armor:DeclareFunctions()
   }
 end
 
-function modifier_boss_charger_super_armor:GetModifierTotal_ConstantBlock(keys)
-  if self:GetParent():HasModifier("modifier_boss_charger_pillar_debuff") then
+function modifier_boss_charger_super_armor:GetModifierTotal_ConstantBlock(event)
+  if not IsServer() then
     return
   end
+
+  local parent = self:GetParent()
+
+  if parent:HasModifier("modifier_boss_charger_pillar_debuff") then
+    return 0
+  end
+
   local damageReduction = self:GetAbility():GetSpecialValueFor("percent_damage_reduce")
-  return math.floor(keys.damage * damageReduction / 100)
+  local blockAmount = event.damage * damageReduction / 100
+
+  if blockAmount > 0 then
+    -- Visual effect (TODO: add unique visual effect)
+    SendOverheadEventMessage(nil, OVERHEAD_ALERT_BLOCK, parent, blockAmount, nil)
+  end
+
+  return blockAmount
 end

--- a/game/scripts/vscripts/abilities/electrician/electrician_electric_shield.lua
+++ b/game/scripts/vscripts/abilities/electrician/electrician_electric_shield.lua
@@ -156,6 +156,11 @@ if IsServer() then
   ]]
 
   function modifier_electrician_electric_shield:GetModifierTotal_ConstantBlock( event )
+    -- Do nothing if damage has HP removal flag
+    if bit.band(event.damage_flags, DOTA_DAMAGE_FLAG_HPLOSS) == DOTA_DAMAGE_FLAG_HPLOSS then
+      return 0
+    end
+
     -- start with the maximum block amount
     local blockAmount = event.damage * self.shieldRate
     local parent = self:GetParent()
@@ -190,13 +195,15 @@ if IsServer() then
       -- remove shield hp
       self:SetStackCount( hp - blockAmount )
 
-      -- do the little block visual effect
-      SendOverheadEventMessage( nil, 8, parent, blockAmount, nil )
-
       -- destroy the modifier if hp is reduced to nothing
       if self:GetStackCount() <= 0 then
         self:Destroy()
       end
+    end
+
+    if blockAmount > 0 then
+      -- do the little block visual effect (TODO: add unique visual effect)
+      SendOverheadEventMessage(nil, OVERHEAD_ALERT_BLOCK, parent, blockAmount, nil)
     end
 
     return blockAmount

--- a/game/scripts/vscripts/items/reflex/preemptive_damage_block.lua
+++ b/game/scripts/vscripts/items/reflex/preemptive_damage_block.lua
@@ -115,15 +115,27 @@ end
   --return self.damageReduction * -1
 --end
 
-function modifier_item_preemptive_damage_reduction:GetModifierTotal_ConstantBlock(keys)
+function modifier_item_preemptive_damage_reduction:GetModifierTotal_ConstantBlock(event)
+  if not IsServer() then
+    return
+  end
+
   local parent = self:GetParent()
-  local damage = keys.damage
+  local damage = event.damage
 
   self.endHeal = self.endHeal + damage * self.damageheal / 100
 
   local block_amount = damage * self.damageReduction / 100
 
-  SendOverheadEventMessage(nil, OVERHEAD_ALERT_BLOCK, parent, block_amount, nil)
+  if block_amount > 0 then
+    -- Visual effect
+    local alert_type = OVERHEAD_ALERT_MAGICAL_BLOCK
+    if event.damage_type == DAMAGE_TYPE_PHYSICAL then
+      alert_type = OVERHEAD_ALERT_BLOCK
+    end
+
+    SendOverheadEventMessage(nil, alert_type, parent, block_amount, nil)
+  end
 
   return block_amount
 end


### PR DESCRIPTION
Important changes:
* Force Shield Staff no longer blocks damage that has HP removal flag.
* Force Shield Staff damage to enemies is now pure and non-lethal.
* Chatterjee's Electric Shield no longer blocks damage that has HP removal flag.
* Visage's Gravekeeper's Cloak no longer blocks damage that has HP removal flag.

Other:
* Added a visual effect to Charger's Super Armor total damage block.
* Disabled Charger's Super Armor code working on clients.
* Fixed Chatterjee's Electric Shield total damage block not having a visual effect with Aghanim Shard.
* Added visual effect to Visage's Gravekeeper's Cloak.
* Added a different visual effect to Reduction Orb's total damage block when damage is not physical.
* Force Shield active buff now has a different visual effect when the blocked damage isn't physical.
* Fixed all Total Damage Block abilities and items showing visual effects when the damage is <= 0.

Most notable damage sources that have HP removal flag in OAA are Offside Penalty damage and https://dota2.fandom.com/wiki/Damage_types#HP_Removal. Zeus passive doesn't have HP removal flag.