### PR TITLE
Abyssal Blade, Skadi and Blade of Judecca adjustments

### DIFF
--- a/game/scripts/npc/items/custom/item_trumps_fists.txt
+++ b/game/scripts/npc/items/custom/item_trumps_fists.txt
@@ -73,12 +73,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "900 1125"
+        "bonus_health"                                    "650 900"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "700 950"
+        "bonus_mana"                                      "650 900"
       }
       "05"
       {

--- a/game/scripts/npc/items/custom/item_trumps_fists_2.txt
+++ b/game/scripts/npc/items/custom/item_trumps_fists_2.txt
@@ -73,12 +73,12 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "900 1125"
+        "bonus_health"                                    "650 900"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "700 950"
+        "bonus_mana"                                      "650 900"
       }
       "05"
       {

--- a/game/scripts/npc/items/item_abyssal_blade.txt
+++ b/game/scripts/npc/items/item_abyssal_blade.txt
@@ -70,7 +70,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "200 400 600 800 1000" //OAA
+        "bonus_health"                                    "200 300 450 650 900" //OAA
       }
       "03"
       {

--- a/game/scripts/npc/items/item_abyssal_blade_2.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_2.txt
@@ -71,7 +71,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "200 400 600 800 1000"
+        "bonus_health"                                    "200 300 450 650 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_abyssal_blade_3.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_3.txt
@@ -72,7 +72,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "200 400 600 800 1000"
+        "bonus_health"                                    "200 300 450 650 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_abyssal_blade_4.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_4.txt
@@ -72,7 +72,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "200 400 600 800 1000"
+        "bonus_health"                                    "200 300 450 650 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_abyssal_blade_5.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_5.txt
@@ -72,7 +72,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "200 400 600 800 1000"
+        "bonus_health"                                    "200 300 450 650 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_skadi.txt
+++ b/game/scripts/npc/items/item_skadi.txt
@@ -60,7 +60,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "200 400 600 800 1000"
+        "bonus_health"                                    "200 300 450 650 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_skadi_2.txt
+++ b/game/scripts/npc/items/item_skadi_2.txt
@@ -63,7 +63,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "200 400 600 800 1000"
+        "bonus_health"                                    "200 300 450 650 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_skadi_3.txt
+++ b/game/scripts/npc/items/item_skadi_3.txt
@@ -65,7 +65,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "200 400 600 800 1000"
+        "bonus_health"                                    "200 300 450 650 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_skadi_4.txt
+++ b/game/scripts/npc/items/item_skadi_4.txt
@@ -65,7 +65,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "200 400 600 800 1000"
+        "bonus_health"                                    "200 300 450 650 900"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_skadi_5.txt
+++ b/game/scripts/npc/items/item_skadi_5.txt
@@ -64,7 +64,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "200 400 600 800 1000"
+        "bonus_health"                                    "200 300 450 650 900"
       }
       "03"
       {


### PR DESCRIPTION
* Bonus HP reduced from 200/400/600/800/1000 to 200/300/450/650/900.
* Blade of Judecca now has the same bonus mana as Skadi.