### PR TITLE
CDR modifiers update

### DIFF
--- a/game/scripts/vscripts/modifiers/funmodifiers/modifier_ham_oaa.lua
+++ b/game/scripts/vscripts/modifiers/funmodifiers/modifier_ham_oaa.lua
@@ -24,6 +24,7 @@ function modifier_ham_oaa:OnCreated()
     dazzle_good_juju = true,
     dazzle_shallow_grave = true,
     earth_spirit_petrify = true,
+    meepo_petrify = true,
     obsidian_destroyer_astral_imprisonment = true,
     oracle_fates_edict = true,
     oracle_false_promise = true,
@@ -34,13 +35,10 @@ function modifier_ham_oaa:OnCreated()
     skeleton_king_reincarnation = true,
     tusk_snowball = true,
     venomancer_plague_ward = true,
+    visage_gravekeepers_cloak = true,
+    visage_gravekeepers_cloak_oaa = true,
     void_spirit_dissimilate = true,
     witch_doctor_voodoo_switcheroo_oaa = true,
-    item_sphere = true,
-    item_sphere_2 = true,
-    item_sphere_3 = true,
-    item_sphere_4 = true,
-    item_sphere_5 = true,
   }
 
   self.cdr_penalty = 5
@@ -61,7 +59,8 @@ function modifier_ham_oaa:GetModifierPercentageCooldown(keys)
   if self:GetParent():HasModifier("modifier_pro_active_oaa") then
     return 0
   end
-  if keys.ability and self.ignore_abilities[keys.ability:GetName()] then
+  local ability = keys.ability
+  if ability and (self.ignore_abilities[ability:GetName()] or ability:IsItem()) then
     return self.cdr_penalty
   else
     return self.cdr

--- a/game/scripts/vscripts/modifiers/funmodifiers/modifier_pro_active_oaa.lua
+++ b/game/scripts/vscripts/modifiers/funmodifiers/modifier_pro_active_oaa.lua
@@ -28,6 +28,7 @@ function modifier_pro_active_oaa:OnCreated()
     dazzle_good_juju = true,
     dazzle_shallow_grave = true,
     earth_spirit_petrify = true,
+    meepo_petrify = true,
     obsidian_destroyer_astral_imprisonment = true,
     oracle_fates_edict = true,
     oracle_false_promise = true,
@@ -38,13 +39,10 @@ function modifier_pro_active_oaa:OnCreated()
     skeleton_king_reincarnation = true,
     tusk_snowball = true,
     venomancer_plague_ward = true,
+    visage_gravekeepers_cloak = true,
+    visage_gravekeepers_cloak_oaa = true,
     void_spirit_dissimilate = true,
     witch_doctor_voodoo_switcheroo_oaa = true,
-    item_sphere = true,
-    item_sphere_2 = true,
-    item_sphere_3 = true,
-    item_sphere_4 = true,
-    item_sphere_5 = true,
   }
 
   self.cdr_penalty = 10
@@ -65,7 +63,8 @@ function modifier_pro_active_oaa:DeclareFunctions()
 end
 
 function modifier_pro_active_oaa:GetModifierPercentageCooldown(keys)
-  if keys.ability and self.ignore_abilities[keys.ability:GetName()] then
+  local ability = keys.ability
+  if ability and (self.ignore_abilities[ability:GetName()] or ability:IsItem()) then
     return self.cdr_penalty
   else
     return self.cdr

--- a/game/scripts/vscripts/modifiers/funmodifiers/modifier_sorcerer_oaa.lua
+++ b/game/scripts/vscripts/modifiers/funmodifiers/modifier_sorcerer_oaa.lua
@@ -159,7 +159,7 @@ if IsServer() then
 
       -- Reset neutral item cooldown
       local neutral_item = parent:GetItemInSlot(DOTA_ITEM_NEUTRAL_SLOT)
-      if neutral_item and neutral_item:IsNeutralDrop() and not self.exempt_item_table[item:GetAbilityName()] then
+      if neutral_item and neutral_item:IsNeutralDrop() and not self.exempt_item_table[neutral_item:GetAbilityName()] then
         neutral_item:EndCooldown()
       end
     end

--- a/game/scripts/vscripts/modifiers/funmodifiers/modifier_sorcerer_oaa.lua
+++ b/game/scripts/vscripts/modifiers/funmodifiers/modifier_sorcerer_oaa.lua
@@ -26,9 +26,17 @@ function modifier_sorcerer_oaa:OnCreated()
 
   -- Put ability exemption in here
   self.exempt_ability_table = {
-    tinker_rearm = true,
+    dazzle_good_juju = true,
     riki_permanent_invisibility = true,
+    tinker_rearm = true,
     treant_natures_guise = true
+  }
+
+  -- Put item exemption in here
+  self.exempt_item_table = {
+    item_ex_machina = true,
+    item_refresher_shard = true,
+    item_tranquil_boots = true,
   }
 end
 
@@ -138,7 +146,7 @@ if IsServer() then
       -- Reset cooldown for items
       for i = DOTA_ITEM_SLOT_1, DOTA_ITEM_SLOT_6 do
         local item = parent:GetItemInSlot(i)
-        if item and item:IsRefreshable() then
+        if item and item:IsRefreshable() and not self.exempt_item_table[item:GetAbilityName()] then
           item:EndCooldown()
         end
       end
@@ -151,7 +159,7 @@ if IsServer() then
 
       -- Reset neutral item cooldown
       local neutral_item = parent:GetItemInSlot(DOTA_ITEM_NEUTRAL_SLOT)
-      if neutral_item and neutral_item:IsNeutralDrop() then
+      if neutral_item and neutral_item:IsNeutralDrop() and not self.exempt_item_table[item:GetAbilityName()] then
         neutral_item:EndCooldown()
       end
     end


### PR DESCRIPTION
* Hyper-Active and Pro-Active modifiers will now provide reduced cdr to all items (not just Linken's Sphere), Meepo Dig (scepter ability) and Visage Gravekeeper's Cloak (with shard).
* Sorcerer modifier cannot refresh Dazzle Good Juju anymore.
* Sorcerer modifier cannot refresh Ex Machina and Refresher Shard anymore.