### PR TITLE
Sohei and Tinkerer small changes

### DIFF
--- a/game/resource/English/npc/tooltip_tinkerer.txt
+++ b/game/resource/English/npc/tooltip_tinkerer.txt
@@ -77,9 +77,8 @@
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_initial_damage"                "INITIAL LASER DAMAGE:"
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_damage_per_second"             "MAX DAMAGE PER SECOND:"
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_attacks_to_destroy"            "ATTACKS REQUIRED:"
-"DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_description"           "Increases cast range. Trapped enemies are blinded, leashed and have reduced healing/regen/lifesteal by %scepter_heal_prevent_percent%%%. Leash and healing reduction pierce spell immunity but blind doesn't."
+"DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_description"           "Increases cast range. Trapped enemies are leashed and have reduced healing/regen/lifesteal by %scepter_heal_prevent_percent%%%. Leash and healing reduction pierce spell immunity."
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_cast_range"            "SCEPTER CAST RANGE:"
-"DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_blind"                 "%SCEPTER BLIND:"
 
 // modifiers
 // "DOTA_Tooltip_modifier_tinker_laser_blind"					"Laser Blind"
@@ -98,7 +97,7 @@
 "DOTA_Tooltip_modifier_tinkerer_oil_spill_debuff_Description"                   "Move speed reduced by %dMODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE%%% and attack speed by %dMODIFIER_PROPERTY_ATTACKSPEED_PERCENTAGE%%%. If ignited, this unit will take %dMODIFIER_PROPERTY_TOOLTIP% damage."
 
 "DOTA_Tooltip_modifier_tinkerer_laser_contraption_debuff"                       "Laser Contraption (Scepter)"
-"DOTA_Tooltip_modifier_tinkerer_laser_contraption_debuff_Description"           "Leashed and missing %dMODIFIER_PROPERTY_MISS_PERCENTAGE%%% of attacks."
+"DOTA_Tooltip_modifier_tinkerer_laser_contraption_debuff_Description"           "Leashed and all healing, regeneration, lifesteal and spell lifesteal reduced by %dMODIFIER_PROPERTY_LIFESTEAL_AMPLIFY_PERCENTAGE%%%."
 
 // talents
 "DOTA_Tooltip_ability_special_bonus_unique_tinkerer_1"                          "+{s:multishot_count} Multishot Smart Missiles"

--- a/game/scripts/npc/abilities/sohei_flurry_of_blows_oaa.txt
+++ b/game/scripts/npc/abilities/sohei_flurry_of_blows_oaa.txt
@@ -60,7 +60,7 @@
       }
       "max_duration"
       {
-        "value"                                           "2.5 3.5 4.5 5.5 6" // min is: max_attacks * attack_interval
+        "value"                                           "2.5 3.5 4.5 5.5 6" // min is: (max_attacks + 1) * attack_interval
         "special_bonus_unique_sohei_8"                    "+1.8"
       }
       "attack_interval"                                   "0.3"

--- a/game/scripts/npc/abilities/sohei_polarizing_palm_oaa.txt
+++ b/game/scripts/npc/abilities/sohei_polarizing_palm_oaa.txt
@@ -43,7 +43,7 @@
     {
       "particle"                                          "particles/hero/sohei/momentum.vpcf"
       "particle"                                          "particles/hero/sohei/arcana/dbz/sohei_momentum_dbz.vpcf"
-      "particle"                                          "particles/hero/sohei/arcana/dbz/sohei_momentum_pepsi.vpcf"
+      "particle"                                          "particles/hero/sohei/arcana/pepsi/sohei_momentum_pepsi.vpcf"
       "particle"                                          "particles/hero/sohei/sohei_trail.vpcf"
       "particle"                                          "particles/hero/sohei/arcana/dbz/sohei_trail_dbz.vpcf"
       "particle"                                          "particles/hero/sohei/arcana/pepsi/sohei_trail_pepsi.vpcf"

--- a/game/scripts/npc/abilities/tinkerer_laser_contraption.txt
+++ b/game/scripts/npc/abilities/tinkerer_laser_contraption.txt
@@ -62,11 +62,6 @@
         "value"                                           "1000"
         "RequiresScepter"                                 "1"
       }
-      "scepter_blind"
-      {
-        "value"                                           "25 50 75 100 100"
-        "RequiresScepter"                                 "1"
-      }
       "scepter_heal_prevent_percent"
       {
         "value"                                           "-25"

--- a/game/scripts/npc/heroes/sohei.txt
+++ b/game/scripts/npc/heroes/sohei.txt
@@ -14,7 +14,7 @@
 
     "MovementCapabilities"      "DOTA_UNIT_CAP_MOVE_GROUND"
     "MovementTurnRate"          "1.5"
-    "MovementSpeed"             "290"
+    "MovementSpeed"             "305"
 
     "AttackCapabilities"        "DOTA_UNIT_CAP_MELEE_ATTACK"
     "AttackDamageMin"           "25"
@@ -85,8 +85,8 @@
     "UnitRelationshipClass"     "DOTA_NPC_UNIT_RELATIONSHIP_TYPE_HERO"
     "HasInventory"              "1"
 
-    "VisionDaytimeRange"        "1800"                            // Range of vision during day light.
-    "VisionNighttimeRange"      "800"                            // Range of vision at night time.
+    "VisionDaytimeRange"        "1800"
+    "VisionNighttimeRange"      "800"
 
     "BoundsHullName"            "DOTA_HULL_SIZE_HERO"
 

--- a/game/scripts/vscripts/abilities/sohei/sohei_flurry_of_blows.lua
+++ b/game/scripts/vscripts/abilities/sohei/sohei_flurry_of_blows.lua
@@ -70,7 +70,7 @@ function sohei_flurry_of_blows:OnSpellStart()
   -- Default particle
   caster.flurry_ground_pfx = ParticleManager:CreateParticle("particles/hero/sohei/flurry_of_blows_ground.vpcf", PATTACH_CUSTOMORIGIN, nil)
   ParticleManager:SetParticleControl(caster.flurry_ground_pfx, 0, target_loc)
-  ParticleManager:SetParticleControl(caster.flurry_ground_pfx, 10, Vector(radius, 0, 0))
+  ParticleManager:SetParticleControl(caster.flurry_ground_pfx, 10, Vector(radius+10, 0, 0))
 
   -- Disjoint projectiles
   ProjectileManager:ProjectileDodge(caster)

--- a/game/scripts/vscripts/abilities/sohei/sohei_momentum.lua
+++ b/game/scripts/vscripts/abilities/sohei/sohei_momentum.lua
@@ -209,7 +209,7 @@ if IsServer() then
     if target:HasModifier('modifier_arcana_dbz') then
       particleName = "particles/hero/sohei/arcana/dbz/sohei_momentum_dbz.vpcf"
     elseif target:HasModifier('modifier_arcana_pepsi') then
-      particleName = "particles/hero/sohei/arcana/dbz/sohei_momentum_pepsi.vpcf"
+      particleName = "particles/hero/sohei/arcana/pepsi/sohei_momentum_pepsi.vpcf"
     end
 
     -- Play the impact particle

--- a/game/scripts/vscripts/abilities/sohei/sohei_momentum_strike.lua
+++ b/game/scripts/vscripts/abilities/sohei/sohei_momentum_strike.lua
@@ -42,7 +42,7 @@ function sohei_momentum_strike:OnSpellStart()
   if caster:HasModifier("modifier_arcana_dbz") then
     particleName = "particles/hero/sohei/arcana/dbz/sohei_momentum_dbz.vpcf"
   elseif caster:HasModifier("modifier_arcana_pepsi") then
-    particleName = "particles/hero/sohei/arcana/dbz/sohei_momentum_pepsi.vpcf"
+    particleName = "particles/hero/sohei/arcana/pepsi/sohei_momentum_pepsi.vpcf"
   end
 
   local ki_strike_particle = ParticleManager:CreateParticle("particles/hero/sohei/ki_strike.vpcf", PATTACH_CUSTOMORIGIN, caster)

--- a/game/scripts/vscripts/abilities/sohei/sohei_polarizing_palm.lua
+++ b/game/scripts/vscripts/abilities/sohei/sohei_polarizing_palm.lua
@@ -147,7 +147,7 @@ function sohei_polarizing_palm:OnSpellStart()
     if caster:HasModifier("modifier_arcana_dbz") then
       particleName1 = "particles/hero/sohei/arcana/dbz/sohei_momentum_dbz.vpcf"
     elseif caster:HasModifier("modifier_arcana_pepsi") then
-      particleName1 = "particles/hero/sohei/arcana/dbz/sohei_momentum_pepsi.vpcf"
+      particleName1 = "particles/hero/sohei/arcana/pepsi/sohei_momentum_pepsi.vpcf"
     end
 
     local particle_enemy = ParticleManager:CreateParticle(particleName1, PATTACH_ABSORIGIN_FOLLOW, caster)
@@ -452,4 +452,3 @@ function modifier_sohei_polarizing_palm_stun:CheckState()
     [MODIFIER_STATE_STUNNED] = true,
   }
 end
-

--- a/game/scripts/vscripts/abilities/tinkerer/tinkerer_laser_contraption.lua
+++ b/game/scripts/vscripts/abilities/tinkerer/tinkerer_laser_contraption.lua
@@ -379,7 +379,7 @@ function modifier_tinkerer_laser_contraption_thinker:OnDestroy()
 end
 
 ---------------------------------------------------------------------------------------------------
--- Scepter Blind and Leash effect provided by an aura of the thinker
+-- Scepter effect provided by an aura of the thinker
 
 modifier_tinkerer_laser_contraption_debuff = class({})
 
@@ -398,7 +398,7 @@ end
 function modifier_tinkerer_laser_contraption_debuff:OnCreated()
   local ability = self:GetAbility()
   if ability and not ability:IsNull() then
-    self.blind_pct = ability:GetSpecialValueFor("scepter_blind")
+    --self.blind_pct = ability:GetSpecialValueFor("scepter_blind")
     self.heal_prevent_percent = ability:GetSpecialValueFor("scepter_heal_prevent_percent")
   end
 end
@@ -407,7 +407,7 @@ modifier_tinkerer_laser_contraption_debuff.OnRefresh = modifier_tinkerer_laser_c
 
 function modifier_tinkerer_laser_contraption_debuff:DeclareFunctions()
   return {
-    MODIFIER_PROPERTY_MISS_PERCENTAGE,
+    --MODIFIER_PROPERTY_MISS_PERCENTAGE, -- blind
     MODIFIER_PROPERTY_HEAL_AMPLIFY_PERCENTAGE_TARGET,
     MODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE,
     MODIFIER_PROPERTY_LIFESTEAL_AMPLIFY_PERCENTAGE,
@@ -415,12 +415,12 @@ function modifier_tinkerer_laser_contraption_debuff:DeclareFunctions()
   }
 end
 
-function modifier_tinkerer_laser_contraption_debuff:GetModifierMiss_Percentage()
-  if not self:GetParent():IsMagicImmune() then
-    return self.blind_pct or self:GetAbility():GetSpecialValueFor("scepter_blind")
-  end
-  return 0
-end
+-- function modifier_tinkerer_laser_contraption_debuff:GetModifierMiss_Percentage()
+  -- if not self:GetParent():IsMagicImmune() then
+    -- return self.blind_pct or self:GetAbility():GetSpecialValueFor("scepter_blind")
+  -- end
+  -- return 0
+-- end
 
 function modifier_tinkerer_laser_contraption_debuff:GetModifierHealAmplify_PercentageTarget()
   return self.heal_prevent_percent or self:GetAbility():GetSpecialValueFor("scepter_heal_prevent_percent")
@@ -439,10 +439,9 @@ function modifier_tinkerer_laser_contraption_debuff:GetModifierSpellLifestealReg
 end
 
 function modifier_tinkerer_laser_contraption_debuff:CheckState()
-  local state = {
-    [MODIFIER_STATE_TETHERED] = true,
+  return {
+    [MODIFIER_STATE_TETHERED] = true, -- leash
   }
-  return state
 end
 
 ---------------------------------------------------------------------------------------------------
@@ -466,15 +465,13 @@ function modifier_tinkerer_laser_contraption_node:RemoveOnDeath()
 end
 
 function modifier_tinkerer_laser_contraption_node:DeclareFunctions()
-  local funcs =
-  {
+  return {
     MODIFIER_PROPERTY_DISABLE_HEALING,
     MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_PHYSICAL,
     MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_MAGICAL,
     MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_PURE,
-    MODIFIER_EVENT_ON_ATTACKED
+    MODIFIER_EVENT_ON_ATTACKED,
   }
-  return funcs
 end
 
 function modifier_tinkerer_laser_contraption_node:GetAbsoluteNoDamagePhysical()
@@ -529,7 +526,7 @@ if IsServer() then
 end
 
 function modifier_tinkerer_laser_contraption_node:CheckState()
-  local state = {
+  return {
     [MODIFIER_STATE_MAGIC_IMMUNE] = true,
     [MODIFIER_STATE_NOT_ON_MINIMAP] = true,
     [MODIFIER_STATE_CANNOT_BE_MOTION_CONTROLLED] = true,
@@ -537,7 +534,6 @@ function modifier_tinkerer_laser_contraption_node:CheckState()
     --[MODIFIER_STATE_NO_HEALTH_BAR] = true,
     [MODIFIER_STATE_STUNNED] = true,
   }
-  return state
 end
 
 function modifier_tinkerer_laser_contraption_node:OnDestroy()

--- a/game/scripts/vscripts/abilities/tinkerer/tinkerer_oil_spill.lua
+++ b/game/scripts/vscripts/abilities/tinkerer/tinkerer_oil_spill.lua
@@ -85,7 +85,7 @@ function tinkerer_oil_spill:OnProjectileHit(target, location)
     duration = duration + talent:GetSpecialValueFor("value")
   end
 
-  --loop enemies
+  -- Apply debuff to enemies
   for _, enemy in pairs(oiled_enemies) do
     if enemy and not enemy:IsNull() and not enemy:IsMagicImmune() then
       enemy:AddNewModifier(caster, self, "modifier_tinkerer_oil_spill_debuff", {duration = duration})

--- a/game/scripts/vscripts/abilities/tinkerer/tinkerer_smart_missiles.lua
+++ b/game/scripts/vscripts/abilities/tinkerer/tinkerer_smart_missiles.lua
@@ -251,11 +251,9 @@ function modifier_tinkerer_smart_missiles_stun:GetEffectAttachType()
 end
 
 function modifier_tinkerer_smart_missiles_stun:DeclareFunctions()
-  local funcs = {
+  return {
     MODIFIER_PROPERTY_OVERRIDE_ANIMATION,
   }
-
-  return funcs
 end
 
 function modifier_tinkerer_smart_missiles_stun:GetOverrideAnimation()
@@ -263,8 +261,7 @@ function modifier_tinkerer_smart_missiles_stun:GetOverrideAnimation()
 end
 
 function modifier_tinkerer_smart_missiles_stun:CheckState()
-  local state = {
+  return {
     [MODIFIER_STATE_STUNNED] = true,
   }
-  return state
 end

--- a/game/scripts/vscripts/precache.lua
+++ b/game/scripts/vscripts/precache.lua
@@ -23,7 +23,6 @@ g_ItemPrecache = {
   "item_martyrs_mail_4",
   --"item_meteor_hammer_1",
   "item_pull_staff",
-  --"item_reflection_shard_1",
   --"item_reflex_core",
   "item_regen_crystal_1",
   --"item_rune_breaker_oaa",


### PR DESCRIPTION
* Sohei base movement speed increased from 290 to 305.
* Fixed Pepsi Sohei Polarizing Palm push/pull particle on enemies.
* Made Sohei Flurry of Blows aoe particle slightly bigger.
* Tinkerer Laser Contraption scepter no longer blinds.