### PR TITLE
Sacred Skull nerfs

### DIFF
--- a/game/scripts/npc/items/custom/item_sacred_skull.txt
+++ b/game/scripts/npc/items/custom/item_sacred_skull.txt
@@ -119,7 +119,7 @@
       "10"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "damage_per_missing_hp"                           "15 20 30 45"
+        "damage_per_missing_hp"                           "15 20 25 30"
       }
       "11"
       {

--- a/game/scripts/npc/items/custom/item_sacred_skull_2.txt
+++ b/game/scripts/npc/items/custom/item_sacred_skull_2.txt
@@ -112,7 +112,7 @@
       "10"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "damage_per_missing_hp"                           "15 20 30 45"
+        "damage_per_missing_hp"                           "15 20 25 30"
       }
       "11"
       {

--- a/game/scripts/npc/items/custom/item_sacred_skull_3.txt
+++ b/game/scripts/npc/items/custom/item_sacred_skull_3.txt
@@ -112,7 +112,7 @@
       "10"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "damage_per_missing_hp"                           "15 20 30 45"
+        "damage_per_missing_hp"                           "15 20 25 30"
       }
       "11"
       {

--- a/game/scripts/npc/items/custom/item_sacred_skull_4.txt
+++ b/game/scripts/npc/items/custom/item_sacred_skull_4.txt
@@ -111,7 +111,7 @@
       "10"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "damage_per_missing_hp"                           "15 20 30 45"
+        "damage_per_missing_hp"                           "15 20 25 30"
       }
       "11"
       {

--- a/game/scripts/vscripts/items/sacred_skull.lua
+++ b/game/scripts/vscripts/items/sacred_skull.lua
@@ -56,7 +56,7 @@ function item_sacred_skull:OnSpellStart()
     radius,
     DOTA_UNIT_TARGET_TEAM_ENEMY,
     target_units,
-    DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES,
+    DOTA_UNIT_TARGET_FLAG_NONE,
     FIND_ANY_ORDER,
     false
   )


### PR DESCRIPTION
* Damage per missing hp percent reduced from 15/20/30/45 to 15/20/25/30.
Min damage reduced from 735/980/1470/2205 to 735/980/1225/1470.
Max damage reduced from 1485/1980/2970/4455 to 1485/1980/2475/2970.
* Damage no longer pierces spell immunity.