### PR TITLE
Silver Staff tweaks

### DIFF
--- a/game/resource/English/ability/items/tooltip_silver_staff.txt
+++ b/game/resource/English/ability/items/tooltip_silver_staff.txt
@@ -8,7 +8,7 @@
 "DOTA_Tooltip_Ability_item_silver_staff_Note0"                "Silver Staff debuff cannot be dispelled."
 "DOTA_Tooltip_Ability_item_silver_staff_Note1"                "Silver Staff debuff duration is not affected by status resistance."
 "DOTA_Tooltip_Ability_item_silver_staff_Note2"                "Silver Staff damage is not affected by spell amplification."
-"DOTA_Tooltip_Ability_item_silver_staff_Note3"                "Silver Staff debuff doesn't damage Bosses."
+"DOTA_Tooltip_Ability_item_silver_staff_Note3"                "Silver Staff debuff does reduced damage to Bosses."
 "DOTA_Tooltip_Ability_item_silver_staff_bonus_health"         "+$health"
 "DOTA_Tooltip_Ability_item_silver_staff_bonus_mana_regen"     "+$mana_regen"
 "DOTA_Tooltip_Ability_item_silver_staff_bonus_all_stats"      "+$all"

--- a/game/scripts/npc/items/custom/item_silver_staff.txt
+++ b/game/scripts/npc/items/custom/item_silver_staff.txt
@@ -43,11 +43,11 @@
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO"
 
     "AbilitySharedCooldown"                               "silver_staff"
-    "AbilityCooldown"                                     "22.0"
+    "AbilityCooldown"                                     "20"
     "AbilityTextureName"                                  "custom/dragonstaff_4"
 
-    "AbilityCastRange"                                    "900"
-    "AbilityManaCost"                                     "50"
+    "AbilityCastRange"                                    "950"
+    "AbilityManaCost"                                     "75"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------
@@ -57,7 +57,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                        "15843"
-    "ItemAliases"                     "silver staff; break staff"
+    "ItemAliases"                     "silver staff; break staff; dragon staff"
     "ItemDisassembleRule"             "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     // Special
@@ -72,7 +72,7 @@
       "02"
       {
         "var_type"                    "FIELD_FLOAT"
-        "bonus_mana_regen"            "3.0 4.0"
+        "bonus_mana_regen"            "3.25 4.25"
       }
       "03"
       {

--- a/game/scripts/npc/items/custom/item_silver_staff_2.txt
+++ b/game/scripts/npc/items/custom/item_silver_staff_2.txt
@@ -44,11 +44,11 @@
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO"
 
     "AbilitySharedCooldown"                               "silver_staff"
-    "AbilityCooldown"                                     "22.0"
+    "AbilityCooldown"                                     "20"
     "AbilityTextureName"                                  "custom/dragonstaff_5"
 
-    "AbilityCastRange"                                    "900"
-    "AbilityManaCost"                                     "50"
+    "AbilityCastRange"                                    "950"
+    "AbilityManaCost"                                     "75"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------
@@ -58,7 +58,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                        "35844"
-    "ItemAliases"                     "silver staff 2; break staff 2"
+    "ItemAliases"                     "silver staff 2; break staff 2; dragon staff 2"
     "ItemDisassembleRule"             "DOTA_ITEM_DISASSEMBLE_NEVER"
 
     // Special
@@ -73,7 +73,7 @@
       "02"
       {
         "var_type"                    "FIELD_FLOAT"
-        "bonus_mana_regen"            "3.0 4.0"
+        "bonus_mana_regen"            "3.25 4.25"
       }
       "03"
       {

--- a/game/scripts/vscripts/items/silver_staff.lua
+++ b/game/scripts/vscripts/items/silver_staff.lua
@@ -142,7 +142,7 @@ function modifier_item_silver_staff_debuff:OnCreated()
 
     -- Do reduced damage to bosses
     if parent:IsOAABoss() then
-      damage_table.damage = self.base_damage + (self.percent_damage * parent:GetMaxHealth() * 0.01) * 85/100
+      damage_table.damage = self.base_damage + (self.percent_damage * parent:GetMaxHealth() * 0.01) * 15/100
     end
 
     ApplyDamage(damage_table)
@@ -195,7 +195,7 @@ function modifier_item_silver_staff_debuff:OnIntervalThink()
 
   -- Do reduced damage to bosses
   if parent:IsOAABoss() then
-    damage_table.damage = base_damage + (percent_damage * parent:GetMaxHealth() * 0.01) * 85/100
+    damage_table.damage = base_damage + (percent_damage * parent:GetMaxHealth() * 0.01) * 15/100
   end
 
   ApplyDamage(damage_table)

--- a/game/scripts/vscripts/items/silver_staff.lua
+++ b/game/scripts/vscripts/items/silver_staff.lua
@@ -140,10 +140,12 @@ function modifier_item_silver_staff_debuff:OnCreated()
       ability = ability,
     }
 
-    -- Don't do damage to bosses
-    if not parent:IsOAABoss() then
-      ApplyDamage(damage_table)
+    -- Do reduced damage to bosses
+    if parent:IsOAABoss() then
+      damage_table.damage = self.base_damage + (self.percent_damage * parent:GetMaxHealth() * 0.01) * 85/100
     end
+
+    ApplyDamage(damage_table)
 
     self:StartIntervalThink(1.0)
   end
@@ -167,14 +169,12 @@ function modifier_item_silver_staff_debuff:CheckState()
 end
 
 function modifier_item_silver_staff_debuff:OnIntervalThink()
+  if not IsServer() then
+    return
+  end
   local parent = self:GetParent()
   local caster = self:GetCaster()
   local ability = self:GetAbility()
-
-  -- Don't do damage to bosses
-  if parent:IsOAABoss() then
-    return
-  end
 
   local base_damage = self.base_damage
   local percent_damage = self.percent_damage
@@ -192,6 +192,11 @@ function modifier_item_silver_staff_debuff:OnIntervalThink()
     damage_flags = DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION,
     ability = ability,
   }
+
+  -- Do reduced damage to bosses
+  if parent:IsOAABoss() then
+    damage_table.damage = base_damage + (percent_damage * parent:GetMaxHealth() * 0.01) * 85/100
+  end
 
   ApplyDamage(damage_table)
 end


### PR DESCRIPTION
* Cooldown reduced from 22 to 20 seconds.
* Cast Range increased from 900 to 950. 
* Mana Cost increased from 50 to 75.
* Bonus mana regen increased from 3/4 to 3.25/4.25
* Silver Staff will now do reduced damage to bosses instead of 0. (Only percentage dmg is reduced)
