### PR TITLE
Heart changes

### DIFF
--- a/game/scripts/npc/items/custom/item_heart_transplant.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant.txt
@@ -92,7 +92,7 @@
       "03" // same as Heart lvls 4-5
       {
         "var_type"                                        "FIELD_FLOAT"
-        "health_regen_pct"                                "2"
+        "health_regen_pct"                                "1.6"
       }
       "04"
       {
@@ -117,7 +117,7 @@
       "08" // same as Heart lvls 3-4
       {
         "var_type"                                        "FIELD_FLOAT"
-        "transplant_health_regen_pct"                     "1.6"
+        "transplant_health_regen_pct"                     "1.5"
       }
       "09"
       {

--- a/game/scripts/npc/items/custom/item_heart_transplant_2.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant_2.txt
@@ -85,7 +85,7 @@
       "03" // same as Heart lvls 4-5
       {
         "var_type"                                        "FIELD_FLOAT"
-        "health_regen_pct"                                "2"
+        "health_regen_pct"                                "1.6"
       }
       "04"
       {
@@ -110,7 +110,7 @@
       "08" // same as Heart lvls 3-4
       {
         "var_type"                                        "FIELD_FLOAT"
-        "transplant_health_regen_pct"                     "1.6"
+        "transplant_health_regen_pct"                     "1.5"
       }
       "09"
       {

--- a/game/scripts/npc/items/item_heart.txt
+++ b/game/scripts/npc/items/item_heart.txt
@@ -83,7 +83,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "health_regen_pct"                                "2"
+        "health_regen_pct"                                "1.6"
       }
       "04"
       {
@@ -98,7 +98,7 @@
       "06"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "buff_duration"                                   "6.0"
+        "buff_duration"                                   "8.0"
       }
       "07"
       {
@@ -118,7 +118,7 @@
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "nuke_base_dmg"                                   "250 350 450 550 650"
+        "nuke_base_dmg"                                   "200 300 400 500 600"
       }
       "11"
       {

--- a/game/scripts/npc/items/item_heart_2.txt
+++ b/game/scripts/npc/items/item_heart_2.txt
@@ -81,7 +81,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "health_regen_pct"                                "2"
+        "health_regen_pct"                                "1.6"
       }
       "04"
       {
@@ -96,7 +96,7 @@
       "06"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "buff_duration"                                   "6.0"
+        "buff_duration"                                   "8.0"
       }
       "07"
       {
@@ -116,7 +116,7 @@
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "nuke_base_dmg"                                   "250 350 450 550 650"
+        "nuke_base_dmg"                                   "200 300 400 500 600"
       }
       "11"
       {

--- a/game/scripts/npc/items/item_heart_3.txt
+++ b/game/scripts/npc/items/item_heart_3.txt
@@ -81,7 +81,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "health_regen_pct"                                "2"
+        "health_regen_pct"                                "1.6"
       }
       "04"
       {
@@ -96,7 +96,7 @@
       "06"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "buff_duration"                                   "6.0"
+        "buff_duration"                                   "8.0"
       }
       "07"
       {
@@ -116,7 +116,7 @@
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "nuke_base_dmg"                                   "250 350 450 550 650"
+        "nuke_base_dmg"                                   "200 300 400 500 600"
       }
       "11"
       {

--- a/game/scripts/npc/items/item_heart_4.txt
+++ b/game/scripts/npc/items/item_heart_4.txt
@@ -82,7 +82,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "health_regen_pct"                                "2"
+        "health_regen_pct"                                "1.6"
       }
       "04"
       {
@@ -97,7 +97,7 @@
       "06"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "buff_duration"                                   "6.0"
+        "buff_duration"                                   "8.0"
       }
       "07"
       {
@@ -117,7 +117,7 @@
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "nuke_base_dmg"                                   "250 350 450 550 650"
+        "nuke_base_dmg"                                   "200 300 400 500 600"
       }
       "11"
       {

--- a/game/scripts/npc/items/item_heart_5.txt
+++ b/game/scripts/npc/items/item_heart_5.txt
@@ -82,7 +82,7 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "health_regen_pct"                                "2"
+        "health_regen_pct"                                "1.6"
       }
       "04"
       {
@@ -97,7 +97,7 @@
       "06"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "buff_duration"                                   "6.0"
+        "buff_duration"                                   "8.0"
       }
       "07"
       {
@@ -117,7 +117,7 @@
       "10"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "nuke_base_dmg"                                   "250 350 450 550 650"
+        "nuke_base_dmg"                                   "200 300 400 500 600"
       }
       "11"
       {


### PR DESCRIPTION
* Heart passive Max HP regen reduced from 2% to 1.6% (Heart Transplant values adjusted accordingly).
* Heart Havoc base damage reduced by 50 at all levels.
* Heart Havoc buff duration increased from 6 to 8 seconds.