### PR TITLE
Splash Cannon rework

### DIFF
--- a/content/soundevents/items/oaa_items_sfx.vsndevts
+++ b/content/soundevents/items/oaa_items_sfx.vsndevts
@@ -16,5 +16,37 @@
     volume_fade_out = "0.600000"
     spread_radius = "300.000000"
   }
+  
+  Splash_Cannon.Launch = {
+    type = "dota_src1_3d"
+    volume = 1.000000
+    pitch_rand_min = -0.050000
+    pitch_rand_max = 0.050000
+    pitch = 1.000000
+    soundlevel = 78.000000
+    distance_max = 2500.000000
+    vsnd_files = 
+    [
+      "sounds/weapons/hero/gyrocopter/rocket_barrage_fire.vsnd",
+    ]
+    vsnd_duration = 1.002857
+  }
+  
+  Splash_Cannon.Explosion = {
+    type = "dota_update_default"
+    volume = 0.800000
+    pitch_rand_min = -0.050000
+    pitch_rand_max = 0.050000
+    pitch = 1.000000
+    soundlevel = 81.000000
+    mixgroup = "Weapons"
+    volume_fade_out = 0.600000
+    spread_radius = 500.000000
+    vsnd_files = 
+    [
+      "sounds/weapons/hero/gyrocopter/call_down_impact.vsnd",
+    ]
+    vsnd_duration = 1.0
+  }
 
 }

--- a/game/resource/English/ability/items/tooltip_siege_mode.txt
+++ b/game/resource/English/ability/items/tooltip_siege_mode.txt
@@ -3,7 +3,7 @@
 //==================================================================
 "DOTA_Tooltip_Ability_item_siege_mode"                          "Splash Cannon"
 "DOTA_Tooltip_Ability_item_recipe_siege_mode"                   "Splash Cannon Recipe"
-"DOTA_Tooltip_Ability_item_siege_mode_Description"              "<h1>Active: Splash Mode</h1> Causes your attacks to deal %active_splash_damage%%% splash damage in a %siege_splash_radius% radius. Lasts %duration% seconds."
+"DOTA_Tooltip_Ability_item_siege_mode_Description"              "<h1>Active: Cannon Fire</h1> Bombard an area with a cannoball. Enemies in the area will be damaged and knocked back. Damage is equal to %active_damage% + %active_splash_percent%%% of your attack damage. Using Cannon Fire will cause a powerful recoil, pushing you backwards.<br><br>Radius: %active_radius%<br>Knockback distance: %knockback_distance%<br>Range: %abilitycastrange% \n\n<h1>Passive: Splash Attack</h1> Causes your attacks to deal %passive_splash_percent%%% splash damage in a %passive_splash_radius% radius."
 "DOTA_Tooltip_Ability_item_siege_mode_Lore"                     "A lost Hero's equipment. Its user becomes the bastion of the battlefield, repelling even the most formidable enemy forces."
 "DOTA_Tooltip_Ability_item_siege_mode_Note0"                    "Splash Cannon bonus attack range doesn't stack with Dragon Lance, Hurricane Pike or with another Splash Cannon."
 //"DOTA_Tooltip_Ability_item_siege_mode_Note1"                    ""
@@ -13,6 +13,7 @@
 "DOTA_Tooltip_Ability_item_siege_mode_bonus_health"             "+$health"
 "DOTA_Tooltip_Ability_item_siege_mode_bonus_health_regen"       "+$hp_regen"
 "DOTA_Tooltip_Ability_item_siege_mode_bonus_attack_range"       "+$attack_range"
+"DOTA_Tooltip_Ability_item_siege_mode_bonus_damage"             "+$damage"
 
 "DOTA_Tooltip_Ability_item_siege_mode_2"                        "#{DOTA_Tooltip_Ability_item_siege_mode}"
 "DOTA_Tooltip_Ability_item_recipe_siege_mode_2"                 "#{DOTA_Tooltip_Ability_item_recipe_siege_mode}"
@@ -26,6 +27,7 @@
 "DOTA_Tooltip_Ability_item_siege_mode_2_bonus_health"           "#{DOTA_Tooltip_Ability_item_siege_mode_bonus_health}"
 "DOTA_Tooltip_Ability_item_siege_mode_2_bonus_health_regen"     "#{DOTA_Tooltip_Ability_item_siege_mode_bonus_health_regen}"
 "DOTA_Tooltip_Ability_item_siege_mode_2_bonus_attack_range"     "#{DOTA_Tooltip_Ability_item_siege_mode_bonus_attack_range}"
+"DOTA_Tooltip_Ability_item_siege_mode_2_bonus_damage"           "#{DOTA_Tooltip_Ability_item_siege_mode_bonus_damage}"
 
-"DOTA_Tooltip_modifier_item_siege_mode_active"                   "Splash Mode"
-"DOTA_Tooltip_modifier_item_siege_mode_active_Description"       "Attacks do splash damage in an area."
+//"DOTA_Tooltip_modifier_item_siege_mode_active"                   "Splash Mode"
+//"DOTA_Tooltip_modifier_item_siege_mode_active_Description"       "Attacks do splash damage in an area."

--- a/game/scripts/npc/items/custom/item_siege_mode.txt
+++ b/game/scripts/npc/items/custom/item_siege_mode.txt
@@ -38,17 +38,17 @@
     "ID"                                                  "3555"
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/siege_mode.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
     "AbilityUnitDamageType"                               "DAMAGE_TYPE_PHYSICAL"
     "AbilityTextureName"                                  "custom/siege_mode_1"
-    "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
     "AbilityCastPoint"                                    "0.0"
-    "AbilityManaCost"                                     "0"
-    "AbilityCooldown"                                     "16"
+    //"AbilityCastRange"                                    "1100" // equal to attack range
+    "AbilityManaCost"                                     "200"
+    "AbilityCooldown"                                     "18"
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
@@ -66,9 +66,10 @@
     //-------------------------------------------------------------------------------------------------------------
     "precache"
     {
-      "particle"                                          "particles/units/heroes/hero_oracle/oracle_fortune_purge_root_pnt.vpcf"
+      //"particle"                                          "particles/units/heroes/hero_oracle/oracle_fortune_purge_root_pnt.vpcf"
       "particle"                                          "particles/econ/items/clockwerk/clockwerk_paraflare/clockwerk_para_rocket_flare_explosion.vpcf"
       "particle"                                          "particles/base_attacks/ranged_tower_bad.vpcf"
+      "particle"                                          "particles/econ/items/techies/techies_arcana/techies_suicide_arcana.vpcf"
     }
 
     // Special
@@ -97,7 +98,7 @@
       }
       "05"
       {
-        "var_type"                                        "FIELD_FLOAT"
+        "var_type"                                        "FIELD_INTEGER"
         "bonus_health_regen"                              "12 15"
       }
       "06" // ranged only
@@ -108,17 +109,47 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_splash_radius"                            "300"
+        "bonus_damage"                                    "100 150"
       }
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_splash_damage"                            "150"
+        "passive_splash_radius"                           "250"
       }
       "09"
       {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_splash_percent"                          "40"
+      }
+      "10"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_damage"                                   "700 1000"
+      }
+      "11"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_radius"                                   "500"
+      }
+      "12"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_splash_percent"                           "150"
+      }
+      "13"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "knockback_distance"                              "250"
+      }
+      "14"
+      {
         "var_type"                                        "FIELD_FLOAT"
-        "duration"                                        "8"
+        "knockback_duration"                              "0.5"
+      }
+      "15"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "projectile_speed_multiplier"                     "0.5"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_siege_mode.txt
+++ b/game/scripts/npc/items/custom/item_siege_mode.txt
@@ -38,7 +38,7 @@
     "ID"                                                  "3555"
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/siege_mode.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE | DOTA_ABILITY_BEHAVIOR_DIRECTIONAL"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
@@ -151,6 +151,16 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "projectile_speed"                                "1800"
+      }
+      "16"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "recoil_distance"                                 "250"
+      }
+      "17"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "recoil_duration"                                 "0.2"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_siege_mode.txt
+++ b/game/scripts/npc/items/custom/item_siege_mode.txt
@@ -46,7 +46,7 @@
     "AbilityTextureName"                                  "custom/siege_mode_1"
 
     "AbilityCastPoint"                                    "0.0"
-    //"AbilityCastRange"                                    "1100" // equal to attack range
+    "AbilityCastRange"                                    "1100"
     "AbilityManaCost"                                     "200"
     "AbilityCooldown"                                     "18"
 
@@ -69,7 +69,8 @@
       //"particle"                                          "particles/units/heroes/hero_oracle/oracle_fortune_purge_root_pnt.vpcf"
       "particle"                                          "particles/econ/items/clockwerk/clockwerk_paraflare/clockwerk_para_rocket_flare_explosion.vpcf"
       "particle"                                          "particles/base_attacks/ranged_tower_bad.vpcf"
-      "particle"                                          "particles/econ/items/techies/techies_arcana/techies_suicide_arcana.vpcf"
+      "particle"                                          "particles/units/heroes/hero_batrider/batrider_flamebreak_explosion.vpcf"
+      "soundfile"                                         "soundevents/items/oaa_items_sfx.vsndevts"
     }
 
     // Special
@@ -148,8 +149,8 @@
       }
       "15"
       {
-        "var_type"                                        "FIELD_FLOAT"
-        "projectile_speed_multiplier"                     "0.5"
+        "var_type"                                        "FIELD_INTEGER"
+        "projectile_speed"                                "1800"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_siege_mode_2.txt
+++ b/game/scripts/npc/items/custom/item_siege_mode_2.txt
@@ -39,17 +39,17 @@
     "ID"                                                  "3559"
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/siege_mode.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
     "AbilityUnitDamageType"                               "DAMAGE_TYPE_PHYSICAL"
     "AbilityTextureName"                                  "custom/siege_mode_2"
-    "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
     "AbilityCastPoint"                                    "0.0"
-    "AbilityManaCost"                                     "0"
-    "AbilityCooldown"                                     "16"
+    //"AbilityCastRange"                                    "1100" // equal to attack range
+    "AbilityManaCost"                                     "200"
+    "AbilityCooldown"                                     "18"
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
@@ -66,9 +66,10 @@
     //-------------------------------------------------------------------------------------------------------------
     "precache"
     {
-      "particle"                                          "particles/units/heroes/hero_oracle/oracle_fortune_purge_root_pnt.vpcf"
+      //"particle"                                          "particles/units/heroes/hero_oracle/oracle_fortune_purge_root_pnt.vpcf"
       "particle"                                          "particles/econ/items/clockwerk/clockwerk_paraflare/clockwerk_para_rocket_flare_explosion.vpcf"
       "particle"                                          "particles/base_attacks/ranged_tower_bad.vpcf"
+      "particle"                                          "particles/econ/items/techies/techies_arcana/techies_suicide_arcana.vpcf"
     }
 
     // Special
@@ -97,7 +98,7 @@
       }
       "05"
       {
-        "var_type"                                        "FIELD_FLOAT"
+        "var_type"                                        "FIELD_INTEGER"
         "bonus_health_regen"                              "12 15"
       }
       "06" // ranged only
@@ -108,17 +109,47 @@
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_splash_radius"                            "300"
+        "bonus_damage"                                    "100 150"
       }
       "08"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_splash_damage"                            "150"
+        "passive_splash_radius"                           "250"
       }
       "09"
       {
+        "var_type"                                        "FIELD_INTEGER"
+        "passive_splash_percent"                          "40"
+      }
+      "10"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_damage"                                   "700 1000"
+      }
+      "11"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_radius"                                   "500"
+      }
+      "12"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "active_splash_percent"                           "150"
+      }
+      "13"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "knockback_distance"                              "250"
+      }
+      "14"
+      {
         "var_type"                                        "FIELD_FLOAT"
-        "duration"                                        "8"
+        "knockback_duration"                              "0.5"
+      }
+      "15"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "projectile_speed_multiplier"                     "0.5"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_siege_mode_2.txt
+++ b/game/scripts/npc/items/custom/item_siege_mode_2.txt
@@ -39,7 +39,7 @@
     "ID"                                                  "3559"
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/siege_mode.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE | DOTA_ABILITY_BEHAVIOR_DIRECTIONAL"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
     "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
@@ -151,6 +151,16 @@
       {
         "var_type"                                        "FIELD_INTEGER"
         "projectile_speed"                                "1800"
+      }
+      "16"
+      {
+        "var_type"                                        "FIELD_INTEGER"
+        "recoil_distance"                                 "250"
+      }
+      "17"
+      {
+        "var_type"                                        "FIELD_FLOAT"
+        "recoil_duration"                                 "0.2"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_siege_mode_2.txt
+++ b/game/scripts/npc/items/custom/item_siege_mode_2.txt
@@ -47,7 +47,7 @@
     "AbilityTextureName"                                  "custom/siege_mode_2"
 
     "AbilityCastPoint"                                    "0.0"
-    //"AbilityCastRange"                                    "1100" // equal to attack range
+    "AbilityCastRange"                                    "1100"
     "AbilityManaCost"                                     "200"
     "AbilityCooldown"                                     "18"
 
@@ -69,7 +69,8 @@
       //"particle"                                          "particles/units/heroes/hero_oracle/oracle_fortune_purge_root_pnt.vpcf"
       "particle"                                          "particles/econ/items/clockwerk/clockwerk_paraflare/clockwerk_para_rocket_flare_explosion.vpcf"
       "particle"                                          "particles/base_attacks/ranged_tower_bad.vpcf"
-      "particle"                                          "particles/econ/items/techies/techies_arcana/techies_suicide_arcana.vpcf"
+      "particle"                                          "particles/units/heroes/hero_batrider/batrider_flamebreak_explosion.vpcf"
+      "soundfile"                                         "soundevents/items/oaa_items_sfx.vsndevts"
     }
 
     // Special
@@ -148,8 +149,8 @@
       }
       "15"
       {
-        "var_type"                                        "FIELD_FLOAT"
-        "projectile_speed_multiplier"                     "0.5"
+        "var_type"                                        "FIELD_INTEGER"
+        "projectile_speed"                                "1800"
       }
     }
   }

--- a/game/scripts/vscripts/items/siege_mode.lua
+++ b/game/scripts/vscripts/items/siege_mode.lua
@@ -1,11 +1,20 @@
 LinkLuaModifier("modifier_intrinsic_multiplexer", "modifiers/modifier_intrinsic_multiplexer.lua", LUA_MODIFIER_MOTION_NONE)
 LinkLuaModifier("modifier_item_siege_mode_stacking_stats", "items/siege_mode.lua", LUA_MODIFIER_MOTION_NONE)
 LinkLuaModifier("modifier_item_siege_mode_non_stacking_stats", "items/siege_mode.lua", LUA_MODIFIER_MOTION_NONE)
-LinkLuaModifier("modifier_item_siege_mode_active", "items/siege_mode.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_siege_mode_thinker", "items/siege_mode.lua", LUA_MODIFIER_MOTION_NONE)
+--LinkLuaModifier("modifier_item_siege_mode_active", "items/siege_mode.lua", LUA_MODIFIER_MOTION_NONE)
 
 ---------------------------------------------------------------------------------------------------
 
-item_siege_mode = class(TransformationBaseClass)
+item_siege_mode = class(ItemBaseClass)
+
+function item_siege_mode:GetCastRange(location, target)
+  return self:GetCaster():GetAttackRange()
+end
+
+function item_siege_mode:GetAOERadius()
+  return self:GetSpecialValueFor("active_radius")
+end
 
 function item_siege_mode:GetIntrinsicModifierName()
   return "modifier_intrinsic_multiplexer"
@@ -18,8 +27,150 @@ function item_siege_mode:GetIntrinsicModifierNames()
   }
 end
 
-function item_siege_mode:GetTransformationModifierName()
-  return "modifier_item_siege_mode_active"
+--function item_siege_mode:GetTransformationModifierName()
+  --return "modifier_item_siege_mode_active"
+--end
+
+function item_siege_mode:OnSpellStart()
+  local caster = self:GetCaster()
+  local target = self:GetCursorPosition()
+
+  if not target then
+    return
+  end
+
+  -- KVs
+  local projectile_speed_multiplier = self:GetSpecialValueFor("projectile_speed_multiplier")
+  local projectile_vision_radius = self:GetSpecialValueFor("knockback_distance")
+
+  -- Other variables
+  local attack_projectile_speed = caster:GetProjectileSpeed()
+  local caster_team = caster:GetTeamNumber()
+  local caster_loc = caster:GetAbsOrigin()
+
+  if not attack_projectile_speed or attack_projectile_speed <= 0 then
+    attack_projectile_speed = 900
+  end
+
+  -- Calculate projectile stuff
+  local projectile_speed = attack_projectile_speed * projectile_speed_multiplier
+  local distance = (caster_loc - target):Length2D()
+  local projectile_duration = distance / projectile_speed + 0.1
+
+  -- Create a dummy for the tracking projectile
+  local dummy = CreateModifierThinker(caster, self, "modifier_item_siege_mode_thinker", {duration = projectile_duration}, target, caster_team, false)
+
+  -- Tracking projectile info
+  local projectile = {
+    EffectName = "particles/base_attacks/ranged_tower_bad.vpcf",
+    Ability = self,
+    Source = caster,
+    vSourceLoc = caster_loc,
+    Target = dummy,
+    iMoveSpeed = projectile_speed,
+    bDodgeable = false,
+    bVisibleToEnemies = true,
+    bProvidesVision = true,
+    iVisionRadius = projectile_vision_radius,
+    iVisionTeamNumber = caster_team,
+  }
+
+  -- Create a tracking projectile
+  ProjectileManager:CreateTrackingProjectile(projectile)
+
+  -- Sound
+  --caster:EmitSound("")
+end
+
+function item_siege_mode:OnProjectileHit(target, location)
+  if not target or not location then
+    return
+  end
+
+  local caster = self:GetCaster()
+  local origin = target:GetAbsOrigin()
+
+  -- Ability constants
+  local targetTeam = self:GetAbilityTargetTeam()
+  local targetType = self:GetAbilityTargetType()
+  local targetFlags = self:GetAbilityTargetFlags()
+  local damageType = self:GetAbilityDamageType()
+
+  -- KVs
+  local radius = self:GetSpecialValueFor("active_radius")
+  local attack_damage_percent = self:GetSpecialValueFor("active_splash_percent")
+  local bonus_damage = self:GetSpecialValueFor("active_damage")
+  local distance = self:GetSpecialValueFor("knockback_distance")
+  local duration = self:GetSpecialValueFor("knockback_duration")
+
+  -- Initialize knockback table
+  local knockback_table = {
+    should_stun = 0,
+    center_x = origin.x,
+    center_y = origin.y,
+    center_z = origin.z,
+    duration = duration,
+    knockback_duration = duration,
+    knockback_distance = distance,
+  }
+
+  -- Initialize damage table
+  local damage_table = {
+    attacker = caster,
+    damage_type = damageType or DAMAGE_TYPE_PHYSICAL,
+    damage_flags = bit.bor(DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION, DOTA_DAMAGE_FLAG_NO_SPELL_LIFESTEAL, DOTA_DAMAGE_FLAG_BYPASSES_BLOCK),
+    ability = self,
+  }
+
+  local splash_damage = caster:GetAverageTrueAttackDamage(nil) * attack_damage_percent * 0.01
+  if caster:IsRangedAttacker() then
+    damage_table.damage = bonus_damage + splash_damage
+  else
+  -- Melee casters don't apply splash
+    damage_table.damage = bonus_damage
+  end
+
+  -- find units around the target location
+  local units = FindUnitsInRadius(
+    caster:GetTeamNumber(),
+    origin,
+    nil,
+    radius,
+    targetTeam,
+    targetType,
+    targetFlags,
+    FIND_ANY_ORDER,
+    false
+  )
+
+  -- Particles
+  local part = ParticleManager:CreateParticle("particles/econ/items/clockwerk/clockwerk_paraflare/clockwerk_para_rocket_flare_explosion.vpcf", PATTACH_CUSTOMORIGIN, caster)
+  ParticleManager:SetParticleControl(part, 3, origin)
+  ParticleManager:ReleaseParticleIndex(part)
+  local explosion = ParticleManager:CreateParticle("particles/econ/items/techies/techies_arcana/techies_suicide_arcana.vpcf", PATTACH_CUSTOMORIGIN, caster)
+  ParticleManager:SetParticleControl(explosion, 0, origin)
+  ParticleManager:SetParticleControl(explosion, 3, origin)
+  ParticleManager:ReleaseParticleIndex(explosion)
+
+  -- iterate through all targets
+  for _, unit in pairs(units) do
+    if unit and not unit:IsNull() then
+      if not unit:IsMagicImmune() and not unit:IsAttackImmune() then
+        -- Apply knockback
+        unit:AddNewModifier(caster, self, "modifier_knockback", knockback_table)
+      end
+
+      -- Apply damage
+      damage_table.victim = unit
+      ApplyDamage(damage_table)
+    end
+  end
+
+  return true
+end
+
+function item_siege_mode:ProcsMagicStick()
+  return false
 end
 
 item_siege_mode_2 = item_siege_mode
@@ -50,6 +201,7 @@ function modifier_item_siege_mode_stacking_stats:OnCreated()
     self.bonus_strength = ability:GetSpecialValueFor("bonus_strength")
     self.bonus_agility = ability:GetSpecialValueFor("bonus_agility")
     self.bonus_intellect = ability:GetSpecialValueFor("bonus_intellect")
+    self.bonus_damage = ability:GetSpecialValueFor("bonus_damage")
   end
 end
 
@@ -61,6 +213,7 @@ function modifier_item_siege_mode_stacking_stats:OnRefresh()
     self.bonus_strength = ability:GetSpecialValueFor("bonus_strength")
     self.bonus_agility = ability:GetSpecialValueFor("bonus_agility")
     self.bonus_intellect = ability:GetSpecialValueFor("bonus_intellect")
+    self.bonus_damage = ability:GetSpecialValueFor("bonus_damage")
   end
 end
 
@@ -71,6 +224,7 @@ function modifier_item_siege_mode_stacking_stats:DeclareFunctions()
     MODIFIER_PROPERTY_STATS_STRENGTH_BONUS,
     MODIFIER_PROPERTY_STATS_AGILITY_BONUS,
     MODIFIER_PROPERTY_STATS_INTELLECT_BONUS,
+    MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE,
   }
 end
 
@@ -92,6 +246,10 @@ end
 
 function modifier_item_siege_mode_stacking_stats:GetModifierBonusStats_Intellect()
   return self.bonus_intellect or self:GetAbility():GetSpecialValueFor("bonus_intellect")
+end
+
+function modifier_item_siege_mode_stacking_stats:GetModifierPreAttack_BonusDamage()
+  return self.bonus_damage or self:GetAbility():GetSpecialValueFor("bonus_damage")
 end
 
 ---------------------------------------------------------------------------------------------------
@@ -130,6 +288,7 @@ end
 function modifier_item_siege_mode_non_stacking_stats:DeclareFunctions()
   local funcs = {
     MODIFIER_PROPERTY_ATTACK_RANGE_BONUS,
+    MODIFIER_EVENT_ON_ATTACK_LANDED,
   }
 
   return funcs
@@ -149,8 +308,137 @@ function modifier_item_siege_mode_non_stacking_stats:GetModifierAttackRangeBonus
   return self.attack_range or self:GetAbility():GetSpecialValueFor("bonus_attack_range")
 end
 
+function modifier_item_siege_mode_non_stacking_stats:OnAttackLanded(event)
+  if not IsServer() then
+    return
+  end
+
+  local parent = self:GetParent()
+  if event.attacker ~= parent then
+    return
+  end
+
+  if not parent or parent:IsNull() then
+    return
+  end
+
+  -- Splash doesn't work on illusions and melee units
+  if parent:IsIllusion() or not parent:IsRangedAttacker() then
+    return
+  end
+
+  local target = event.target
+  if not target or target:IsNull() then
+    return
+  end
+
+  if target.GetUnitName == nil then
+    return
+  end
+
+  -- Don't affect buildings, wards and invulnerable units.
+  if target:IsTower() or target:IsBarracks() or target:IsBuilding() or target:IsOther() or target:IsInvulnerable() then
+    return
+  end
+
+  local ability = self:GetAbility()
+  if not ability or ability:IsNull() then
+    return
+  end
+
+  local origin = target:GetAbsOrigin()
+
+  -- set the targeting requirements for the actual targets
+  local targetTeam = ability:GetAbilityTargetTeam()
+  local targetType = ability:GetAbilityTargetType()
+  local targetFlags = ability:GetAbilityTargetFlags()
+
+  -- Splash parameters
+  local splash_radius = ability:GetSpecialValueFor("passive_splash_radius")
+  local splash_percent = ability:GetSpecialValueFor("passive_splash_percent")
+
+  -- find all appropriate targets around the initial target
+  local units = FindUnitsInRadius(
+    parent:GetTeamNumber(),
+    origin,
+    nil,
+    splash_radius,
+    targetTeam,
+    targetType,
+    targetFlags,
+    FIND_ANY_ORDER,
+    false
+  )
+
+  -- get the wearer's damage
+  local damage = event.original_damage
+
+  -- get the damage modifier
+  local actual_damage = damage * splash_percent * 0.01
+
+  -- Damage table
+  local damage_table = {}
+  damage_table.attacker = parent
+  damage_table.damage_type = ability:GetAbilityDamageType() or DAMAGE_TYPE_PHYSICAL
+  damage_table.ability = ability
+  damage_table.damage = actual_damage
+  damage_table.damage_flags = bit.bor(DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION, DOTA_DAMAGE_FLAG_NO_SPELL_LIFESTEAL)
+
+  -- Show particle only if damage is above zero and only if there are units nearby
+  if actual_damage > 0 and #units > 1 then
+    local part = ParticleManager:CreateParticle("particles/econ/items/clockwerk/clockwerk_paraflare/clockwerk_para_rocket_flare_explosion.vpcf", PATTACH_CUSTOMORIGIN, parent)
+    ParticleManager:SetParticleControl(part, 3, origin)
+    ParticleManager:ReleaseParticleIndex(part)
+  end
+
+  -- iterate through all targets
+  for _, unit in pairs(units) do
+    if unit and not unit:IsNull() and unit ~= target then
+      damage_table.victim = unit
+      ApplyDamage(damage_table)
+    end
+  end
+
+  -- sound
+  target:EmitSound("dota_fountain.ProjectileImpact")
+end
+
 ---------------------------------------------------------------------------------------------------
 
+modifier_item_siege_mode_thinker = class(ModifierBaseClass)
+
+function modifier_item_siege_mode_thinker:IsHidden()
+  return true
+end
+
+function modifier_item_siege_mode_thinker:IsDebuff()
+  return false
+end
+
+function modifier_item_siege_mode_thinker:IsPurgable()
+  return false
+end
+
+function modifier_item_siege_mode_thinker:OnCreated()
+
+end
+
+function modifier_item_siege_mode_thinker:OnDestroy()
+  if not IsServer() then
+    return
+  end
+  local parent = self:GetParent()
+  if self.particle then
+    ParticleManager:DestroyParticle(self.particle, true)
+    ParticleManager:ReleaseParticleIndex(self.particle)
+  end
+  if parent and not parent:IsNull() then
+    parent:ForceKill(false)
+  end
+end
+
+---------------------------------------------------------------------------------------------------
+--[[
 modifier_item_siege_mode_active = class(ModifierBaseClass)
 
 function modifier_item_siege_mode_active:IsHidden()
@@ -169,7 +457,6 @@ function modifier_item_siege_mode_active:GetEffectName()
   return "particles/units/heroes/hero_oracle/oracle_fortune_purge_root_pnt.vpcf"
 end
 
---[[
 function modifier_item_siege_mode_active:OnCreated()
   local ability = self:GetAbility()
 
@@ -223,80 +510,53 @@ function modifier_item_siege_mode_active:OnIntervalThink()
     self:Destroy()
   end
 end
-]]
-function modifier_item_siege_mode_active:OnDestroy()
-  if not IsServer() then
-    return
-  end
-
-  local parent = self:GetParent()
-
-  if not parent:IsRangedAttacker() then
-    return
-  end
-
-  -- if self.parentWasRanged then
-  parent:ChangeAttackProjectile()
-    -- return
-  -- end
-
-  -- if parent:HasModifier("modifier_terrorblade_metamorphosis") or parent:HasAbility("troll_warlord_berserkers_rage") or parent:HasModifier("modifier_dragon_knight_dragon_form") or parent:HasModifier("modifier_lone_druid_true_form") then
-    -- return
-  -- end
-
-  -- parent:SetAttackCapability(DOTA_UNIT_CAP_MELEE_ATTACK)
-end
 
 function modifier_item_siege_mode_active:DeclareFunctions()
   local funcs = {
-    --MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE,
-    --MODIFIER_PROPERTY_FIXED_ATTACK_RATE,
-    --MODIFIER_PROPERTY_ATTACK_RANGE_BONUS,
-    --MODIFIER_PROPERTY_CAST_RANGE_BONUS,
-    --MODIFIER_PROPERTY_MOVESPEED_ABSOLUTE,
-    --MODIFIER_PROPERTY_PROJECTILE_SPEED_BONUS,
-    MODIFIER_EVENT_ON_ATTACK_START,
-    MODIFIER_EVENT_ON_ATTACK_LANDED,
-    MODIFIER_EVENT_ON_ATTACK_FINISHED,
+    MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE,
+    MODIFIER_PROPERTY_FIXED_ATTACK_RATE,
+    MODIFIER_PROPERTY_ATTACK_RANGE_BONUS,
+    MODIFIER_PROPERTY_CAST_RANGE_BONUS,
+    MODIFIER_PROPERTY_MOVESPEED_ABSOLUTE,
+    MODIFIER_PROPERTY_PROJECTILE_SPEED_BONUS,
   }
 
   return funcs
 end
 
--- function modifier_item_siege_mode_active:CheckState()
-  -- if self:GetParent():IsRangedAttacker() then
-    -- return {
-      -- [MODIFIER_STATE_ROOTED] = true,
-    -- }
-  -- end
-  -- return {}
--- end
+function modifier_item_siege_mode_active:CheckState()
+  if self:GetParent():IsRangedAttacker() then
+    return {
+      [MODIFIER_STATE_ROOTED] = true,
+    }
+  end
+  return {}
+end
 
---function modifier_item_siege_mode_active:GetModifierPreAttack_BonusDamage()
-  --return self.atkDmg or 500
---end
+function modifier_item_siege_mode_active:GetModifierPreAttack_BonusDamage()
+  return self.atkDmg or 500
+end
 
---function modifier_item_siege_mode_active:GetModifierFixedAttackRate()
-  --return self.atkRate or 0.7
---end
+function modifier_item_siege_mode_active:GetModifierFixedAttackRate()
+  return self.atkRate or 0.7
+end
 
---function modifier_item_siege_mode_active:GetModifierAttackRangeBonus()
-  --if self:GetParent():IsRangedAttacker() then
-    --return self.atkRange or 600
-  --end
+function modifier_item_siege_mode_active:GetModifierAttackRangeBonus()
+  if self:GetParent():IsRangedAttacker() then
+    return self.atkRange or 600
+  end
 
-  --return 0
---end
+  return 0
+end
 
---function modifier_item_siege_mode_active:GetModifierCastRangeBonus()
-  --return self.castRange or 0
---end
+function modifier_item_siege_mode_active:GetModifierCastRangeBonus()
+  return self.castRange or 0
+end
 
---function modifier_item_siege_mode_active:GetModifierMoveSpeed_Absolute()
-  --return self.moveSpeed or 270
---end
+function modifier_item_siege_mode_active:GetModifierMoveSpeed_Absolute()
+  return self.moveSpeed or 270
+end
 
---[[
 function modifier_item_siege_mode_active:GetModifierProjectileSpeedBonus()
   local parent = self:GetParent()
   if not IsServer() or parent:HasModifier("modifier_item_princes_knife") then
@@ -316,146 +576,8 @@ function modifier_item_siege_mode_active:GetModifierProjectileSpeedBonus()
 
   return 0
 end
-]]
-
-function modifier_item_siege_mode_active:OnAttackStart(event)
-  if not IsServer() then
-    return
-  end
-
-  local parent = self:GetParent()
-  if event.attacker ~= parent then
-    return
-  end
-
-  if not parent or parent:IsNull() then
-    return
-  end
-
-  if not parent:IsRangedAttacker() then
-    return
-  end
-
-  local target = event.target
-  if not target or target:IsNull() then
-    return
-  end
-
-  -- Only AttackStart is early enough to override the projectile
-  parent:ChangeAttackProjectile()
-end
-
-function modifier_item_siege_mode_active:OnAttackLanded(event)
-  if not IsServer() then
-    return
-  end
-
-  local parent = self:GetParent()
-  if event.attacker ~= parent then
-    return
-  end
-
-  if not parent or parent:IsNull() then
-    return
-  end
-
-  if parent:IsIllusion() then
-    return
-  end
-
-  local target = event.target
-  if not target or target:IsNull() then
-    return
-  end
-
-  if target.GetUnitName == nil then
-    return
-  end
-
-  -- Don't affect buildings, wards and invulnerable units.
-  if target:IsTower() or target:IsBarracks() or target:IsBuilding() or target:IsOther() or target:IsInvulnerable() then
-    return
-  end
-
-  local ability = self:GetAbility()
-  if not ability or ability:IsNull() then
-    return
-  end
-
-  local targetOrigin = target:GetAbsOrigin()
-
-  -- set the targeting requirements for the actual targets
-  local targetTeam = ability:GetAbilityTargetTeam()
-  local targetType = ability:GetAbilityTargetType()
-  local targetFlags = ability:GetAbilityTargetFlags()
-
-  -- get the radius
-  local splash_radius = ability:GetSpecialValueFor("active_splash_radius")
-  local splash_damage = ability:GetSpecialValueFor("active_splash_damage")
-
-  -- find all appropriate targets around the initial target
-  local units = FindUnitsInRadius(
-    parent:GetTeamNumber(),
-    targetOrigin,
-    nil,
-    splash_radius,
-    targetTeam,
-    targetType,
-    targetFlags,
-    FIND_ANY_ORDER,
-    false
-  )
-
-  -- get the wearer's damage
-  local damage = event.original_damage
-
-  -- get the damage modifier
-  local actual_damage = damage*splash_damage*0.01
-
-  -- Damage table
-  local damage_table = {}
-  damage_table.attacker = parent
-  damage_table.damage_type = ability:GetAbilityDamageType() or DAMAGE_TYPE_PHYSICAL
-  damage_table.ability = ability
-  damage_table.damage = actual_damage
-  damage_table.damage_flags = bit.bor(DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION, DOTA_DAMAGE_FLAG_NO_SPELL_LIFESTEAL)
-
-  -- Show particle only if damage is above zero and only if there are units nearby
-  if actual_damage > 0 and #units > 1 then
-    local part = ParticleManager:CreateParticle("particles/econ/items/clockwerk/clockwerk_paraflare/clockwerk_para_rocket_flare_explosion.vpcf", PATTACH_CUSTOMORIGIN, target)
-    ParticleManager:SetParticleControl(part, 3, targetOrigin)
-    ParticleManager:ReleaseParticleIndex(part)
-  end
-
-  -- iterate through all targets
-  for _, unit in pairs(units) do
-    if unit and not unit:IsNull() and unit ~= target then
-      damage_table.victim = unit
-      ApplyDamage(damage_table)
-    end
-  end
-
-  -- sound
-  target:EmitSound("dota_fountain.ProjectileImpact")
-end
-
-function modifier_item_siege_mode_active:OnAttackFinished(event)
-  if not IsServer() then
-    return
-  end
-
-  local parent = self:GetParent()
-  if event.attacker == parent then
-
-    if not parent:IsRangedAttacker() then
-      return
-    end
-
-    -- Change the projectile (if a parent doesn't have modifier_item_siege_mode_active)
-    parent:ChangeAttackProjectile()
-  end
-end
 
 function modifier_item_siege_mode_active:GetTexture()
   return "custom/siege_mode_active"
 end
+]]

--- a/game/scripts/vscripts/items/siege_mode.lua
+++ b/game/scripts/vscripts/items/siege_mode.lua
@@ -35,9 +35,13 @@ function item_siege_mode:OnSpellStart()
     return
   end
 
+  caster:FaceTowards(target)
+
   -- KVs
   local projectile_speed = self:GetSpecialValueFor("projectile_speed")
   local projectile_vision_radius = self:GetSpecialValueFor("knockback_distance")
+  local recoil_distance = self:GetSpecialValueFor("recoil_distance")
+  local recoil_duration = self:GetSpecialValueFor("recoil_duration")
 
   -- Other variables
   local caster_team = caster:GetTeamNumber()
@@ -69,12 +73,26 @@ function item_siege_mode:OnSpellStart()
     iVisionTeamNumber = caster_team,
     iSourceAttachment = DOTA_PROJECTILE_ATTACHMENT_ATTACK_1,
   }
-
   -- Create a tracking projectile
   ProjectileManager:CreateTrackingProjectile(projectile)
 
   -- Sound
   caster:EmitSound("Splash_Cannon.Launch")
+  
+  -- Initialize knockback table for recoil
+  local knockback_table = {
+    should_stun = 0,
+    center_x = target.x,
+    center_y = target.y,
+    center_z = target.z,
+    duration = recoil_duration,
+    knockback_duration = recoil_duration,
+    knockback_distance = recoil_distance,
+    --knockback_height = recoil_distance / 2,
+  }
+  
+  -- Apply Recoil to the caster
+  caster:AddNewModifier(caster, self, "modifier_knockback", knockback_table)
 end
 
 function item_siege_mode:OnProjectileHit(target, location)

--- a/game/scripts/vscripts/items/siege_mode.lua
+++ b/game/scripts/vscripts/items/siege_mode.lua
@@ -35,6 +35,9 @@ function item_siege_mode:OnSpellStart()
     return
   end
 
+  -- 'Fix' for the caster not turning to cast this item at the location
+  -- Items are weird because they are not supposed to have cast points or to require facing
+  -- See Gleipnir in vanilla for reference
   caster:FaceTowards(target)
 
   -- KVs
@@ -46,10 +49,6 @@ function item_siege_mode:OnSpellStart()
   -- Other variables
   local caster_team = caster:GetTeamNumber()
   local caster_loc = caster:GetAbsOrigin()
-
-  if not attack_projectile_speed or attack_projectile_speed <= 0 then
-    attack_projectile_speed = 900
-  end
 
   -- Calculate projectile stuff
   local distance = (caster_loc - target):Length2D()
@@ -78,7 +77,7 @@ function item_siege_mode:OnSpellStart()
 
   -- Sound
   caster:EmitSound("Splash_Cannon.Launch")
-  
+
   -- Initialize knockback table for recoil
   local knockback_table = {
     should_stun = 0,
@@ -90,7 +89,7 @@ function item_siege_mode:OnSpellStart()
     knockback_distance = recoil_distance,
     --knockback_height = recoil_distance / 2,
   }
-  
+
   -- Apply Recoil to the caster
   caster:AddNewModifier(caster, self, "modifier_knockback", knockback_table)
 end
@@ -445,10 +444,6 @@ function modifier_item_siege_mode_thinker:OnDestroy()
     return
   end
   local parent = self:GetParent()
-  if self.particle then
-    ParticleManager:DestroyParticle(self.particle, true)
-    ParticleManager:ReleaseParticleIndex(self.particle)
-  end
   if parent and not parent:IsNull() then
     parent:ForceKill(false)
   end


### PR DESCRIPTION
* Splash Cannon now passively provides 100/150 damage.
* Splash Cannon now passively provides 40% splash in 250 radius. Doesn't work on melee heroes.
* Splash Cannon active reworked: **Cannon Fire** - Launches a projectile (cannon ball) at target location that damages and knocks back enemies in 500 radius upon landing. Damage is 700/1000 damage + 150% of your attack damage. Using Cannon Fire will cause a powerful recoil, pushing you backwards 250 units. 
* Notes:
1) Cast range: 1100; 
2) Projectile speed: 1800;
3) Knockback distance: 250; 
4) Knockback doesn't work against spell-immune and attack-immune enemies.
5) Mana cost: 200
6) Cooldown: 18 seconds.
7) Knockback duration is 0.5s and recoil duration is 0.2s
8) Active does work on melee heroes but the damage is reduced. It only applies 700/1000 physical damage.
9) Passive splash damage doesn't ignore enemy Damage Block. Cannon Fire damage ignores enemy Damage Block.