### PR TITLE
Fix for Nullifier and Greater Phase Boots

### DIFF
--- a/game/scripts/npc/items/custom/item_greater_phase_boots.txt
+++ b/game/scripts/npc/items/custom/item_greater_phase_boots.txt
@@ -25,10 +25,10 @@
     "ItemRequirements"
     {
       "01"                                                "item_phase_boots;item_upgrade_core"
-      "02"                                                "item_power_treads;item_upgrade_core"
-      "03"                                                "item_tranquil_boots;item_upgrade_core"
-      "04"                                                "item_travel_boots_oaa;item_upgrade_core"
-      "05"                                                "item_arcane_boots;item_upgrade_core"
+      //"02"                                                "item_power_treads;item_upgrade_core"
+      //"03"                                                "item_tranquil_boots;item_upgrade_core"
+      //"04"                                                "item_travel_boots_oaa;item_upgrade_core"
+      //"05"                                                "item_arcane_boots;item_upgrade_core"
     }
   }
 
@@ -52,7 +52,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "2426"
+    "ItemCost"                                            "3001"
     "ItemShopTags"                                        "damage;move_speed;hard_to_tag"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "greater phase boots;phase boots;phase"

--- a/game/scripts/npc/items/custom/item_greater_phase_boots_2.txt
+++ b/game/scripts/npc/items/custom/item_greater_phase_boots_2.txt
@@ -52,7 +52,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "5927"
+    "ItemCost"                                            "6502"
     "ItemShopTags"                                        "damage;move_speed;hard_to_tag"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "greater phase boots 2;phase boots 2;phase 2"

--- a/game/scripts/npc/items/custom/item_greater_phase_boots_3.txt
+++ b/game/scripts/npc/items/custom/item_greater_phase_boots_3.txt
@@ -52,7 +52,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "13928"
+    "ItemCost"                                            "14503"
     "ItemShopTags"                                        "damage;move_speed;hard_to_tag"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "greater phase boots 3;phase boots 3;phase 3"

--- a/game/scripts/npc/items/custom/item_greater_phase_boots_4.txt
+++ b/game/scripts/npc/items/custom/item_greater_phase_boots_4.txt
@@ -53,7 +53,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "33929"
+    "ItemCost"                                            "34504"
     "ItemShopTags"                                        "damage;move_speed;hard_to_tag"
     "ItemQuality"                                         "common"
     "ItemAliases"                                         "greater phase boots 4;phase boots 4;phase 4"

--- a/game/scripts/npc/items/custom/item_sonic.txt
+++ b/game/scripts/npc/items/custom/item_sonic.txt
@@ -45,7 +45,7 @@
     "ItemBaseLevel"         "1"
     "UpgradesItems"         "item_sonic_2"
 
-    "ItemCost"              "13928"
+    "ItemCost"              "14053"
     "ItemShopTags"          "sonic"
     "ItemQuality"           ""
     "ItemAliases"           "sonic"

--- a/game/scripts/npc/items/custom/item_sonic_2.txt
+++ b/game/scripts/npc/items/custom/item_sonic_2.txt
@@ -46,7 +46,7 @@
     "ItemBaseLevel"         "2"
     "UpgradesItems"         "item_sonic_2"
 
-    "ItemCost"              "33929"
+    "ItemCost"              "34054"
     "ItemShopTags"          "sonic"
     "ItemQuality"           ""
     "ItemAliases"           "sonic"

--- a/game/scripts/npc/items/item_force_boots.txt
+++ b/game/scripts/npc/items/item_force_boots.txt
@@ -57,7 +57,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "33929"
+    "ItemCost"                                            "34054"
     "ItemShopTags"                                        "move_speed"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "fb; force boots"

--- a/game/scripts/npc/items/item_nullifier.txt
+++ b/game/scripts/npc/items/item_nullifier.txt
@@ -7,7 +7,7 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"              "224"                           // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"              "224"
     "Model"             "models/props_gameplay/recipe.vmdl"
 
     // Item Info
@@ -31,12 +31,12 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"              "225"                           // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"              "225"
     "AbilityBehavior"       "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
     "AbilityUnitTargetTeam"     "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"     "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
-    "AbilityUnitTargetFlags"    "DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
-    "FightRecapLevel"       "1"
+    "AbilityUnitTargetFlags"    "DOTA_UNIT_TARGET_FLAG_INVULNERABLE | DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+
     "AbilityTextureName"    "custom/nullifier_1"
 
     // Item Info

--- a/game/scripts/npc/items/item_nullifier_2.txt
+++ b/game/scripts/npc/items/item_nullifier_2.txt
@@ -7,7 +7,7 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"              "8407"                           // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "8407"
     "BaseClass"                                           "item_datadriven"
     "Model"                                               "models/props_gameplay/recipe.vmdl"
     "AbilityTextureName"                                  "custom/recipe/recipe_2"
@@ -32,13 +32,13 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"              "8408"                           // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "8408"
     "BaseClass"                                           "item_nullifier"
     "AbilityBehavior"       "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
     "AbilityUnitTargetTeam"     "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"     "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
-    "AbilityUnitTargetFlags"    "DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
-    "FightRecapLevel"       "1"
+    "AbilityUnitTargetFlags"    "DOTA_UNIT_TARGET_FLAG_INVULNERABLE | DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+
     "AbilityTextureName"    "custom/nullifier_2"
 
     // Item Info

--- a/game/scripts/npc/items/item_nullifier_3.txt
+++ b/game/scripts/npc/items/item_nullifier_3.txt
@@ -7,7 +7,7 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"              "8409"                           // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "8409"
     "BaseClass"                                           "item_datadriven"
     "Model"                                               "models/props_gameplay/recipe.vmdl"
     "AbilityTextureName"                                  "custom/recipe/recipe_3"
@@ -32,13 +32,13 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"              "8410"                           // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "8410"
     "BaseClass"                                           "item_nullifier"
     "AbilityBehavior"       "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
     "AbilityUnitTargetTeam"     "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"     "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
-    "AbilityUnitTargetFlags"    "DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
-    "FightRecapLevel"       "1"
+    "AbilityUnitTargetFlags"    "DOTA_UNIT_TARGET_FLAG_INVULNERABLE | DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+
     "AbilityTextureName"    "custom/nullifier_3"
 
     // Item Info

--- a/game/scripts/npc/items/item_nullifier_4.txt
+++ b/game/scripts/npc/items/item_nullifier_4.txt
@@ -7,7 +7,7 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"              "8411"                           // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "8411"
     "BaseClass"                                           "item_datadriven"
     "Model"                                               "models/props_gameplay/recipe.vmdl"
     "AbilityTextureName"                                  "custom/recipe/recipe_4"
@@ -32,13 +32,13 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"              "8412"                           // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "8412"
     "BaseClass"                                           "item_nullifier"
     "AbilityBehavior"       "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
     "AbilityUnitTargetTeam"     "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"     "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
-    "AbilityUnitTargetFlags"    "DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
-    "FightRecapLevel"       "1"
+    "AbilityUnitTargetFlags"    "DOTA_UNIT_TARGET_FLAG_INVULNERABLE | DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+
     "AbilityTextureName"    "custom/nullifier_4"
 
     // Item Info

--- a/game/scripts/npc/items/item_nullifier_5.txt
+++ b/game/scripts/npc/items/item_nullifier_5.txt
@@ -7,7 +7,7 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"              "8413"                           // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "8413"
     "BaseClass"                                           "item_datadriven"
     "Model"                                               "models/props_gameplay/recipe.vmdl"
     "AbilityTextureName"                                  "custom/recipe/recipe_5"
@@ -32,13 +32,13 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"              "8414"                           // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "8414"
     "BaseClass"                                           "item_nullifier"
     "AbilityBehavior"       "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
     "AbilityUnitTargetTeam"     "DOTA_UNIT_TARGET_TEAM_ENEMY"
     "AbilityUnitTargetType"     "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
-    "AbilityUnitTargetFlags"    "DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
-    "FightRecapLevel"       "1"
+    "AbilityUnitTargetFlags"    "DOTA_UNIT_TARGET_FLAG_INVULNERABLE | DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+
     "AbilityTextureName"    "custom/nullifier_5"
 
     // Item Info


### PR DESCRIPTION
* Fixed not being able to target spell-immune units with Nullifier.
* Fixed being able to build Greater Phase Boots out of any boots. (Adjusted some item costs accordingly)