### PR TITLE
Ta nerfs 

### DIFF
--- a/game/scripts/npc/items/custom/item_devastator_1.txt
+++ b/game/scripts/npc/items/custom/item_devastator_1.txt
@@ -15,7 +15,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCorePointCost"                                   "0"
-    "ItemCost"                                            "1500"
+    "ItemCost"                                            "1650"
     "ItemShopTags"                                        ""
 
     // Recipe
@@ -53,8 +53,8 @@
     "AbilityCastPoint"                                    "0"
 
     "AbilitySharedCooldown"                               "devastator"
-    "AbilityCooldown"                                     "9 8.5 8 7.5 7"
-    "AbilityManaCost"                                     "75"
+    "AbilityCooldown"                                     "11 10 9 8 7"
+    "AbilityManaCost"                                     "125"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
@@ -63,7 +63,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "5000"
+    "ItemCost"                                            "5150"
     "ItemShopTags"                                        "damage;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "devastator"

--- a/game/scripts/npc/items/custom/item_devastator_1.txt
+++ b/game/scripts/npc/items/custom/item_devastator_1.txt
@@ -15,7 +15,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCorePointCost"                                   "0"
-    "ItemCost"                                            "1650"
+    "ItemCost"                                            "1550"
     "ItemShopTags"                                        ""
 
     // Recipe
@@ -63,7 +63,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "5150"
+    "ItemCost"                                            "5050"
     "ItemShopTags"                                        "damage;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "devastator"

--- a/game/scripts/npc/items/custom/item_devastator_2.txt
+++ b/game/scripts/npc/items/custom/item_devastator_2.txt
@@ -63,7 +63,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "6651"
+    "ItemCost"                                            "6551"
     "ItemShopTags"                                        "damage;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "devastator 2"

--- a/game/scripts/npc/items/custom/item_devastator_2.txt
+++ b/game/scripts/npc/items/custom/item_devastator_2.txt
@@ -53,8 +53,8 @@
     "AbilityCastPoint"                                    "0"
 
     "AbilitySharedCooldown"                               "devastator"
-    "AbilityCooldown"                                     "9 8.5 8 7.5 7"
-    "AbilityManaCost"                                     "75"
+    "AbilityCooldown"                                     "11 10 9 8 7"
+    "AbilityManaCost"                                     "125"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
@@ -63,7 +63,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "6501"
+    "ItemCost"                                            "6651"
     "ItemShopTags"                                        "damage;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "devastator 2"

--- a/game/scripts/npc/items/custom/item_devastator_3.txt
+++ b/game/scripts/npc/items/custom/item_devastator_3.txt
@@ -53,8 +53,8 @@
     "AbilityCastPoint"                                    "0"
 
     "AbilitySharedCooldown"                               "devastator"
-    "AbilityCooldown"                                     "9 8.5 8 7.5 7"
-    "AbilityManaCost"                                     "75"
+    "AbilityCooldown"                                     "11 10 9 8 7"
+    "AbilityManaCost"                                     "125"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
@@ -63,7 +63,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "10002"
+    "ItemCost"                                            "10152"
     "ItemShopTags"                                        "damage;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "devastator 3"

--- a/game/scripts/npc/items/custom/item_devastator_3.txt
+++ b/game/scripts/npc/items/custom/item_devastator_3.txt
@@ -63,7 +63,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "10152"
+    "ItemCost"                                            "10052"
     "ItemShopTags"                                        "damage;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "devastator 3"

--- a/game/scripts/npc/items/custom/item_devastator_4.txt
+++ b/game/scripts/npc/items/custom/item_devastator_4.txt
@@ -53,8 +53,8 @@
     "AbilityCastPoint"                                    "0"
 
     "AbilitySharedCooldown"                               "devastator"
-    "AbilityCooldown"                                     "9 8.5 8 7.5 7"
-    "AbilityManaCost"                                     "75"
+    "AbilityCooldown"                                     "11 10 9 8 7"
+    "AbilityManaCost"                                     "125"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
@@ -63,7 +63,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "18003"
+    "ItemCost"                                            "18153"
     "ItemShopTags"                                        "damage;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "devastator 4"

--- a/game/scripts/npc/items/custom/item_devastator_4.txt
+++ b/game/scripts/npc/items/custom/item_devastator_4.txt
@@ -63,7 +63,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "18153"
+    "ItemCost"                                            "18053"
     "ItemShopTags"                                        "damage;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "devastator 4"

--- a/game/scripts/npc/items/custom/item_devastator_5.txt
+++ b/game/scripts/npc/items/custom/item_devastator_5.txt
@@ -63,7 +63,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "38154"
+    "ItemCost"                                            "38054"
     "ItemShopTags"                                        "damage;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "devastator 5"

--- a/game/scripts/npc/items/custom/item_devastator_5.txt
+++ b/game/scripts/npc/items/custom/item_devastator_5.txt
@@ -53,8 +53,8 @@
     "AbilityCastPoint"                                    "0"
 
     "AbilitySharedCooldown"                               "devastator"
-    "AbilityCooldown"                                     "9 8.5 8 7.5 7"
-    "AbilityManaCost"                                     "75"
+    "AbilityCooldown"                                     "11 10 9 8 7"
+    "AbilityManaCost"                                     "125"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
@@ -63,7 +63,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "38004"
+    "ItemCost"                                            "38154"
     "ItemShopTags"                                        "damage;unique"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "devastator 5"


### PR DESCRIPTION
- Base camps can only stack up to 6 creeps 
- Devastator has a slightly longer cooldown, costs more mana and costs 50 more gold.