### PR TITLE
Heart and Regen Crystal nerfs

### DIFF
--- a/game/scripts/npc/items/custom/item_heart_transplant.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant.txt
@@ -7,7 +7,7 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"                                                  "3258"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "3258"
     "BaseClass"                                           "item_datadriven"
     "Model"                                               "models/props_gameplay/recipe.vmdl"
     "AbilityTextureName"                                  "custom/recipe/recipe_4"
@@ -37,7 +37,7 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"                                                  "3260"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "3260"
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/heart_transplant.lua"
     "AbilityTextureName"                                  "custom/heart_transplant"
@@ -112,9 +112,9 @@
       "07" // same as Heart lvls 4-5
       {
         "var_type"                                        "FIELD_INTEGER"
-        "transplant_bonus_health"                         "1000 1250"
+        "transplant_bonus_health"                         "700 950"
       }
-      "08" // same as Heart lvls 3-4
+      "08"
       {
         "var_type"                                        "FIELD_FLOAT"
         "transplant_health_regen_pct"                     "1.5"
@@ -127,7 +127,7 @@
       "10" // same as Solar Crest
       {
         "var_type"                                        "FIELD_INTEGER"
-        "transplant_max_duration"                         "7"
+        "transplant_max_duration"                         "12"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_heart_transplant_2.txt
+++ b/game/scripts/npc/items/custom/item_heart_transplant_2.txt
@@ -7,7 +7,7 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"                                                  "3259"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "3259"
     "BaseClass"                                           "item_datadriven"
     "Model"                                               "models/props_gameplay/recipe.vmdl"
     "AbilityTextureName"                                  "custom/recipe/recipe_5"
@@ -38,7 +38,7 @@
   {
     // General
     //-------------------------------------------------------------------------------------------------------------
-    "ID"                                                  "3261"                            // unique ID number for this item.  Do not change this once established or it will invalidate collected stats.
+    "ID"                                                  "3261"
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/heart_transplant.lua"
     "AbilityTextureName"                                  "custom/heart_transplant_2"
@@ -105,9 +105,9 @@
       "07" // same as Heart lvls 4-5
       {
         "var_type"                                        "FIELD_INTEGER"
-        "transplant_bonus_health"                         "1000 1250"
+        "transplant_bonus_health"                         "700 950"
       }
-      "08" // same as Heart lvls 3-4
+      "08"
       {
         "var_type"                                        "FIELD_FLOAT"
         "transplant_health_regen_pct"                     "1.5"
@@ -120,7 +120,7 @@
       "10" // same as Solar Crest
       {
         "var_type"                                        "FIELD_INTEGER"
-        "transplant_max_duration"                         "7"
+        "transplant_max_duration"                         "12"
       }
     }
   }

--- a/game/scripts/npc/items/custom/item_regen_crystal_1.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_1.txt
@@ -47,13 +47,13 @@
     "AbilityCooldown"                                     "25"
     "AbilityCastPoint"                                    "0.0"
     "AbilitySharedCooldown"                               "regen_crystal"
+    "AbilityManaCost"                                     "200"
 
     "MaxUpgradeLevel"                                     "3"
     "ItemBaseLevel"                                       "1"
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityManaCost"                                     "200"
     "ItemCost"                                            "9302"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
@@ -68,7 +68,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "1750 2450 3150"
+        "bonus_health"                                    "1500 2100 2850"
       }
       "02"
       {
@@ -78,12 +78,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "max_mana_to_hp_regen"                            "5"
+        "max_mana_to_hp_regen"                            "4.25"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen"                                 "400 450 500"
+        "active_hp_regen"                                 "200 225 250"
       }
       "05"
       {
@@ -93,7 +93,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "duration"                                        "5"
+        "duration"                                        "6"
       }
     }
 

--- a/game/scripts/npc/items/custom/item_regen_crystal_2.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_2.txt
@@ -42,18 +42,19 @@
     "ScriptFile"                                          "items/reflex/postactive_regen.lua"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
     "AbilityTextureName"                                  "custom/regen_crystal_2"
+
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "25"
     "AbilityCastPoint"                                    "0.0"
     "AbilitySharedCooldown"                               "regen_crystal"
+    "AbilityManaCost"                                     "200"
 
     "MaxUpgradeLevel"                                     "3"
     "ItemBaseLevel"                                       "2"
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityManaCost"                                     "200"
     "ItemCost"                                            "17303"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
@@ -68,7 +69,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "1750 2450 3150"
+        "bonus_health"                                    "1500 2100 2850"
       }
       "02"
       {
@@ -78,12 +79,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "max_mana_to_hp_regen"                            "5"
+        "max_mana_to_hp_regen"                            "4.25"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen"                                 "400 450 500"
+        "active_hp_regen"                                 "200 225 250"
       }
       "05"
       {
@@ -93,7 +94,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "duration"                                        "5"
+        "duration"                                        "6"
       }
     }
 

--- a/game/scripts/npc/items/custom/item_regen_crystal_3.txt
+++ b/game/scripts/npc/items/custom/item_regen_crystal_3.txt
@@ -43,18 +43,19 @@
     "ScriptFile"                                          "items/reflex/postactive_regen.lua"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
     "AbilityTextureName"                                  "custom/regen_crystal_3"
+
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "25"
     "AbilityCastPoint"                                    "0.0"
     "AbilitySharedCooldown"                               "regen_crystal"
+    "AbilityManaCost"                                     "200"
 
     "MaxUpgradeLevel"                                     "3"
     "ItemBaseLevel"                                       "3"
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityManaCost"                                     "200"
     "ItemCost"                                            "34304"
     "ItemShopTags"                                        "str;regen_health;health_pool"
     "ItemQuality"                                         "epic"
@@ -69,7 +70,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "1750 2450 3150"
+        "bonus_health"                                    "1500 2100 2850"
       }
       "02"
       {
@@ -79,12 +80,12 @@
       "03"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "max_mana_to_hp_regen"                            "5"
+        "max_mana_to_hp_regen"                            "4.25"
       }
       "04"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "active_hp_regen"                                 "400 450 500"
+        "active_hp_regen"                                 "200 225 250"
       }
       "05"
       {
@@ -94,7 +95,7 @@
       "06"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "duration"                                        "5"
+        "duration"                                        "6"
       }
     }
 

--- a/game/scripts/npc/items/item_heart.txt
+++ b/game/scripts/npc/items/item_heart.txt
@@ -78,7 +78,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "250 500 750 1000 1250"
+        "bonus_health"                                    "250 350 500 700 950"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_heart_2.txt
+++ b/game/scripts/npc/items/item_heart_2.txt
@@ -76,7 +76,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "250 500 750 1000 1250"
+        "bonus_health"                                    "250 350 500 700 950"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_heart_3.txt
+++ b/game/scripts/npc/items/item_heart_3.txt
@@ -76,7 +76,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "250 500 750 1000 1250"
+        "bonus_health"                                    "250 350 500 700 950"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_heart_4.txt
+++ b/game/scripts/npc/items/item_heart_4.txt
@@ -77,7 +77,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "250 500 750 1000 1250"
+        "bonus_health"                                    "250 350 500 700 950"
       }
       "03"
       {

--- a/game/scripts/npc/items/item_heart_5.txt
+++ b/game/scripts/npc/items/item_heart_5.txt
@@ -77,7 +77,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "250 500 750 1000 1250"
+        "bonus_health"                                    "250 350 500 700 950"
       }
       "03"
       {


### PR DESCRIPTION
* Heart of Tarrasque bonus hp reduced from 250/500/750/1000/1250 to 250/350/500/700/950.
* Regen Crystal bonus hp reduced from 1750/2450/3150 to 1500/2100/2850.
* Regen Crystal max mana as passive bonus hp regen reduced from 5% to 4.25%.
* Regen Crystal active bonus hp regen reduced from 400/450/500 to 200/225/250.
* Regen Crystal active duration increased from 5 to 6 seconds.
* Heart Transplant transplanted hp reduced from 1000/1250 to 700/950.
* Heart Transplant max duration increased from 7 to 12 seconds.