### PR TITLE
Experience changes 2022

### DIFF
--- a/game/scripts/vscripts/components/creeps/creep_types.lua
+++ b/game/scripts/vscripts/components/creeps/creep_types.lua
@@ -21,7 +21,8 @@ CreepTypes = {
       {"npc_dota_neutral_custom_harpy_scout",       400,    0,  30,     1,   25,  61}
     },
     {
-      {"npc_dota_neutral_custom_mud_golem",         650,    0,  35,    1,    30,  57} -- multiply gold value by 2 and xp value by 2.5 because they split
+      {"npc_dota_neutral_custom_mud_golem",         525,    0,  35,    1,    15,  29}, -- multiply gold value by 2 and xp value by 2.5 because they split
+      {"npc_dota_neutral_custom_mud_golem",         525,    0,  35,    1,    15,  29}
     },
     {
       {"npc_dota_neutral_custom_blue_tomato",       650,  300,  40,   1.3,   35,  82},
@@ -31,30 +32,31 @@ CreepTypes = {
     -- 3 "hard camp"
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_custom_ghost",             800,    0,  35,   1.5,   50,  60}, -- expected gold is 100 and XP 120
-      {"npc_dota_neutral_custom_ghost",             800,    0,  35,   1.5,   50,  60}
+      {"npc_dota_neutral_custom_ghost",             800,    0,  40,   1.5,   50,  50}, -- expected gold is 100 and XP 100
+      {"npc_dota_neutral_fel_beast",                400,    0,  30,    1,    25,  25},
+      {"npc_dota_neutral_fel_beast",                400,    0,  30,    1,    25,  25}
     },
     {
-      {"npc_dota_neutral_custom_centaur_khan",      800,  300,  50,   1.5,   50,  60},
-      {"npc_dota_neutral_custom_small_centaur",     400,    0,  30,    1,    25,  30},
-      {"npc_dota_neutral_custom_small_centaur",     400,    0,  30,    1,    25,  30}
+      {"npc_dota_neutral_custom_centaur_khan",      800,  300,  50,   1.5,   50,  50},
+      {"npc_dota_neutral_custom_small_centaur",     400,    0,  30,    1,    25,  25},
+      {"npc_dota_neutral_custom_small_centaur",     400,    0,  30,    1,    25,  25}
     },
     {
-      {"npc_dota_neutral_satyr_hellcaller",         800,  400,  50,   1.5,   50,  53},
-      {"npc_dota_neutral_satyr_soulstealer",        500,  600,  30,    1,    30,  40},
-      {"npc_dota_neutral_satyr_trickster",          300,  500,  10,    1,    20,  27}
+      {"npc_dota_neutral_satyr_hellcaller",         800,  400,  50,   1.5,   50,  50},
+      {"npc_dota_neutral_satyr_soulstealer",        500,  600,  30,    1,    30,  30},
+      {"npc_dota_neutral_satyr_trickster",          300,  500,  10,    1,    20,  25}
     }
   },
    -- 4 "ancient camp"
   {
     {                                               --HP  MANA  DMG   ARM   GOLD  EXP
-      {"npc_dota_neutral_granite_golem",           1275,    0,  50,    2,   120,  140} -- expected gold is 120 and XP is 140
+      {"npc_dota_neutral_granite_golem",           1275,    0,  50,    2,   120,  120} -- expected gold is 120 and XP is 120
     },
     {
-      {"npc_dota_neutral_rock_golem",              1200,    0,  40,    1,    50,  140}
+      {"npc_dota_neutral_rock_golem",              1200,    0,  40,    1,    50,  120}
     },
     {
-      {"npc_dota_neutral_black_dragon",            1275,  500,  80,    3,   120, 140}
+      {"npc_dota_neutral_black_dragon",            1275,  500,  80,    3,   120, 120}
     }
   },
    -- 5 "solo ancient corner camp"
@@ -66,13 +68,13 @@ CreepTypes = {
    -- 6 "solo ancient mid camp"
   {
     {
-      {"npc_dota_mini_roshan",                     1500,  300,  80,    3,   100, 150}
+      {"npc_dota_mini_roshan",                     1500,  300,  80,    3,   120, 25}
     }
   },
    -- 7 Solo Prowler
   {
     {
-      {"npc_dota_neutral_prowler_shaman",          1275,  400,  80,    3,   100, 150}
+      {"npc_dota_neutral_prowler_shaman",          1275,  400,  80,    3,   100, 120}
     }
   }
 }

--- a/game/scripts/vscripts/components/creeps/creep_types.lua
+++ b/game/scripts/vscripts/components/creeps/creep_types.lua
@@ -1,7 +1,7 @@
 -- These values are starting and minimum values for neutral creeps when 5vs5; values increase over time (check creep_power.lua)
 -- "creep name", Health, Mana, Damage, Armor, Gold Bounty, Exp Bounty
 CreepTypes = {
-  -- 1 "easy camp"
+  -- 1 "easy camp" (CreepMax is 10 for all easy camps)
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
       {"npc_dota_neutral_custom_big_wolf",          480,  150,  35,   1.5,   30,  40}, -- expected gold is 70 and XP is 90
@@ -14,7 +14,7 @@ CreepTypes = {
       {"npc_dota_neutral_custom_kobold",            250,    0,  10,   0.5,   15,  25}
     },
   },
-    -- 2 "medium camp"
+    -- 2 "medium camp" (CreepMax is 8 for all medium camps)
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
       {"npc_dota_neutral_custom_harpy_storm",       650,  300,  40,   1.3,   35,  82}, -- expected gold is 60 and XP is 143
@@ -29,7 +29,7 @@ CreepTypes = {
       {"npc_dota_neutral_custom_blue_potato",       400,    0,  35,   1.3,   25,  61}
     }
   },
-    -- 3 "hard camp"
+    -- 3 "hard camp" (CreepMax is 10 for all hard camps)
   {
     {                                              --HP   MANA  DMG   ARM   GOLD  EXP
       {"npc_dota_neutral_custom_ghost",             800,    0,  40,   1.5,   50,  50}, -- expected gold is 100 and XP 100
@@ -47,7 +47,7 @@ CreepTypes = {
       {"npc_dota_neutral_satyr_trickster",          300,  500,  10,    1,    20,  25}
     }
   },
-   -- 4 "ancient camp"
+   -- 4 "ancient camp" (CreepMax is 8 for ancient camps)
   {
     {                                               --HP  MANA  DMG   ARM   GOLD  EXP
       {"npc_dota_neutral_granite_golem",           1275,    0,  50,    2,   120,  120} -- expected gold is 120 and XP is 120
@@ -59,19 +59,19 @@ CreepTypes = {
       {"npc_dota_neutral_black_dragon",            1275,  500,  80,    3,   120, 120}
     }
   },
-   -- 5 "solo ancient corner camp"
+   -- 5 "solo ancient corner camp" (CreepMax is 1)
   {
     {
       {"npc_dota_neutral_custom_black_dragon",     1500,  300,  80,    3,   100, 150}
     }
   },
-   -- 6 "solo ancient mid camp"
+   -- 6 "solo ancient mid camp" (CreepMax is 1)
   {
     {
       {"npc_dota_mini_roshan",                     1500,  300,  80,    3,   120, 25}
     }
   },
-   -- 7 Solo Prowler
+   -- 7 "solo prowler - part of the ancient camp" (CreepMax is 1)
   {
     {
       {"npc_dota_neutral_prowler_shaman",          1275,  400,  80,    3,   100, 120}

--- a/game/scripts/vscripts/components/duels/duels.lua
+++ b/game/scripts/vscripts/components/duels/duels.lua
@@ -244,7 +244,7 @@ function Duels:StartDuel(options)
   options = options or {}
   if not options.firstDuel then
     Music:SetMusic(12)
-    self.allowExperienceGain = 0
+    self.allowExperienceGain = 1
   else
     self.allowExperienceGain = 2
   end

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -141,13 +141,15 @@ LOGGLY_ACCOUNT_ID = 'afa7c97f-1110-4738-9e10-4423f3675386'      -- The Loggly to
 USE_CUSTOM_HERO_LEVELS = true  -- Should the heroes give a custom amount of XP when killed? Set to true if you don't want DotA default values.
 
 -- Formula for XP on hero kill: (HERO_XP_BOUNTY_BASE + HERO_XP_BOUNTY_STREAK + HERO_XP_BONUS_FACTOR x DyingHeroXP) / number_of_killers
-HERO_XP_BOUNTY_BASE = 100            -- 100 in normal dota
+HERO_XP_BOUNTY_BASE = 80             -- 100 in normal dota
 HERO_XP_BOUNTY_STREAK_BASE = 30      -- Min amount of streak XP bonus (min streak is 3; lvl * 30 in normal dota)
 HERO_XP_BOUNTY_STREAK_INCREASE = 100 -- not used for now
 HERO_XP_BOUNTY_STREAK_MAX = 3000     -- Max amount of streak XP bonus (lvl * streak * 10 in normal dota where lvl <= 25)
-HERO_XP_BONUS_FACTOR = 0.13          -- Multiplier for the XP of the killed hero (0.13 in normal dota)
+HERO_XP_BONUS_FACTOR = 0.12          -- Multiplier for the XP of the killed hero (0.13 in normal dota)
+HERO_XP_BOUNTY_PER_HERO_LVL = 20     -- Multiplier for the lvl of the killed hero (not in normal dota)
 HERO_KILL_XP_RADIUS = 1500           -- XP range for killing heroes (1500 in normal dota)
 HERO_KILL_GOLD_RADIUS = 1500         -- Gold assist range for killing heroes (1500 in normal dota)
+HERO_DYING_STREAK_MAX = 5            -- After how many deaths, hero stops giving bonus xp to the killer
 
 -- Runes
 USE_DEFAULT_RUNE_SYSTEM = false      -- Should we use the default dota rune spawn timings and the same runes as dota have?


### PR DESCRIPTION
When I rearranged the creep camps on the map, my intention was to increase the amount of gold on the map. But in the process, I increased the number of creeps by 2 camps and I forgot that experience from some camps was already overtuned. Total experience on the map was increased by 11% and more (the exact number is not easy to calculate because of too many factors). With this PR, I am trying to mitigate that issue and tone down experience bounty from the Ancient camp and mini Roshans. For the mini Roshans I had something in plan (they were meant as a cute placeholder), but idk if I will ever get to realize that plan. Mini Roshans are not supposed to give any xp.
The second part of this PR is focused on the hero kill experience. I changed the formula to be more casual and noob-friendly. The goal was to make 'feeding' less punishing. I added a new 'dying streak' mechanic that should decrease the xp bounty of 'feeders'. I think I covered all the edge cases where this can be abused, if not, please tell me.

* Mud Golems now spawn in pairs. This change prevents the chance for medium camps to give way too much experience if multiple golems spawn. (Adjusted Mud Golems gold and experience accordingly.)
* Reduced experience bounty of Hard camps by 17%.
* Ghosts no longer spawn in pairs. Now it only spawns one Ghost and 2 small ghost-like creeps without abilities. This change prevents the chance for hard camps to give way too much gold and experience if multiple ghosts spawn.
* Reduced experience bounty of Ancient camps by 14%. (Prowler experience bounty reduced by 20%)
* Mini Roshan experience bounty reduced by 84%.
* Mini Roshan gold bounty increased by 20%.

* Hero kill xp formula changed from (100 + killedHeroStreakXP + (killedHeroXP * 0.13)) / N to **(80 + killedHeroStreakXP + 20 * killedHeroLevel + killedHeroXP * max(0.12 * (6 - killedHeroDyingStreak) / 5), 0)) / N**.
* Hero's dying streak is reset to 0 when the hero with dying streak kills another hero or when the hero with dying streak is denied (by Neutrals or his team).
* Hero's dying streak is 1 if the hero died to offside or fountain.
* No more special rules for hero kills and normal duels. First Duel still doesn't give experience for hero kills.