### PR TITLE
Fix Vengeful Spirit aghs illusion not working on certain lvls

### DIFF
--- a/game/resource/English/ability/units/tooltip_vengeful_spirit_vengeance_aura.txt
+++ b/game/resource/English/ability/units/tooltip_vengeful_spirit_vengeance_aura.txt
@@ -1,0 +1,26 @@
+//=============================================================================
+// Vengeful Spirit Vengeance Aura Rework
+//=============================================================================
+//"DOTA_Tooltip_ability_vengefulspirit_command_aura"                              "Vengeance Aura"
+//"DOTA_Tooltip_ability_vengefulspirit_command_aura_Description"                  "Vengeful Spirit's presence increases the damage of nearby friendly heroes."
+//"DOTA_Tooltip_ability_vengefulspirit_command_aura_scepter_description"          "Upon death, creates a strong illusion of Vengeful Spirit that deals and takes 100%% damage and can cast all of her spells. Illusion has 12%% movement speed bonus. If the illusion is alive when Vengeful Spirit respawn, she will take its place. XP earned by her illusion is given to her."
+//"DOTA_Tooltip_ability_vengefulspirit_command_aura_Lore"                         "Although they may not share her undying passion for revenge, allies do draw on her fanaticism in combat."
+//"DOTA_Tooltip_ability_vengefulspirit_command_aura_Note0"                        "Vengeance Illusion keeps providing the Vengeance Aura after Vengeful Spirit's death."
+//"DOTA_Tooltip_ability_vengefulspirit_command_aura_Note1"                        "Strong Illusions are not instantly killed by spells."
+//"DOTA_Tooltip_ability_vengefulspirit_command_aura_bonus_base_damage"            "%BASE DAMAGE BONUS:"
+//"DOTA_Tooltip_ability_vengefulspirit_command_aura_aura_radius"                  "RADIUS:"
+
+//"DOTA_Tooltip_modifier_vengefulspirit_command_aura_effect"                      "Vengeance Aura"
+//"DOTA_Tooltip_modifier_vengefulspirit_command_aura_effect_Description"          "Providing  +%dMODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE%%% base damage."
+
+"DOTA_Tooltip_ability_vengefulspirit_command_aura_oaa"                              "#{DOTA_Tooltip_ability_vengefulspirit_command_aura}"
+"DOTA_Tooltip_ability_vengefulspirit_command_aura_oaa_Description"                  "#{DOTA_Tooltip_ability_vengefulspirit_command_aura_Description}"
+"DOTA_Tooltip_ability_vengefulspirit_command_aura_oaa_scepter_description"          "#{DOTA_Tooltip_ability_vengefulspirit_command_aura_scepter_description}"
+"DOTA_Tooltip_ability_vengefulspirit_command_aura_oaa_Lore"                         "#{DOTA_Tooltip_ability_vengefulspirit_command_aura_Lore}"
+"DOTA_Tooltip_ability_vengefulspirit_command_aura_oaa_Note0"                        "#{DOTA_Tooltip_ability_vengefulspirit_command_aura_Note0}"
+"DOTA_Tooltip_ability_vengefulspirit_command_aura_oaa_Note1"                        "#{DOTA_Tooltip_ability_vengefulspirit_command_aura_Note1}"
+"DOTA_Tooltip_ability_vengefulspirit_command_aura_oaa_bonus_base_damage"            "#{DOTA_Tooltip_ability_vengefulspirit_command_aura_bonus_base_damage}"
+"DOTA_Tooltip_ability_vengefulspirit_command_aura_oaa_aura_radius"                  "#{DOTA_Tooltip_ability_vengefulspirit_command_aura_aura_radius}"
+
+"DOTA_Tooltip_modifier_vengefulspirit_command_aura_oaa_damage_buff"                 "#{DOTA_Tooltip_ability_vengefulspirit_command_aura}"
+"DOTA_Tooltip_modifier_vengefulspirit_command_aura_oaa_damage_buff_Description"     "#{DOTA_Tooltip_modifier_vengefulspirit_command_aura_effect_Description}"

--- a/game/scripts/npc/abilities/vengefulspirit_command_aura_oaa.txt
+++ b/game/scripts/npc/abilities/vengefulspirit_command_aura_oaa.txt
@@ -1,0 +1,56 @@
+"DOTAAbilities"
+{
+  //=================================================================================================================
+  // Vengeful Spirit: Vengeance Aura (OAA Rework)
+  //=================================================================================================================
+  "vengefulspirit_command_aura_oaa"
+  {
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "ID"                                                  "85123"
+    "BaseClass"                                           "ability_lua"
+    "ScriptFile"                                          "abilities/oaa_vengefulspirit_command_aura.lua"
+    "AbilityTextureName"                                  "vengefulspirit_command_aura"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_AURA"
+    "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+    "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+    "SpellDispellableType"                                "SPELL_DISPELLABLE_NO"
+
+    "MaxLevel"                                            "6"
+    "RequiredLevel"                                       "1"
+    "LevelsBetweenUpgrades"                               "2"
+
+    "HasScepterUpgrade"                                   "1"
+
+    // Casting
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCastRange"                                    "1200"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilitySpecial"
+    {
+      "01"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "bonus_base_damage"                               "11 18 25 32 36 40"
+        "LinkedSpecialBonus"                              "special_bonus_unique_vengeful_spirit_2"
+      }
+      "02"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "aura_radius"                                     "1200"
+      }
+      "03"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "illusion_damage_out_pct"                         "100"
+      }
+      "04"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "illusion_damage_in_pct"                          "100"
+      }
+    }
+  }
+}

--- a/game/scripts/npc/heroes/vengeful_spirit.txt
+++ b/game/scripts/npc/heroes/vengeful_spirit.txt
@@ -5,6 +5,6 @@
   //=================================================================================================================
   "npc_dota_hero_vengefulspirit"
   {
-
+    "Ability3"                                            "vengefulspirit_command_aura_oaa" // replaces vengefulspirit_command_aura
   }
 }

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -39,6 +39,7 @@
 #base "abilities/sohei_palm_of_life_oaa.txt"
 #base "abilities/tinker_rearm_oaa.txt"
 #base "abilities/tiny_grow_oaa.txt"
+#base "abilities/vengefulspirit_command_aura_oaa.txt"
 #base "abilities/viper_viper_strike_oaa.txt"
 #base "abilities/visage_gravekeepers_cloak_oaa.txt"
 #base "abilities/visage_summon_familiars_oaa.txt"

--- a/game/scripts/vscripts/abilities/oaa_vengefulspirit_command_aura.lua
+++ b/game/scripts/vscripts/abilities/oaa_vengefulspirit_command_aura.lua
@@ -1,7 +1,7 @@
 LinkLuaModifier("modifier_vengefulspirit_command_aura_oaa", "abilities/oaa_vengefulspirit_command_aura.lua", LUA_MODIFIER_MOTION_NONE)
 LinkLuaModifier("modifier_vengefulspirit_command_aura_oaa_damage_buff", "abilities/oaa_vengefulspirit_command_aura.lua", LUA_MODIFIER_MOTION_NONE)
-LinkLuaModifier("modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker", "abilities/oaa_vengefulspirit_command_aura.lua", LUA_MODIFIER_MOTION_NONE)
-LinkLuaModifier("modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide", "abilities/oaa_vengefulspirit_command_aura.lua", LUA_MODIFIER_MOTION_NONE)
+--LinkLuaModifier("modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker", "abilities/oaa_vengefulspirit_command_aura.lua", LUA_MODIFIER_MOTION_NONE)
+--LinkLuaModifier("modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide", "abilities/oaa_vengefulspirit_command_aura.lua", LUA_MODIFIER_MOTION_NONE)
 
 vengefulspirit_command_aura_oaa = class(AbilityBaseClass)
 
@@ -55,7 +55,7 @@ end
 function modifier_vengefulspirit_command_aura_oaa:DeclareFunctions()
   return {
     MODIFIER_EVENT_ON_DEATH,
-    --MODIFIER_EVENT_ON_RESPAWN
+    MODIFIER_EVENT_ON_RESPAWN
   }
 end
 
@@ -82,16 +82,19 @@ function modifier_vengefulspirit_command_aura_oaa:OnDeath(event)
     outgoing_damage_structure = 0,
     outgoing_damage_roshan = 0,
   }
-  local illusion = CreateIllusions(parent, parent, illusion_table, 1, parent:GetHullRadius(), true, true)
+  local illusions = CreateIllusions(parent, parent, illusion_table, 1, parent:GetHullRadius(), true, true)
+  for _, illusion in pairs(illusions) do
+    illusion:SetHealth(illusion:GetMaxHealth())
+    illusion:AddNewModifier(parent, ability, "modifier_vengefulspirit_hybrid_special", {})
+    --illusion:AddNewModifier(parent, ability, "modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker", {})
+    --self.illusion = illusion
 
-  illusion:SetHealth(illusion:GetMaxHealth())
-	illusion:AddNewModifier(parent, ability, "modifier_vengefulspirit_hybrid_special", {})
-  illusion:AddNewModifier(parent, ability, "modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker", {})
-
-  self.illusion = illusion
+    PlayerResource:SetOverrideSelectionEntity(parent:GetPlayerOwnerID(), illusion)
+	--PlayerResource:SetOverrideSelectionEntity(parent:GetPlayerOwnerID(), nil)
+  end
 end
 
---[[
+
 function modifier_vengefulspirit_command_aura_oaa:OnRespawn(event)
   local parent = self:GetParent()
   if not parent:HasScepter() or parent:IsIllusion() or parent:IsTempestDouble() or parent:IsClone() or not IsServer() then
@@ -101,13 +104,15 @@ function modifier_vengefulspirit_command_aura_oaa:OnRespawn(event)
   if event.unit ~= parent then
     return
   end
-
+--[[
   if self.illusion and self.illusion:IsNull() then
-    self.illusion:ForceKill(false)
+    --self.illusion:ForceKill(false)
+    self.illusion:AddNoDraw()
+    self.illusion:AddNewModifier(parent, nil, "modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide", {})
   end
-
+  ]]
+  PlayerResource:SetOverrideSelectionEntity(parent:GetPlayerOwnerID(), parent)
 end
-]]
 
 ---------------------------------------------------------------------------------------------------
 
@@ -152,7 +157,7 @@ function modifier_vengefulspirit_command_aura_oaa_damage_buff:GetModifierBaseDam
 end
 
 ---------------------------------------------------------------------------------------------------
-
+--[[ -- if 'modifier_vengefulspirit_hybrid_special' doesn't handle everything
 modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker = class(ModifierBaseClass)
 
 function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker:IsHidden()
@@ -167,28 +172,9 @@ function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker:IsPur
   return false
 end
 
-function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker:OnCreated()
-  if not IsServer() then
-    return
-  end
-  --self:StartIntervalThink(0)
-end
-
-function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker:OnIntervalThink()
-  if not IsServer() then
-    return
-  end
-  local parent = self:GetParent()
-  if not parent or parent:IsNull() then
-    return
-  end
-
-  -- If OnDeath doesn't work, then track illusion health with this maybe? Axe Cuilling Blade can be a problem
-end
-
 function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker:DeclareFunctions()
   return {
-    --MODIFIER_EVENT_ON_DEATH,
+    MODIFIER_EVENT_ON_DEATH,
   }
 end
 
@@ -309,8 +295,7 @@ function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:CheckSta
     [MODIFIER_STATE_COMMAND_RESTRICTED] = true,
     [MODIFIER_STATE_BLIND] = true,
     [MODIFIER_STATE_CANNOT_BE_MOTION_CONTROLLED] = true,
-    --[MODIFIER_STATE_NO_TEAM_MOVE_TO] = true,
-    --[MODIFIER_STATE_NO_TEAM_SELECT] = true,
   }
   return state
 end
+]]

--- a/game/scripts/vscripts/abilities/oaa_vengefulspirit_command_aura.lua
+++ b/game/scripts/vscripts/abilities/oaa_vengefulspirit_command_aura.lua
@@ -90,7 +90,7 @@ function modifier_vengefulspirit_command_aura_oaa:OnDeath(event)
     --self.illusion = illusion
 
     PlayerResource:SetOverrideSelectionEntity(parent:GetPlayerOwnerID(), illusion)
-	--PlayerResource:SetOverrideSelectionEntity(parent:GetPlayerOwnerID(), nil)
+    --PlayerResource:SetOverrideSelectionEntity(parent:GetPlayerOwnerID(), nil)
   end
 end
 
@@ -112,6 +112,9 @@ function modifier_vengefulspirit_command_aura_oaa:OnRespawn(event)
   end
   ]]
   PlayerResource:SetOverrideSelectionEntity(parent:GetPlayerOwnerID(), parent)
+  Timers:CreateTimer(1/30, function()
+    PlayerResource:SetOverrideSelectionEntity(parent:GetPlayerOwnerID(), nil)
+  end)
 end
 
 ---------------------------------------------------------------------------------------------------

--- a/game/scripts/vscripts/abilities/oaa_vengefulspirit_command_aura.lua
+++ b/game/scripts/vscripts/abilities/oaa_vengefulspirit_command_aura.lua
@@ -1,0 +1,316 @@
+LinkLuaModifier("modifier_vengefulspirit_command_aura_oaa", "abilities/oaa_vengefulspirit_command_aura.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_vengefulspirit_command_aura_oaa_damage_buff", "abilities/oaa_vengefulspirit_command_aura.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker", "abilities/oaa_vengefulspirit_command_aura.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide", "abilities/oaa_vengefulspirit_command_aura.lua", LUA_MODIFIER_MOTION_NONE)
+
+vengefulspirit_command_aura_oaa = class(AbilityBaseClass)
+
+function vengefulspirit_command_aura_oaa:GetIntrinsicModifierName()
+  return "modifier_vengefulspirit_command_aura_oaa"
+end
+
+---------------------------------------------------------------------------------------------------
+
+modifier_vengefulspirit_command_aura_oaa = class(ModifierBaseClass)
+
+function modifier_vengefulspirit_command_aura_oaa:IsHidden()
+  return true
+end
+
+function modifier_vengefulspirit_command_aura_oaa:IsPurgable()
+  return false
+end
+
+function modifier_vengefulspirit_command_aura_oaa:RemoveOnDeath()
+  return false
+end
+
+function modifier_vengefulspirit_command_aura_oaa:IsAura()
+  if self:GetParent():PassivesDisabled() then
+    return false
+  end
+  return true
+end
+
+function modifier_vengefulspirit_command_aura_oaa:GetModifierAura()
+  return "modifier_vengefulspirit_command_aura_oaa_damage_buff"
+end
+
+function modifier_vengefulspirit_command_aura_oaa:GetAuraSearchTeam()
+  return DOTA_UNIT_TARGET_TEAM_FRIENDLY
+end
+
+function modifier_vengefulspirit_command_aura_oaa:GetAuraSearchType()
+  return bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC)
+end
+
+function modifier_vengefulspirit_command_aura_oaa:GetAuraSearchFlags()
+  return DOTA_UNIT_TARGET_FLAG_INVULNERABLE
+end
+
+function modifier_vengefulspirit_command_aura_oaa:GetAuraRadius()
+  return self:GetAbility():GetSpecialValueFor("aura_radius")
+end
+
+function modifier_vengefulspirit_command_aura_oaa:DeclareFunctions()
+  return {
+    MODIFIER_EVENT_ON_DEATH,
+    --MODIFIER_EVENT_ON_RESPAWN
+  }
+end
+
+function modifier_vengefulspirit_command_aura_oaa:OnDeath(event)
+  local parent = self:GetParent()
+  if not parent:HasScepter() or parent:IsIllusion() or not IsServer() then
+    return
+  end
+
+  if event.unit ~= parent then
+    return
+  end
+
+  local ability = self:GetAbility()
+  if not ability or ability:IsNull() then
+    return
+  end
+
+  local illusion_table = {
+    outgoing_damage = 100 - ability:GetSpecialValueFor("illusion_damage_out_pct"),
+    incoming_damage = ability:GetSpecialValueFor("illusion_damage_in_pct") - 100,
+    bounty_base = 0,
+    bounty_growth = 0,
+    outgoing_damage_structure = 0,
+    outgoing_damage_roshan = 0,
+  }
+  local illusion = CreateIllusions(parent, parent, illusion_table, 1, parent:GetHullRadius(), true, true)
+
+  illusion:SetHealth(illusion:GetMaxHealth())
+	illusion:AddNewModifier(parent, ability, "modifier_vengefulspirit_hybrid_special", {})
+  illusion:AddNewModifier(parent, ability, "modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker", {})
+
+  self.illusion = illusion
+end
+
+--[[
+function modifier_vengefulspirit_command_aura_oaa:OnRespawn(event)
+  local parent = self:GetParent()
+  if not parent:HasScepter() or parent:IsIllusion() or parent:IsTempestDouble() or parent:IsClone() or not IsServer() then
+    return
+  end
+
+  if event.unit ~= parent then
+    return
+  end
+
+  if self.illusion and self.illusion:IsNull() then
+    self.illusion:ForceKill(false)
+  end
+
+end
+]]
+
+---------------------------------------------------------------------------------------------------
+
+modifier_vengefulspirit_command_aura_oaa_damage_buff = class(ModifierBaseClass)
+
+function modifier_vengefulspirit_command_aura_oaa_damage_buff:IsHidden()
+  return false
+end
+
+function modifier_vengefulspirit_command_aura_oaa_damage_buff:IsDebuff()
+  return false
+end
+
+function modifier_vengefulspirit_command_aura_oaa_damage_buff:IsPurgable()
+  return false
+end
+
+function modifier_vengefulspirit_command_aura_oaa_damage_buff:OnCreated()
+  self.damage = self:GetAbility():GetSpecialValueFor("bonus_base_damage")
+end
+
+function modifier_vengefulspirit_command_aura_oaa_damage_buff:OnRefresh()
+  self:OnCreated()
+end
+
+function modifier_vengefulspirit_command_aura_oaa_damage_buff:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE,
+  }
+end
+
+function modifier_vengefulspirit_command_aura_oaa_damage_buff:GetModifierBaseDamageOutgoing_Percentage()
+  local caster = self:GetCaster()
+  if caster and not caster:IsNull() then
+    local talent = caster:FindAbilityByName("special_bonus_unique_vengeful_spirit_2")
+    if talent and talent:GetLevel() > 0 then
+      return self.damage + math.abs(talent:GetSpecialValueFor("value"))
+    end
+  end
+
+  return self.damage
+end
+
+---------------------------------------------------------------------------------------------------
+
+modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker = class(ModifierBaseClass)
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker:IsHidden()
+  return true
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker:IsDebuff()
+  return false
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker:IsPurgable()
+  return false
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker:OnCreated()
+  if not IsServer() then
+    return
+  end
+  --self:StartIntervalThink(0)
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker:OnIntervalThink()
+  if not IsServer() then
+    return
+  end
+  local parent = self:GetParent()
+  if not parent or parent:IsNull() then
+    return
+  end
+
+  -- If OnDeath doesn't work, then track illusion health with this maybe? Axe Cuilling Blade can be a problem
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker:DeclareFunctions()
+  return {
+    --MODIFIER_EVENT_ON_DEATH,
+  }
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_tracker:OnDeath(event)
+  local parent = self:GetParent()
+  if not parent:HasScepter() or not parent:IsIllusion() or not IsServer() then
+    return
+  end
+
+  if event.unit ~= parent then
+    return
+  end
+
+  parent:RespawnUnit() -- idk if this works on illusions
+  parent:AddNoDraw()
+  parent:AddNewModifier(parent, nil, "modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide", {})
+end
+
+---------------------------------------------------------------------------------------------------
+
+modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide = class(ModifierBaseClass)
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:IsHidden()
+  return true
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:IsDebuff()
+  return false
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:IsPurgable()
+  return false
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:OnCreated()
+  if not IsServer() then
+    return
+  end
+  self.counter = 0
+  self:StartIntervalThink(1)
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:OnIntervalThink()
+  if not IsServer() then
+    return
+  end
+  local parent = self:GetParent()
+  if not parent or parent:IsNull() then
+    return
+  end
+  local num_of_active_modifiers = 0
+  for index = 0, parent:GetAbilityCount() - 1 do
+    local ability = parent:GetAbilityByIndex(index)
+    if ability and not ability:IsNull() then
+      if ability.NumModifiersUsingAbility and ability:NumModifiersUsingAbility() then
+        num_of_active_modifiers = num_of_active_modifiers + ability:NumModifiersUsingAbility()
+      end
+    end
+  end
+
+  self.counter = self.counter + 1
+
+  if self.counter > 9 or num_of_active_modifiers == 0 then
+    self:StartIntervalThink(-1)
+    self:Destroy()
+  end
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:OnDestroy()
+  if not IsServer() then
+    return
+  end
+  local parent = self:GetParent()
+  if not parent or parent:IsNull() then
+    return
+  end
+
+  parent:ForceKill(false)
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_PHYSICAL,
+    MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_MAGICAL,
+    MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_PURE,
+  }
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:GetAbsoluteNoDamagePhysical()
+  return 1
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:GetAbsoluteNoDamageMagical()
+  return 1
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:GetAbsoluteNoDamagePure()
+  return 1
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:GetPriority()
+  return MODIFIER_PRIORITY_SUPER_ULTRA + 10000
+end
+
+function modifier_vengefulspirit_command_aura_oaa_scepter_illusion_hide:CheckState()
+  local state = {
+    [MODIFIER_STATE_STUNNED] = true,
+    [MODIFIER_STATE_OUT_OF_GAME] = true,
+    [MODIFIER_STATE_INVULNERABLE] = true,
+    [MODIFIER_STATE_ATTACK_IMMUNE] = true,
+    [MODIFIER_STATE_MAGIC_IMMUNE] = true,
+    [MODIFIER_STATE_NO_HEALTH_BAR] = true,
+    [MODIFIER_STATE_UNSELECTABLE] = true,
+    [MODIFIER_STATE_NO_UNIT_COLLISION] = true,
+    [MODIFIER_STATE_NOT_ON_MINIMAP] = true,
+    [MODIFIER_STATE_NOT_ON_MINIMAP_FOR_ENEMIES] = true,
+    [MODIFIER_STATE_PASSIVES_DISABLED] = true,
+    [MODIFIER_STATE_COMMAND_RESTRICTED] = true,
+    [MODIFIER_STATE_BLIND] = true,
+    [MODIFIER_STATE_CANNOT_BE_MOTION_CONTROLLED] = true,
+    --[MODIFIER_STATE_NO_TEAM_MOVE_TO] = true,
+    --[MODIFIER_STATE_NO_TEAM_SELECT] = true,
+  }
+  return state
+end


### PR DESCRIPTION
Rewrote the ability in lua. Engine events and filters don't detect Venge's illusion which means Valve super hardcoded venge's aghs.
This implementation uses a built-in modifier for hybrid strong illusion so the ability is not completely custom.