### PR TITLE
More Tinkerer tweaks

### DIFF
--- a/game/resource/English/npc/tooltip_tinkerer.txt
+++ b/game/resource/English/npc/tooltip_tinkerer.txt
@@ -76,7 +76,9 @@
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_initial_damage"                "INITIAL LASER DAMAGE:"
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_damage_per_second"             "MAX DAMAGE PER SECOND:"
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_attacks_to_destroy"            "ATTACKS REQUIRED:"
-"DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_description"           "Trapped enemies are blinded, leashed and have reduced healing by %scepter_heal_prevent_percent%%%. This debuff pierces spell immunity."
+"DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_description"           "Increases cast range. Trapped enemies are blinded, leashed and have reduced healing by %scepter_heal_prevent_percent%%%. This debuff pierces spell immunity."
+"DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_cast_range"            "SCEPTER CAST RANGE:"
+"DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_blind"                 "%SCEPTER BLIND:"
 
 // modifiers
 // "DOTA_Tooltip_modifier_tinker_laser_blind"					"Laser Blind"

--- a/game/scripts/npc/abilities/talents/tinkerer_talent4_oaa.txt
+++ b/game/scripts/npc/abilities/talents/tinkerer_talent4_oaa.txt
@@ -19,7 +19,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "value"                                           "2"
+        "value"                                           "3"
       }
     }
   }

--- a/game/scripts/npc/abilities/talents/tinkerer_talent6_oaa.txt
+++ b/game/scripts/npc/abilities/talents/tinkerer_talent6_oaa.txt
@@ -19,7 +19,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "value"                                           "60"
+        "value"                                           "100"
       }
     }
   }

--- a/game/scripts/npc/abilities/tinkerer_laser_contraption.txt
+++ b/game/scripts/npc/abilities/tinkerer_laser_contraption.txt
@@ -33,7 +33,7 @@
 
     // Time and Cost
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "60 55 50 45 40" // original: 65/55/45
+    "AbilityCooldown"                                     "55 50 45 40 35" // original: 65/55/45
     "AbilityManaCost"                                     "140 180 220 260 300"
 
     // Precache
@@ -48,13 +48,17 @@
     "AbilityValues"
     {
       "radius"                                            "300" // original: 800 x 100
-      "duration"                                          "8"
+      "duration"                                          "8.55"
       "delay"                                             "0.5"
-      "initial_damage"                                    "200 400 600 1200 1800" // original: 200/300/400
+      "initial_damage"
+      {
+        "value"                                           "200 400 600 1200 1800" // original: 200/300/400
+        "DamageTypeTooltip"                               "DAMAGE_TYPE_PURE"
+      }
       "damage_per_second"                                 "75 175 275 575 875" // original: 75 125 175
       "damage_interval"                                   "2" // 5 damage instances
       "attacks_to_destroy"                                "1 2 3 4 5"
-      "scepter_cast_range" // unused
+      "scepter_cast_range"
       {
         "value"                                           "1000"
         "RequiresScepter"                                 "1"

--- a/game/scripts/npc/abilities/tinkerer_smart_missiles.txt
+++ b/game/scripts/npc/abilities/tinkerer_smart_missiles.txt
@@ -59,7 +59,7 @@
       "rocket_range"                                      "3000"
       "rocket_vision"                                     "400"
       "bonus_max_hp_damage"                               "7"
-      "bonus_damage_range"                                "2000"
+      "bonus_damage_range"                                "1500"
       "stun_duration"                                     "0.1"
       "rocket_explode_vision"                             "400"
       "vision_duration"                                   "1.5"

--- a/game/scripts/vscripts/abilities/tinkerer/tinkerer_laser_contraption.lua
+++ b/game/scripts/vscripts/abilities/tinkerer/tinkerer_laser_contraption.lua
@@ -26,6 +26,16 @@ function tinkerer_laser_contraption:GetAOERadius()
   return self:GetSpecialValueFor("radius")
 end
 
+function tinkerer_laser_contraption:GetCastRange(location, target)
+  local caster = self:GetCaster()
+
+  if caster:HasScepter() then
+    return self:GetSpecialValueFor("scepter_cast_range")
+  end
+
+  return self.BaseClass.GetCastRange(self, location, target)
+end
+
 function tinkerer_laser_contraption:OnAbilityPhaseStart()
   if not IsServer() then
     return
@@ -126,6 +136,7 @@ function tinkerer_laser_contraption:OnSpellStart()
     node:AddNewModifier(caster, self, "modifier_tinkerer_laser_contraption_node", {duration = total_duration})
     node:AddNewModifier(caster, self, 'modifier_kill', {duration = total_duration})
     node:SetNeverMoveToClearSpace(true)
+    node:MakePhantomBlocker()
   end
 
   local units = FindUnitsInRadius(
@@ -148,7 +159,7 @@ function tinkerer_laser_contraption:OnSpellStart()
   damage_table.attacker = caster
   damage_table.damage = self:GetSpecialValueFor("initial_damage")
   damage_table.ability = self
-  damage_table.damage_type = self:GetAbilityDamageType()
+  damage_table.damage_type = DAMAGE_TYPE_PURE
 
   -- Unstuck all non-node units and damage non-spell-immune enemies if non-square shape
   for _, unit in pairs(units) do


### PR DESCRIPTION
* Scepter now also increases cast range for Laser Contraption.
* Level 20 Talent +2 Tar Spill duration increased to +3.
* Level 15 Talent +60 Tar Spill burn damage increased to +100.
* Laser Contraption cooldown reduced by 5 at all levels.
* Fixed Laser Contraption not having 5 damage instances. (increased duration from 8 to 8.55 seconds)
* Laser Contraption initial damage is now Pure.
* Laser Contraption trap cannot be escaped with Phase (No Collision) buffs anymore.
* Smart Missiles bonus damage range reduced from 2000 to 1500.