### PR TITLE
Duel and capture point timings settings changes

### DIFF
--- a/game/scripts/vscripts/components/capturepoints/capturepoints.lua
+++ b/game/scripts/vscripts/components/capturepoints/capturepoints.lua
@@ -59,8 +59,8 @@ function CapturePoints:Init ()
   self.currentCapture = nil
   self.NumCaptures = 0
 
-  CapturePoints.nextCaptureTime = INITIAL_CAPTURE_POINT_DELAY
-  HudTimer:At(INITIAL_CAPTURE_POINT_DELAY - 60, function ()
+  self.nextCaptureTime = self:GetInitialDelay()
+  HudTimer:At(CapturePoints:GetInitialDelay() - 60, function ()
     CapturePoints:ScheduleCapture()
   end)
 
@@ -132,9 +132,9 @@ function CapturePoints:ScheduleCapture()
   end
   PrepareCapture.broadcast(true)
 
-  CapturePoints.nextCaptureTime = HudTimer:GetGameTime() + CAPTURE_INTERVAL + CAPTURE_FIRST_WARN
+  self.nextCaptureTime = HudTimer:GetGameTime() + self:GetCapturePointIntervalTime() + CAPTURE_FIRST_WARN
 
-  self.scheduleCaptureTimer = Timers:CreateTimer(CAPTURE_INTERVAL, function ()
+  self.scheduleCaptureTimer = Timers:CreateTimer(CapturePoints:GetCapturePointIntervalTime(), function ()
     CapturePoints:ScheduleCapture()
   end)
 
@@ -188,7 +188,7 @@ function CapturePoints:StartCapture(color)
 
   Timers:CreateTimer(CAPTURE_FIRST_WARN, function ()
     self:ActuallyStartCapture()
-    CapturePoints.nextCaptureTime = HudTimer:GetGameTime() + CAPTURE_INTERVAL + CAPTURE_FIRST_WARN
+    CapturePoints.nextCaptureTime = HudTimer:GetGameTime() + CapturePoints:GetCapturePointIntervalTime() + CAPTURE_FIRST_WARN
   end)
 end
 
@@ -299,4 +299,42 @@ function CapturePoints:EndCapture ()
   -- Remove vision over capture points
   self.radiant_dummy:AddNewModifier(self.radiant_dummy, nil, "modifier_kill", {duration = 0.1})
   self.dire_dummy:AddNewModifier(self.dire_dummy, nil, "modifier_kill", {duration = 0.1})
+end
+
+function CapturePoints:GetInitialDelay()
+  if CAPTURE_POINTS_AND_DUELS_NO_OVERLAP then
+    if Duels then
+      return Duels:GetDuelTimeout(1) + Duels:GetDuelIntervalTime() + Duels:GetDuelTimeout() + 10
+    else
+      if GetMapName() == "1v1" then
+        return ONE_V_ONE_DUEL_TIMEOUT + ONE_V_ONE_DUEL_INTERVAL + ONE_V_ONE_DUEL_TIMEOUT + 10
+      end
+      return FIRST_DUEL_TIMEOUT + DUEL_INTERVAL + DUEL_TIMEOUT + 10
+    end
+  end
+
+  if GetMapName() == "1v1" then
+    return ONE_V_ONE_INITIAL_CAPTURE_POINT_DELAY
+  end
+
+  return INITIAL_CAPTURE_POINT_DELAY
+end
+
+function CapturePoints:GetCapturePointIntervalTime()
+  if CAPTURE_POINTS_AND_DUELS_NO_OVERLAP then
+    if Duels then
+      return Duels:GetDuelIntervalTime()
+    else
+      if GetMapName() == "1v1" then
+        return ONE_V_ONE_DUEL_INTERVAL
+      end
+      return DUEL_INTERVAL
+    end
+  end
+
+  if GetMapName() == "1v1" then
+    return ONE_V_ONE_CAPTURE_INTERVAL
+  end
+
+  return CAPTURE_INTERVAL
 end

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -109,7 +109,7 @@ function Duels:Init ()
     Duels:StartDuel({
       players = 0,
       firstDuel = true,
-      timeout = FIRST_DUEL_TIMEOUT
+      timeout = Duels:GetDuelTimeout(1)
     })
   end)
 
@@ -489,7 +489,7 @@ function Duels:PreparePlayersToStartDuel(options, playerSplit)
   DuelStartEvent.broadcast(self.currentDuel)
 
   if options.timeout == nil then
-    options.timeout = DUEL_TIMEOUT
+    options.timeout = Duels:GetDuelTimeout()
   end
 
   if options.timeout ~= 0 then
@@ -559,7 +559,7 @@ function Duels:TimeoutDuel ()
 end
 
 function Duels:SetNextDuelTime()
-  Duels.nextDuelTime = HudTimer:GetGameTime() + DUEL_INTERVAL + DUEL_START_WARN_TIME
+  Duels.nextDuelTime = HudTimer:GetGameTime() + Duels:GetDuelIntervalTime() + DUEL_START_WARN_TIME
 end
 
 function Duels:GetNextDuelTime()
@@ -578,7 +578,7 @@ function Duels:CleanUpDuel ()
 
   Music:PlayBackground(1, 7)
 
-  local nextDuelIn = DUEL_INTERVAL
+  local nextDuelIn = Duels:GetDuelIntervalTime()
   Duels:SetNextDuelTime()
 
   if self.startDuelTimer then
@@ -588,7 +588,7 @@ function Duels:CleanUpDuel ()
 
   self.startDuelTimer = Timers:CreateTimer(nextDuelIn - 60 + DUEL_START_WARN_TIME, function ()
     Notifications:TopToAll({text="#duel_minute_warning", duration=10.0})
-    self.startDuelTimer = Timers:CreateTimer(60 - DUEL_START_WARN_TIME, partial(self.StartDuel, self))
+    Duels.startDuelTimer = Timers:CreateTimer(60 - DUEL_START_WARN_TIME, partial(Duels.StartDuel, Duels))
   end)
 
   self.currentDuel = nil
@@ -692,4 +692,30 @@ function Duels:PlayerForDuel(playerId)
   end)
 
   return foundIt
+end
+
+function Duels:GetDuelIntervalTime()
+  if GetMapName() == "1v1" then
+    return ONE_V_ONE_DUEL_INTERVAL
+  end
+
+  return DUEL_INTERVAL
+end
+
+function Duels:GetDuelTimeout(duelType)
+  if GetMapName() == "1v1" then
+    return ONE_V_ONE_DUEL_TIMEOUT
+  end
+  if not duelType then
+    -- Duel is not first and not final
+    return DUEL_TIMEOUT
+  elseif duelType == 1 then
+    -- First duel
+    return FIRST_DUEL_TIMEOUT
+  elseif duelType == 2 then
+    -- Final duel
+    return FINAL_DUEL_TIMEOUT
+  end
+
+  return DUEL_TIMEOUT
 end

--- a/game/scripts/vscripts/components/duels/final-duel.lua
+++ b/game/scripts/vscripts/components/duels/final-duel.lua
@@ -49,7 +49,7 @@ function FinalDuel:Trigger (team)
 
   Duels:StartDuel({
     players = 0,
-    timeout = FINAL_DUEL_TIMEOUT,
+    timeout = Duels:GetDuelTimeout(2),
     isFinalDuel = true,
     forceAllPlayers = true
   })

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -81,7 +81,7 @@ ONE_V_ONE_DUEL_INTERVAL = 360           -- time from duel ending until next duel
 DUEL_START_PROTECTION_TIME = 2          -- duel start protection duration
 
 -- CapturePoints
-CAPTURE_POINTS_AND_DUELS_NO_OVERLAP = true
+CAPTURE_POINTS_AND_DUELS_NO_OVERLAP = true -- Changing INITIAL_CAPTURE_POINT_DELAY, ONE_V_ONE_INITIAL_CAPTURE_POINT_DELAY, CAPTURE_INTERVAL, ONE_V_ONE_CAPTURE_INTERVAL will have no effect if this is true
 INITIAL_CAPTURE_POINT_DELAY = 660       -- how long after the clock hits 0 should the initial Capture Point start counting down. FIRST_DUEL_TIMEOUT + DUEL_INTERVAL + DUEL_TIMEOUT + 10.
 ONE_V_ONE_INITIAL_CAPTURE_POINT_DELAY = 510   -- 2 x ONE_V_ONE_DUEL_TIMEOUT + ONE_V_ONE_DUEL_INTERVAL + 10.
 CAPTURE_FIRST_WARN = 60                 -- how many seconds before spawn of capture points the first ping on minimap will show

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -35,7 +35,7 @@ ABANDON_NEEDED = 3                        -- how many total abandons you need be
 
 -- kill limits
 NORMAL_KILL_LIMIT = 3                     -- Starting KILL_LIMIT = 10 + NORMAL_KILL_LIMIT x number of players: 5v5 - 40; 4v4 - 34; 3v3 - 28; 2v2 - 22; 1v1 - 16;
-ONE_V_ONE_KILL_LIMIT = 10                 -- Starting KILL_LIMIT = 10 + ONE_V_ONE_KILL_LIMIT x 2: 30
+ONE_V_ONE_KILL_LIMIT = 6                  -- Starting KILL_LIMIT = 10 + ONE_V_ONE_KILL_LIMIT x 2: 22
 TEN_V_TEN_KILL_LIMIT = 4                  -- Starting KILL_LIMIT = 10 + TEN_V_TEN_KILL_LIMIT x number of players: 6v6 - 58; 8v8 - 74; 10v10 - 90;
 KILL_LIMIT_INCREASE = 1                   -- Extend amount = KILL_LIMIT_INCREASE x number of players: 5v5 - 10; 4v4 - 8;
 TEN_V_TEN_LIMIT_INCREASE = 1              -- Extend amount = TEN_V_TEN_LIMIT_INCREASE x number of players: 10v10 - 20; 8v8 - 16; 6v6 - 12;

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -73,17 +73,22 @@ DUEL_START_COUNTDOWN = 5                -- How many seconds to count down before
 DUEL_TIMEOUT = 90                       -- Time before the duel starts counting down to end in a stalemate
 FIRST_DUEL_TIMEOUT = 80                 -- Timeout for the level 1 duel at the start of them game
 FINAL_DUEL_TIMEOUT = 180                -- Timeout for the final duel, the game cannot end unless this duel completes without timing out
+ONE_V_ONE_DUEL_TIMEOUT = 70             -- Timeout for every duel in 1v1 mode
 DUEL_END_COUNTDOWN = 10                 -- How many seconds to count down before a duel can timeout (added as a delay before the duel times out)
 DUEL_RUNE_TIMER = 30                    -- how long until the highground object becomes active in duels
-DUEL_INTERVAL = 480                     -- time from duel ending until dnext duel countdown begins
+DUEL_INTERVAL = 480                     -- time from duel ending until next duel countdown begins
+ONE_V_ONE_DUEL_INTERVAL = 360           -- time from duel ending until next duel countdown begins in 1v1 mode
 DUEL_START_PROTECTION_TIME = 2          -- duel start protection duration
 
 -- CapturePoints
-INITIAL_CAPTURE_POINT_DELAY = 660       -- how long after the clock hits 0 should the initial Capture Point start counting down
+CAPTURE_POINTS_AND_DUELS_NO_OVERLAP = true
+INITIAL_CAPTURE_POINT_DELAY = 660       -- how long after the clock hits 0 should the initial Capture Point start counting down. FIRST_DUEL_TIMEOUT + DUEL_INTERVAL + DUEL_TIMEOUT + 10.
+ONE_V_ONE_INITIAL_CAPTURE_POINT_DELAY = 510   -- 2 x ONE_V_ONE_DUEL_TIMEOUT + ONE_V_ONE_DUEL_INTERVAL + 10.
 CAPTURE_FIRST_WARN = 60                 -- how many seconds before spawn of capture points the first ping on minimap will show
 CAPTURE_SECOND_WARN = 30                -- how many seconds before spawn of capture points the second ping on minimap will show
 CAPTURE_START_COUNTDOWN = 5             -- How many seconds to count down before each CapturePoint (added as a delay before the duel starts)
-CAPTURE_INTERVAL = 480                  -- time from CapturePoint beginning until next CapturePoint begins
+CAPTURE_INTERVAL = 480                  -- time from CapturePoint beginning until next CapturePoint begins. DUEL_INTERVAL.
+ONE_V_ONE_CAPTURE_INTERVAL = 360        -- ONE_V_ONE_DUEL_INTERVAL
 CAPTURE_LENTGH = 30                     -- amount of time for 1 hero to capture the point (less with more)
 
 -- Bosses


### PR DESCRIPTION
* Added CAPTURE_POINTS_AND_DUELS_NO_OVERLAP to settings.lua. If you want to try to overlap Duel and Capture point timings, set this to false.
* Changed duel timeout for every duel in 1v1 mode from 80/90/180 to 70 seconds.
* Changed duel interval in 1v1 mode from 480 seconds to 360 seconds.
* Changed initial capture point delay from 660 seconds (11 min) to **FIRST_DUEL_TIMEOUT + DUEL_INTERVAL + DUEL_TIMEOUT + 10** seconds (11 min normal, 8.5 min in 1v1 mode). Changing INITIAL_CAPTURE_POINT_DELAY or ONE_V_ONE_INITIAL_CAPTURE_POINT_DELAY will have no effect if CAPTURE_POINTS_AND_DUELS_NO_OVERLAP is true.
* Changed capture point interval from 480 seconds (8 min) to **DUEL_INTERVAL** (8 min normal, 6 min in 1v1 mode). Changing CAPTURE_INTERVAL or ONE_V_ONE_CAPTURE_INTERVAL will have no effect if CAPTURE_POINTS_AND_DUELS_NO_OVERLAP is true.