### PR TITLE
Meteor Hammer buffs

### DIFF
--- a/game/resource/English/ability/items/tooltip_meteor_hammer.txt
+++ b/game/resource/English/ability/items/tooltip_meteor_hammer.txt
@@ -54,3 +54,9 @@
 "DOTA_Tooltip_ability_item_meteor_hammer_5_bonus_health_regen"    "#{DOTA_Tooltip_ability_item_meteor_hammer_bonus_health_regen}"
 "DOTA_Tooltip_ability_item_meteor_hammer_5_bonus_mana_regen"      "#{DOTA_Tooltip_ability_item_meteor_hammer_bonus_mana_regen}"
 "DOTA_Tooltip_Ability_item_meteor_hammer_5_cooldown_tooltip"      "#{DOTA_Tooltip_Ability_item_meteor_hammer_1_cooldown_tooltip}"
+
+"DOTA_Tooltip_modifier_item_meteor_hammer_oaa_dot"                "#{DOTA_Tooltip_modifier_item_meteor_hammer_burn}"
+"DOTA_Tooltip_modifier_item_meteor_hammer_oaa_dot_Description"    "Taking damage over time"
+
+"DOTA_Tooltip_modifier_item_meteor_hammer_oaa_stun"               "#{DOTA_Tooltip_Ability_item_meteor_hammer} Stun"
+"DOTA_Tooltip_modifier_item_meteor_hammer_oaa_stun_Description"   "Stunned"

--- a/game/resource/English/modifier/items/modifier_meteor_hammer.txt
+++ b/game/resource/English/modifier/items/modifier_meteor_hammer.txt
@@ -1,5 +1,0 @@
-//=============================================================================
-// Meteor Hammer
-//=============================================================================
-"DOTA_Tooltip_modifier_item_meteor_hammer_damage_over_time"              "Meteor Hammer Burn"
-"DOTA_Tooltip_modifier_item_meteor_hammer_damage_over_time_Description"  "Taking damage over time"

--- a/game/scripts/npc/items/item_meteor_hammer.txt
+++ b/game/scripts/npc/items/item_meteor_hammer.txt
@@ -102,12 +102,12 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "burn_dps_boss"                                   "180 360 540 720 900"
+        "burn_dps_boss"                                   "200 400 600 800 1000"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "burn_dps"                                        "90 180 270 360 450"
+        "burn_dps"                                        "100 200 300 400 500"
       }
       "08"
       {

--- a/game/scripts/npc/items/item_meteor_hammer_2.txt
+++ b/game/scripts/npc/items/item_meteor_hammer_2.txt
@@ -101,12 +101,12 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "burn_dps_boss"                                   "180 360 540 720 900"
+        "burn_dps_boss"                                   "200 400 600 800 1000"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "burn_dps"                                        "90 180 270 360 450"
+        "burn_dps"                                        "100 200 300 400 500"
       }
       "08"
       {

--- a/game/scripts/npc/items/item_meteor_hammer_3.txt
+++ b/game/scripts/npc/items/item_meteor_hammer_3.txt
@@ -101,12 +101,12 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "burn_dps_boss"                                   "180 360 540 720 900"
+        "burn_dps_boss"                                   "200 400 600 800 1000"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "burn_dps"                                        "90 180 270 360 450"
+        "burn_dps"                                        "100 200 300 400 500"
       }
       "08"
       {

--- a/game/scripts/npc/items/item_meteor_hammer_4.txt
+++ b/game/scripts/npc/items/item_meteor_hammer_4.txt
@@ -101,12 +101,12 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "burn_dps_boss"                                   "180 360 540 720 900"
+        "burn_dps_boss"                                   "200 400 600 800 1000"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "burn_dps"                                        "90 180 270 360 450"
+        "burn_dps"                                        "100 200 300 400 500"
       }
       "08"
       {

--- a/game/scripts/npc/items/item_meteor_hammer_5.txt
+++ b/game/scripts/npc/items/item_meteor_hammer_5.txt
@@ -102,12 +102,12 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "burn_dps_boss"                                   "180 360 540 720 900"
+        "burn_dps_boss"                                   "200 400 600 800 1000"
       }
       "07"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "burn_dps"                                        "90 180 270 360 450"
+        "burn_dps"                                        "100 200 300 400 500"
       }
       "08"
       {

--- a/game/scripts/vscripts/items/meteor_hammer.lua
+++ b/game/scripts/vscripts/items/meteor_hammer.lua
@@ -1,6 +1,7 @@
 LinkLuaModifier("modifier_generic_bonus", "modifiers/modifier_generic_bonus.lua", LUA_MODIFIER_MOTION_NONE)
-LinkLuaModifier("modifier_item_meteor_hammer_thinker", "items/meteor_hammer.lua", LUA_MODIFIER_MOTION_NONE )
-LinkLuaModifier("modifier_item_meteor_hammer_damage_over_time", "items/meteor_hammer.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_meteor_hammer_oaa_thinker", "items/meteor_hammer.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_meteor_hammer_oaa_dot", "items/meteor_hammer.lua", LUA_MODIFIER_MOTION_NONE)
+LinkLuaModifier("modifier_item_meteor_hammer_oaa_stun", "items/meteor_hammer.lua", LUA_MODIFIER_MOTION_NONE)
 
 item_meteor_hammer_1 = class(ItemBaseClass)
 item_meteor_hammer_2 = item_meteor_hammer_1
@@ -10,6 +11,10 @@ item_meteor_hammer_5 = item_meteor_hammer_1
 
 function item_meteor_hammer_1:GetAOERadius()
   return self:GetSpecialValueFor("impact_radius")
+end
+
+function item_meteor_hammer_1:GetIntrinsicModifierName()
+  return "modifier_generic_bonus"
 end
 
 function item_meteor_hammer_1:OnSpellStart()
@@ -39,7 +44,15 @@ function item_meteor_hammer_1:OnChannelFinish(bInterrupted)
 
   if not bInterrupted then
     caster:EmitSound("DOTA_Item.MeteorHammer.Cast")
-    CreateModifierThinker(caster, self, "modifier_item_meteor_hammer_thinker", {}, self:GetCursorPosition(), caster:GetTeamNumber(), false)
+    CreateModifierThinker(
+      caster,
+      self,
+      "modifier_item_meteor_hammer_oaa_thinker",
+      {duration = self:GetSpecialValueFor("land_time") + self:GetSpecialValueFor("stun_duration")},
+      self:GetCursorPosition(),
+      caster:GetTeamNumber(),
+      false
+    )
   else
     caster:StopSound("DOTA_Item.MeteorHammer.Channel")
     ParticleManager:DestroyParticle(self.channel_particle_caster, true)
@@ -50,15 +63,19 @@ function item_meteor_hammer_1:OnChannelFinish(bInterrupted)
   ParticleManager:ReleaseParticleIndex(self.channel_particle)
 end
 
-function item_meteor_hammer_1:GetIntrinsicModifierName()
-  return "modifier_generic_bonus"
+---------------------------------------------------------------------------------------------------
+
+modifier_item_meteor_hammer_oaa_thinker = class(ModifierBaseClass)
+
+function modifier_item_meteor_hammer_oaa_thinker:IsHidden()
+  return true
 end
------------------------------------------------------------------------------------------------------------------------
------------------------------------------------------------------------------------------------------------------------
 
-modifier_item_meteor_hammer_thinker = class(ModifierBaseClass)
+function modifier_item_meteor_hammer_oaa_thinker:IsPurgable()
+  return false
+end
 
-function modifier_item_meteor_hammer_thinker:OnCreated()
+function modifier_item_meteor_hammer_oaa_thinker:OnCreated()
   if IsServer() then
     local ability = self:GetAbility()
     local parent = self:GetParent()
@@ -84,62 +101,75 @@ function modifier_item_meteor_hammer_thinker:OnCreated()
   end
 end
 
-function modifier_item_meteor_hammer_thinker:OnIntervalThink()
- local parent = self:GetParent()
- local caster = self:GetCaster()
+function modifier_item_meteor_hammer_oaa_thinker:OnIntervalThink()
+  local parent = self:GetParent() -- thinker
+  local caster = self:GetCaster() -- item owner
+  local ability = self:GetAbility() -- item
+  local parent_loc = parent:GetAbsOrigin()
 
-  parent:EmitSound("DOTA_Item.MeteorHammer.Impact")
+  -- Sound
+  EmitSoundOnLocationWithCaster(parent_loc, "DOTA_Item.MeteorHammer.Impact", caster)
 
-  if IsServer() then
-    GridNav:DestroyTreesAroundPoint(parent:GetOrigin(), self.impact_radius, true)
+  -- Destroy trees
+  GridNav:DestroyTreesAroundPoint(parent_loc, self.impact_radius, true)
 
-    local ability = self:GetAbility()
-    local enemies = FindUnitsInRadius(caster:GetTeamNumber(), parent:GetOrigin(), caster, self.impact_radius, DOTA_UNIT_TARGET_TEAM_ENEMY, bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC), DOTA_UNIT_TARGET_FLAG_NONE, FIND_ANY_ORDER, false)
+  local enemies = FindUnitsInRadius(
+    caster:GetTeamNumber(),
+    parent_loc,
+    nil,
+    self.impact_radius,
+    DOTA_UNIT_TARGET_TEAM_ENEMY,
+    bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC),
+    DOTA_UNIT_TARGET_FLAG_NONE,
+    FIND_ANY_ORDER,
+    false
+  )
 
-    if enemies then
-      for _, enemy in pairs(enemies) do
-        -- Debuffs first, then damage
-        -- Apply damage-over-time debuff (duration is not affected by status resistance)
-        enemy:AddNewModifier(caster, ability, "modifier_item_meteor_hammer_damage_over_time", {duration = self.burn_duration})
-        -- Apply stun debuff (duration is affected by status resistance)
-        local stun_duration = enemy:GetValueChangedByStatusResistance(self.stun_duration)
-        enemy:AddNewModifier(caster, ability, "modifier_stunned", {duration = stun_duration})
+  for _, enemy in pairs(enemies) do
+    if enemy and not enemy:IsNull() then
+      -- Apply damage-over-time debuff (duration is not affected by status resistance)
+      enemy:AddNewModifier(caster, ability, "modifier_item_meteor_hammer_oaa_dot", {duration = self.burn_duration})
+      -- Apply stun debuff (duration is affected by status resistance)
+      local stun_duration = enemy:GetValueChangedByStatusResistance(self.stun_duration)
+      enemy:AddNewModifier(caster, ability, "modifier_item_meteor_hammer_oaa_stun", {duration = stun_duration})
 
-        local damage_table = {
-          victim = enemy,
-          attacker = caster,
-          damage = self.impact_damage,
-          damage_type = DAMAGE_TYPE_MAGICAL,
-          ability = ability,
-        }
-        -- Is the enemy a boss?
-        if enemy:IsOAABoss() then
-          damage_table.damage = self.impact_damage_bosses
-        end
+      local damage_table = {
+        victim = enemy,
+        attacker = caster,
+        damage = self.impact_damage,
+        damage_type = DAMAGE_TYPE_MAGICAL,
+        ability = ability,
+      }
+      -- Is the enemy a boss?
+      if enemy:IsOAABoss() then
+        damage_table.damage = self.impact_damage_bosses
+      end
 
+      if enemy:IsAlive() then
         ApplyDamage(damage_table)
-      end-- end of for enemy pairs
-    end-- end of if enemies statemnt
+      end
+    end
+  end
 
-    self:StartIntervalThink(-1)
-  end-- end of if server
-
-  UTIL_Remove(self:GetParent())
-end-- end of function
-
-function modifier_item_meteor_hammer_thinker:IsPurgable()
-  return false
+  self:StartIntervalThink(-1)
+  self:Destroy()
 end
 
-function modifier_item_meteor_hammer_thinker:IsHidden()
-  return true
+function modifier_item_meteor_hammer_oaa_thinker:OnDestroy()
+  if not IsServer() then
+    return
+  end
+  local parent = self:GetParent()
+  if parent and not parent:IsNull() then
+    parent:ForceKill(false)
+  end
 end
 
------------------------------------------------------------------------------------------------------------------------
------------------------------------------------------------------------------------------------------------------------
-modifier_item_meteor_hammer_damage_over_time = class(ModifierBaseClass)
+---------------------------------------------------------------------------------------------------
 
-function modifier_item_meteor_hammer_damage_over_time:OnCreated(params)
+modifier_item_meteor_hammer_oaa_dot = class(ModifierBaseClass)
+
+function modifier_item_meteor_hammer_oaa_dot:OnCreated(params)
   if IsServer() then
     local enemy = self:GetParent()
     local caster = self:GetCaster()
@@ -167,7 +197,7 @@ function modifier_item_meteor_hammer_damage_over_time:OnCreated(params)
   end
 end
 
-function modifier_item_meteor_hammer_damage_over_time:OnIntervalThink()
+function modifier_item_meteor_hammer_oaa_dot:OnIntervalThink()
   if IsServer() then
     local enemy = self:GetParent()
     local caster = self:GetCaster()
@@ -189,14 +219,61 @@ function modifier_item_meteor_hammer_damage_over_time:OnIntervalThink()
   end
 end
 
-function modifier_item_meteor_hammer_damage_over_time:GetEffectName()
+function modifier_item_meteor_hammer_oaa_dot:GetEffectName()
   return "particles/items4_fx/meteor_hammer_spell_debuff.vpcf"
 end
 
-function modifier_item_meteor_hammer_damage_over_time:IsDebuff()
+function modifier_item_meteor_hammer_oaa_dot:IsDebuff()
   return true
 end
 
-function modifier_item_meteor_hammer_damage_over_time:IsPurgable()
+function modifier_item_meteor_hammer_oaa_dot:IsPurgable()
   return not self:GetParent():IsOAABoss()
+end
+
+---------------------------------------------------------------------------------------------------
+
+modifier_item_meteor_hammer_oaa_stun = class(ModifierBaseClass)
+
+function modifier_item_meteor_hammer_oaa_stun:IsHidden()
+  return false
+end
+
+function modifier_item_meteor_hammer_oaa_stun:IsDebuff()
+  return true
+end
+
+function modifier_item_meteor_hammer_oaa_stun:IsStunDebuff()
+  return true
+end
+
+function modifier_item_meteor_hammer_oaa_stun:IsPurgable()
+  return not self:GetParent():IsOAABoss()
+end
+
+function modifier_item_meteor_hammer_oaa_stun:GetEffectName()
+  return "particles/generic_gameplay/generic_stunned.vpcf"
+end
+
+function modifier_item_meteor_hammer_oaa_stun:GetEffectAttachType()
+  return PATTACH_OVERHEAD_FOLLOW
+end
+
+function modifier_item_meteor_hammer_oaa_stun:DeclareFunctions()
+  local funcs = {
+    MODIFIER_PROPERTY_OVERRIDE_ANIMATION,
+  }
+
+  return funcs
+end
+
+function modifier_item_meteor_hammer_oaa_stun:GetOverrideAnimation()
+  return ACT_DOTA_DISABLED
+end
+
+function modifier_item_meteor_hammer_oaa_stun:CheckState()
+  local state = {
+    [MODIFIER_STATE_STUNNED] = true,
+  }
+  return state
 end


### PR DESCRIPTION
* Meteor Hammer burn dps damage increased.
* Meteor Hammer is no longer using a built-in stun modifier. It now uses a unique stun modifier. This means that stun duration on the enemy will be refreshed if affected by multiple meteor hammers in succession.
* Renamed Meteor Hammer modifiers just in case if there is a conflict with built-in modifiers.
* Improved Meteor Hammer code a little bit.
