### PR TITLE
Echo Sabre cd buff

### DIFF
--- a/game/scripts/npc/items/item_echo_sabre.txt
+++ b/game/scripts/npc/items/item_echo_sabre.txt
@@ -41,7 +41,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "6.0 4.0 2.5 1.8 1.6"
+    "AbilityCooldown"                                     "5.5 3.75 2.5 1.75 1.5" //OAA
     "AbilitySharedCooldown"                               "echo"
 
     // Item Info
@@ -103,7 +103,7 @@
       "10" //OAA
       {
         "var_type"                                        "FIELD_FLOAT"
-        "cooldown_tooltip"                                "5.0 4.0 2.5 1.8 1.6"
+        "cooldown_tooltip"                                "5.5 3.75 2.5 1.75 1.5"
       }
     }
   }

--- a/game/scripts/npc/items/item_echo_sabre_2.txt
+++ b/game/scripts/npc/items/item_echo_sabre_2.txt
@@ -46,7 +46,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "6.0 4.0 2.5 1.8 1.6"
+    "AbilityCooldown"                                     "5.5 3.75 2.5 1.75 1.5"
     "AbilitySharedCooldown"                               "echo"
 
     // Item Info
@@ -109,7 +109,7 @@
       "10" //OAA
       {
         "var_type"                                        "FIELD_FLOAT"
-        "cooldown_tooltip"                                "5.0 4.0 2.5 1.8 1.6"
+        "cooldown_tooltip"                                "5.5 3.75 2.5 1.75 1.5"
       }
     }
   }

--- a/game/scripts/npc/items/item_echo_sabre_3.txt
+++ b/game/scripts/npc/items/item_echo_sabre_3.txt
@@ -46,7 +46,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "6.0 4.0 2.5 1.8 1.6"
+    "AbilityCooldown"                                     "5.5 3.75 2.5 1.75 1.5"
     "AbilitySharedCooldown"                               "echo"
 
     // Item Info
@@ -109,7 +109,7 @@
       "10" //OAA
       {
         "var_type"                                        "FIELD_FLOAT"
-        "cooldown_tooltip"                                "5.0 4.0 2.5 1.8 1.6"
+        "cooldown_tooltip"                                "5.5 3.75 2.5 1.75 1.5"
       }
     }
   }

--- a/game/scripts/npc/items/item_echo_sabre_4.txt
+++ b/game/scripts/npc/items/item_echo_sabre_4.txt
@@ -46,7 +46,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "6.0 4.0 2.5 1.8 1.6"
+    "AbilityCooldown"                                     "5.5 3.75 2.5 1.75 1.5"
     "AbilitySharedCooldown"                               "echo"
 
     // Item Info
@@ -109,7 +109,7 @@
       "10" //OAA
       {
         "var_type"                                        "FIELD_FLOAT"
-        "cooldown_tooltip"                                "5.0 4.0 2.5 1.8 1.6"
+        "cooldown_tooltip"                                "5.5 3.75 2.5 1.75 1.5"
       }
     }
   }

--- a/game/scripts/npc/items/item_echo_sabre_5.txt
+++ b/game/scripts/npc/items/item_echo_sabre_5.txt
@@ -46,7 +46,7 @@
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.0"
-    "AbilityCooldown"                                     "6.0 4.0 2.5 1.8 1.6"
+    "AbilityCooldown"                                     "5.5 3.75 2.5 1.75 1.5"
     "AbilitySharedCooldown"                               "echo"
 
     // Item Info
@@ -108,7 +108,7 @@
       "10" //OAA
       {
         "var_type"                                        "FIELD_FLOAT"
-        "cooldown_tooltip"                                "5.0 4.0 2.5 1.8 1.6"
+        "cooldown_tooltip"                                "5.5 3.75 2.5 1.75 1.5"
       }
     }
   }


### PR DESCRIPTION
* Reduced cd from 6/4/2.5/1.8/1.6 to 5.5/3.75/2.5/1.75/1.5 seconds.
* Fixed tooltip not matching the actual cd.