### PR TITLE
Tinkerer buffs

### DIFF
--- a/game/resource/English/npc/tooltip_tinkerer.txt
+++ b/game/resource/English/npc/tooltip_tinkerer.txt
@@ -60,7 +60,7 @@
 "DOTA_Tooltip_ability_tinkerer_smart_missiles_stun_duration"                    "STUN DURATION:"
 
 "DOTA_Tooltip_ability_tinkerer_oil_spill"                                       "Tar Spill"
-"DOTA_Tooltip_ability_tinkerer_oil_spill_Description"                           "Target a location to smother enemy units in tar. Applies percentage movement and attack speed slow to all enemies on hit. If an enemy is hit with a smart missile while having a Tar Spill debuff it will start burning for the remaining duration. "
+"DOTA_Tooltip_ability_tinkerer_oil_spill_Description"                           "Target a location to smother enemy units in tar. Applies percentage movement and attack speed slow to all enemies in the target area when the tar projectile hits the ground. Enemy units Covered in Tar will ignite for the remaining duration once they take any spell or item damage."
 "DOTA_Tooltip_ability_tinkerer_oil_spill_Lore"                                  "Tinkerer is a fan of tar and feathers prank."
 "DOTA_Tooltip_ability_tinkerer_oil_spill_radius"                                "RADIUS:"
 "DOTA_Tooltip_ability_tinkerer_oil_spill_duration"                              "DEBUFF DURATION:"
@@ -112,6 +112,6 @@
 "DOTA_Tooltip_ability_special_bonus_unique_tinkerer_6"                          "+{s:value} Tar Spill Burn Damage"
 
 "DOTA_Tooltip_Ability_special_bonus_unique_tinkerer_7"                          "Tar Spill Reduces Magic Resistance"
-"DOTA_Tooltip_Ability_special_bonus_unique_tinkerer_7_Description"              "Reduces magic resistance by 25%."
+"DOTA_Tooltip_Ability_special_bonus_unique_tinkerer_7_Description"              "Reduces magic resistance by 45%."
 
 "DOTA_Tooltip_ability_special_bonus_unique_tinkerer_8"                          ""

--- a/game/resource/English/npc/tooltip_tinkerer.txt
+++ b/game/resource/English/npc/tooltip_tinkerer.txt
@@ -76,7 +76,7 @@
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_initial_damage"                "INITIAL LASER DAMAGE:"
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_damage_per_second"             "MAX DAMAGE PER SECOND:"
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_attacks_to_destroy"            "ATTACKS REQUIRED:"
-"DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_description"           "Trapped enemies are blinded and leashed. Blind and Leash pierce spell immunity."
+"DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_description"           "Trapped enemies are blinded, leashed and have reduced healing by %scepter_heal_prevent_percent%%%. This debuff pierces spell immunity."
 
 // modifiers
 // "DOTA_Tooltip_modifier_tinker_laser_blind"					"Laser Blind"

--- a/game/scripts/npc/abilities/talents/tinkerer_talent2_oaa.txt
+++ b/game/scripts/npc/abilities/talents/tinkerer_talent2_oaa.txt
@@ -19,7 +19,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "value"                                           "40"
+        "value"                                           "50"
       }
     }
   }

--- a/game/scripts/npc/abilities/talents/tinkerer_talent7_oaa.txt
+++ b/game/scripts/npc/abilities/talents/tinkerer_talent7_oaa.txt
@@ -19,7 +19,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "value"                                           "25"
+        "value"                                           "45"
       }
     }
   }

--- a/game/scripts/npc/abilities/tinkerer_laser_contraption.txt
+++ b/game/scripts/npc/abilities/tinkerer_laser_contraption.txt
@@ -64,6 +64,11 @@
         "value"                                           "100"
         "RequiresScepter"                                 "1"
       }
+      "scepter_heal_prevent_percent"
+      {
+        "value"                                           "-25"
+        "RequiresScepter"                                 "1"
+      }
     }
   }
 }

--- a/game/scripts/npc/abilities/tinkerer_laser_contraption.txt
+++ b/game/scripts/npc/abilities/tinkerer_laser_contraption.txt
@@ -50,9 +50,9 @@
       "radius"                                            "300" // original: 800 x 100
       "duration"                                          "8"
       "delay"                                             "0.5"
-      "initial_damage"                                    "200 300 400 700 1200" // original: 200/300/400
-      "damage_per_second"                                 "75 150 225 375 675" // original: 75 125 175
-      "damage_interval"                                   "2"
+      "initial_damage"                                    "200 400 600 1200 1800" // original: 200/300/400
+      "damage_per_second"                                 "75 175 275 575 875" // original: 75 125 175
+      "damage_interval"                                   "2" // 5 damage instances
       "attacks_to_destroy"                                "1 2 3 4 5"
       "scepter_cast_range" // unused
       {

--- a/game/scripts/npc/abilities/tinkerer_oil_spill.txt
+++ b/game/scripts/npc/abilities/tinkerer_oil_spill.txt
@@ -62,7 +62,7 @@
       }
       "attack_speed_slow"
       {
-        "value"                                           "15 20 25 30 35 40" // percentage attack speed slow; original: 10/20/30/40%
+        "value"                                           "10 20 30 40 45 50" // percentage attack speed slow; original: 10/20/30/40%
         "special_bonus_unique_tinkerer_5"                 "+10"
       }
       "burn_dps"

--- a/game/scripts/npc/abilities/tinkerer_oil_spill.txt
+++ b/game/scripts/npc/abilities/tinkerer_oil_spill.txt
@@ -42,6 +42,7 @@
       "particle"                                          "particles/units/heroes/hero_batrider/batrider_stickynapalm_impact.vpcf"
       "particle"                                          "particles/econ/items/huskar/huskar_2021_immortal/huskar_2021_immortal_burning_spear_debuff_flame_circulate.vpcf"
       "particle"                                          "particles/hero/tinkerer/ground_splatter.vpcf"
+      "soundfile"                                         "soundevents/game_sounds_heroes/game_sounds_grimstroke.vsndevts"
     }
 
     // Special

--- a/game/scripts/npc/abilities/tinkerer_smart_missiles.txt
+++ b/game/scripts/npc/abilities/tinkerer_smart_missiles.txt
@@ -55,7 +55,7 @@
         "LinkedSpecialBonus"                              "special_bonus_unique_tinkerer_2"
       }
       "rocket_speed"                                      "1200"
-      "rocket_width"                                      "100" // original: 75
+      "rocket_width"                                      "115" // original: 75
       "rocket_range"                                      "3000"
       "rocket_vision"                                     "400"
       "bonus_max_hp_damage"                               "7"

--- a/game/scripts/npc/units/npc_dota_tinkerer_keen_node.txt
+++ b/game/scripts/npc/units/npc_dota_tinkerer_keen_node.txt
@@ -38,7 +38,7 @@
 
     // Bounds
     //----------------------------------------------------------------
-    "BoundsHullName"                                      "DOTA_HULL_SIZE_FILLER"      // Hull type used for navigation/locomotion.
+    "BoundsHullName"                                      "DOTA_HULL_SIZE_HUGE"      // Hull type used for navigation/locomotion.
     "HealthBarOffset"                                     "230"
 
     // Movement

--- a/game/scripts/vscripts/abilities/tinkerer/tinkerer_laser_contraption.lua
+++ b/game/scripts/vscripts/abilities/tinkerer/tinkerer_laser_contraption.lua
@@ -67,44 +67,44 @@ function tinkerer_laser_contraption:OnSpellStart()
   }
 
   if square_shape then
-	effect_radius = radius * math.sqrt(2) + 50 -- because nodes form in a square
+    effect_radius = radius * math.sqrt(2) + 50 -- because nodes form in a square
 
-	local top = cursor + radius * Vector(0, 1, 0)
-	local bottom = cursor + radius * Vector(0, -1, 0)
-	local left = cursor + radius * Vector(-1, 0, 0)
-	local right = cursor + radius * Vector(1, 0, 0)
+    local top = cursor + radius * Vector(0, 1, 0)
+    local bottom = cursor + radius * Vector(0, -1, 0)
+    local left = cursor + radius * Vector(-1, 0, 0)
+    local right = cursor + radius * Vector(1, 0, 0)
 
-	local top_left = left + radius * Vector(0, 1, 0)
-	local top_right = right + radius * Vector(0, 1, 0)
+    local top_left = left + radius * Vector(0, 1, 0)
+    local top_right = right + radius * Vector(0, 1, 0)
 
-	local bot_left = left + radius * Vector(0, -1, 0)
-	local bot_right = right + radius * Vector(0, -1, 0)
+    local bot_left = left + radius * Vector(0, -1, 0)
+    local bot_right = right + radius * Vector(0, -1, 0)
 
-	local p1 = left + radius * 0.5 * Vector(0, 1, 0)
-	local p2 = right + radius * 0.5 * Vector(0, 1, 0)
-	local p3 = left + radius * 0.5 * Vector(0, -1, 0)
-	local p4 = right + radius * 0.5 * Vector(0, -1, 0)
-	local p5 = top + radius * 0.5 * Vector(1, 0, 0)
-	local p6 = top + radius * 0.5 * Vector(-1, 0, 0)
-	local p7 = bottom + radius * 0.5 * Vector(1, 0, 0)
-	local p8 = bottom + radius * 0.5 * Vector(-1, 0, 0)
+    local p1 = left + radius * 0.5 * Vector(0, 1, 0)
+    local p2 = right + radius * 0.5 * Vector(0, 1, 0)
+    local p3 = left + radius * 0.5 * Vector(0, -1, 0)
+    local p4 = right + radius * 0.5 * Vector(0, -1, 0)
+    local p5 = top + radius * 0.5 * Vector(1, 0, 0)
+    local p6 = top + radius * 0.5 * Vector(-1, 0, 0)
+    local p7 = bottom + radius * 0.5 * Vector(1, 0, 0)
+    local p8 = bottom + radius * 0.5 * Vector(-1, 0, 0)
 
-	table.insert(positions, top)
-	table.insert(positions, bottom)
-	table.insert(positions, left)
-	table.insert(positions, right)
-	table.insert(positions, top_left)
-	table.insert(positions, top_right)
-	table.insert(positions, bot_left)
-	table.insert(positions, bot_right)
-	table.insert(positions, p1)
-	table.insert(positions, p2)
-	table.insert(positions, p3)
-	table.insert(positions, p4)
-	table.insert(positions, p5)
-	table.insert(positions, p6)
-	table.insert(positions, p7)
-	table.insert(positions, p8)
+    table.insert(positions, top)
+    table.insert(positions, bottom)
+    table.insert(positions, left)
+    table.insert(positions, right)
+    table.insert(positions, top_left)
+    table.insert(positions, top_right)
+    table.insert(positions, bot_left)
+    table.insert(positions, bot_right)
+    table.insert(positions, p1)
+    table.insert(positions, p2)
+    table.insert(positions, p3)
+    table.insert(positions, p4)
+    table.insert(positions, p5)
+    table.insert(positions, p6)
+    table.insert(positions, p7)
+    table.insert(positions, p8)
   else
     effect_radius = radius + 100
     for i = 1, 16 do
@@ -185,6 +185,10 @@ function tinkerer_laser_contraption:OnSpellStart()
 
   -- Sound
   caster:EmitSound("Hero_Tinker.Laser")
+end
+
+function tinkerer_laser_contraption:ProcsMagicStick()
+  return true
 end
 
 ---------------------------------------------------------------------------------------------------
@@ -384,6 +388,7 @@ function modifier_tinkerer_laser_contraption_debuff:OnCreated()
   local ability = self:GetAbility()
   if ability and not ability:IsNull() then
     self.blind_pct = ability:GetSpecialValueFor("scepter_blind")
+    self.heal_prevent_percent = ability:GetSpecialValueFor("scepter_heal_prevent_percent")
   end
 end
 
@@ -392,11 +397,31 @@ modifier_tinkerer_laser_contraption_debuff.OnRefresh = modifier_tinkerer_laser_c
 function modifier_tinkerer_laser_contraption_debuff:DeclareFunctions()
   return {
     MODIFIER_PROPERTY_MISS_PERCENTAGE,
+    MODIFIER_PROPERTY_HEAL_AMPLIFY_PERCENTAGE_TARGET,
+    MODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE,
+    MODIFIER_PROPERTY_LIFESTEAL_AMPLIFY_PERCENTAGE,
+    MODIFIER_PROPERTY_SPELL_LIFESTEAL_AMPLIFY_PERCENTAGE,
   }
 end
 
 function modifier_tinkerer_laser_contraption_debuff:GetModifierMiss_Percentage()
   return self.blind_pct or self:GetAbility():GetSpecialValueFor("scepter_blind")
+end
+
+function modifier_tinkerer_laser_contraption_debuff:GetModifierHealAmplify_PercentageTarget()
+  return self.heal_prevent_percent or self:GetAbility():GetSpecialValueFor("scepter_heal_prevent_percent")
+end
+
+function modifier_tinkerer_laser_contraption_debuff:GetModifierHPRegenAmplify_Percentage()
+  return self.heal_prevent_percent or self:GetAbility():GetSpecialValueFor("scepter_heal_prevent_percent")
+end
+
+function modifier_tinkerer_laser_contraption_debuff:GetModifierLifestealRegenAmplify_Percentage()
+  return self.heal_prevent_percent or self:GetAbility():GetSpecialValueFor("scepter_heal_prevent_percent")
+end
+
+function modifier_tinkerer_laser_contraption_debuff:GetModifierSpellLifestealRegenAmplify_Percentage()
+  return self.heal_prevent_percent or self:GetAbility():GetSpecialValueFor("scepter_heal_prevent_percent")
 end
 
 function modifier_tinkerer_laser_contraption_debuff:CheckState()

--- a/game/scripts/vscripts/abilities/tinkerer/tinkerer_oil_spill.lua
+++ b/game/scripts/vscripts/abilities/tinkerer/tinkerer_oil_spill.lua
@@ -92,10 +92,14 @@ function tinkerer_oil_spill:OnProjectileHit(target, location)
     end
   end
 
-  --target:EmitSound("Hero_Alchemist.AcidSpray.Damage")
+  target:EmitSound("Hero_Grimstroke.InkOver.Target")
 
   target:ForceKill(false)
 
+  return true
+end
+
+function tinkerer_oil_spill:ProcsMagicStick()
   return true
 end
 
@@ -147,6 +151,10 @@ end
 
 function modifier_tinkerer_oil_spill_debuff:GetStatusEffectName()
   return "particles/status_fx/status_effect_stickynapalm.vpcf"
+end
+
+function modifier_tinkerer_oil_spill_debuff:StatusEffectPriority()
+  return MODIFIER_PRIORITY_LOW
 end
 
 function modifier_tinkerer_oil_spill_debuff:OnCreated()

--- a/game/scripts/vscripts/abilities/tinkerer/tinkerer_oil_spill.lua
+++ b/game/scripts/vscripts/abilities/tinkerer/tinkerer_oil_spill.lua
@@ -234,16 +234,15 @@ if IsServer() then
       return
     end
 
-    local caster = self:GetCaster()
     local parent = self:GetParent()
 
-    if attacker ~= caster or victim ~= parent then
+    if victim ~= parent then
       return
     end
 
-    if inflictor:GetName() ~= "tinkerer_smart_missiles" then
-      return
-    end
+    --if inflictor:GetName() ~= "tinkerer_smart_missiles" then
+      --return
+    --end
 
     if self.already_burning then
       return

--- a/game/scripts/vscripts/abilities/tinkerer/tinkerer_smart_missiles.lua
+++ b/game/scripts/vscripts/abilities/tinkerer/tinkerer_smart_missiles.lua
@@ -11,7 +11,23 @@ function tinkerer_smart_missiles:OnSpellStart()
     return
   end
 
-  local direction = (target - caster_loc):Normalized()
+  local rocket_width = self:GetSpecialValueFor("rocket_width")
+  local rocket_speed = self:GetSpecialValueFor("rocket_speed")
+  local rocket_range = self:GetSpecialValueFor("rocket_range")
+  local rocket_vision = self:GetSpecialValueFor("rocket_vision")
+
+  -- Calculate offset and starting width
+  local attachment = caster:ScriptLookupAttachment("attach_attack3")
+  local rocket_spawn_loc = caster_loc
+  local offset = 0
+  if attachment ~= 0 then
+    rocket_spawn_loc = caster:GetAttachmentOrigin(attachment)
+    offset = (caster_loc - rocket_spawn_loc):Length2D()
+  end
+  local start_width = rocket_width + offset
+
+  -- Calculate direction
+  local direction = (target - rocket_spawn_loc):Normalized()
 
   -- Reverse cast direction for self point cast
   if target == caster_loc then
@@ -21,20 +37,15 @@ function tinkerer_smart_missiles:OnSpellStart()
   -- Remove vertical component
   direction.z = 0
 
-  local rocket_width = self:GetSpecialValueFor("rocket_width")
-  local rocket_speed = self:GetSpecialValueFor("rocket_speed")
-  local rocket_range = self:GetSpecialValueFor("rocket_range")
-  local rocket_vision = self:GetSpecialValueFor("rocket_vision")
-
   local projectile_table = {
     Ability = self,
     EffectName = "particles/hero/tinkerer/rocket_projectile_linear.vpcf",
-    vSpawnOrigin = caster:GetAttachmentOrigin(caster:ScriptLookupAttachment("attach_attack3")),
+    vSpawnOrigin = rocket_spawn_loc,
     fDistance = rocket_range + caster:GetCastRangeBonus(),
-    fStartRadius = rocket_width,
+    fStartRadius = start_width,
     fEndRadius = rocket_width,
     Source = caster,
-    bHasFrontalCone = false,
+    bHasFrontalCone = true,
     bReplaceExisting = false,
     iUnitTargetTeam = self:GetAbilityTargetTeam(),
     iUnitTargetType = self:GetAbilityTargetType(),
@@ -200,6 +211,10 @@ function tinkerer_smart_missiles:OnProjectileHit_ExtraData(target, location, dat
     end
   end
 
+  return true
+end
+
+function tinkerer_smart_missiles:ProcsMagicStick()
   return true
 end
 

--- a/game/scripts/vscripts/abilities/tinkerer/tinkerer_smart_missiles.lua
+++ b/game/scripts/vscripts/abilities/tinkerer/tinkerer_smart_missiles.lua
@@ -138,8 +138,12 @@ function tinkerer_smart_missiles:OnProjectileHit_ExtraData(target, location, dat
 
   -- Calculate bonus damage if traveled distance is higher than the threshold for non-boss units
   local bonus_damage = 0
-  if travel_distance >= bonus_damage_range and not target:IsOAABoss() then
+  if travel_distance >= bonus_damage_range then
     bonus_damage = target:GetMaxHealth() * bonus_max_hp_damage * 0.01
+  end
+
+  if target:IsOAABoss() then
+    bonus_damage = bonus_damage * 15/100
   end
 
   -- Calculate total damage


### PR DESCRIPTION
* Smart Missiles width increased from 100 to 115.
* Tar Spill attack speed slow rescaled from 15/20/25/30/35/40% to 10/20/30/40/45/50%.
* Tar Spill will now ignite on any spell or item damage, not just from Smart Missiles and not just from Tinkerer.
* Laser Contraption initial damage increased from 200/300/400/700/1200 to 200/400/600/1200/1800.
* Laser Contraption damage per second increased from 75/150/225/375/675 to 75/175/275/575/875.
* Level 10 Talent +40 Smart Missiles Damage increased to +50.
* Level 25 Talent Tar Spills magic resistance reduction improved from 25% to 45%.

