### PR TITLE
Aeon Disk stat 'fix'

### DIFF
--- a/game/scripts/npc/items/item_aeon_disk_2.txt
+++ b/game/scripts/npc/items/item_aeon_disk_2.txt
@@ -50,12 +50,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "250 500 1000 1750 2750"
+        "bonus_health"                                    "500 500 500 500 500"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 400 550 750 1000"
+        "bonus_mana"                                      "400 400 400 400 400"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk_3.txt
+++ b/game/scripts/npc/items/item_aeon_disk_3.txt
@@ -51,12 +51,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "250 500 1000 1750 2750"
+        "bonus_health"                                    "1000 1000 1000 1000 1000"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 400 550 750 1000"
+        "bonus_mana"                                      "550 550 550 550 550"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk_4.txt
+++ b/game/scripts/npc/items/item_aeon_disk_4.txt
@@ -51,12 +51,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "250 500 1000 1750 2750"
+        "bonus_health"                                    "1750 1750 1750 1750 1750"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 400 550 750 1000"
+        "bonus_mana"                                      "750 750 750 750 750"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_aeon_disk_5.txt
+++ b/game/scripts/npc/items/item_aeon_disk_5.txt
@@ -51,12 +51,12 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "250 500 1000 1750 2750"
+        "bonus_health"                                    "2750 2750 2750 2750 2750"
       }
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_mana"                                      "300 400 550 750 1000"
+        "bonus_mana"                                      "1000 1000 1000 1000 1000"
       }
       "03"
       {


### PR DESCRIPTION
my greatest hater npm test is telling me this is a moral and ethical violation of OAA law. both solutions I have break the law, is there some way that I can bribe test to shut up or is this the end of the road?

Item looks worse but functions better. Every level looks like it only has 1 level, it only shows the currents levels stats 1 time (it works if you change 400 400 400 400 400 to just 400 but I liked this better idk sue me). 

You can also scale the number of levels between the files but it still requires you to drop it and pick it up for it to work. Upgrading it could do that for you but its still really messy. 