### PR TITLE
Minor boss changes

### DIFF
--- a/game/scripts/npc/abilities/boss/lycan_boss/lycan_boss_claw_attack_tier5.txt
+++ b/game/scripts/npc/abilities/boss/lycan_boss/lycan_boss_claw_attack_tier5.txt
@@ -42,7 +42,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage"                                          "25000"
+        "damage"                                          "10000"
       }
       "02"
       {

--- a/game/scripts/npc/npc_units_custom.txt
+++ b/game/scripts/npc/npc_units_custom.txt
@@ -46,6 +46,7 @@
 #base "units/boss/twin/twin_dumb_tier5.txt"
 #base "units/boss/shielder_tier5.txt"
 #base "units/boss/bear_boss_tier5.txt"
+#base "units/boss/big_bird.txt"
 #base "units/boss/charger/charger_tier5.txt"
 #base "units/boss/ogre_tank_boss/ogre_tank_boss_tier5.txt"
 #base "units/boss/ogre_tank_boss/ogre_seer_tier5.txt"
@@ -57,7 +58,6 @@
 #base "units/boss/temple_guardian/temple_guardian_spawner_tier5.txt"
 #base "units/boss/stopfightingyourself_tier5.txt"
 
-//#base "units/boss/big_bird.txt"
 //#base "units/boss/butterface.txt"
 //#base "units/boss/jingu_banger.txt"
 //#base "units/boss/shrek.txt"

--- a/game/scripts/npc/units/boss/big_bird.txt
+++ b/game/scripts/npc/units/boss/big_bird.txt
@@ -7,40 +7,41 @@
   {
     // General
     //----------------------------------------------------------------
-    "Model"                                               "models/creeps/neutral_creeps/n_creep_vulture_b/n_creep_vulture_b.vmdl"  // Model.
     "BaseClass"                                           "npc_dota_creature"
+    "Model"                                               "models/creeps/neutral_creeps/n_creep_vulture_b/n_creep_vulture_b.vmdl"
+    "vscripts"                                            "units/ai_simple.lua"
     "SoundSet"                                            "n_creep_Melee"                                   // Name of sound set.
-    "Level"                                               "125"
+    "Level"                                               "60"
     "ModelScale"                                          "3.0"
     "IsAncient"                                           "1"
     "ConsideredHero"                                      "1"
+    "UseNeutralCreepBehavior"                             "0"
 
     // Abilities
     //----------------------------------------------------------------
     "Ability1"                                            "boss_resistance"
     "Ability2"                                            "boss_cliffwalk"
     "Ability3"                                            "boss_regen"
+    "Ability4"                                            "boss_true_strike"
 
     // Armor
     //-----------------------------------------------------------------
-    "ArmorPhysical"                                       "25"        // Physical protection.
-    "MagicalResistance"                                   "-25"        // Magical protection.
+    "ArmorPhysical"                                       "43"        // Physical protection.
+    "MagicalResistance"                                   "-50"        // Magical protection.
 
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_MELEE_ATTACK"
-    "AttackDamageMin"                                     "7910"      // Damage range min.
-    "AttackDamageMax"                                     "7910"      // Damage range max.
+    "AttackDamageMin"                                     "7500"      // Damage range min.
+    "AttackDamageMax"                                     "7500"      // Damage range max.
     "AttackRate"                                          "0.625"     // Speed of attack.
     "AttackAnimationPoint"                                "0.3"       // Normalized time in animation cycle to attack.
-    "AttackAcquisitionRange"                              "800"       // Range within a target can be acquired.
+    "AttackAcquisitionRange"                              "150"       // Range within a target can be acquired.
     "AttackRange"                                         "128"       // Range within a target can be attacked.
-    "ProjectileModel"                                     ""          // Particle system model for projectile.
-    "ProjectileSpeed"                                     "0"         // Speed of projectile.
 
     // Bounty
     //----------------------------------------------------------------
-    "BountyXP"                                            "0"         // Experience earn.
+    "BountyXP"                                            "5000"         // Experience earn.
     "BountyGoldMin"                                       "0"         // Gold earned min.
     "BountyGoldMax"                                       "0"         // Gold earned max.
 
@@ -53,20 +54,19 @@
     //----------------------------------------------------------------
     "MovementCapabilities"                                "DOTA_UNIT_CAP_MOVE_GROUND"      // Type of locomotion - ground, air
     "MovementSpeed"                                       "420"       // Speed
-    "MovementTurnRate"                                    "0.5"       // Turning rate.
+    "MovementTurnRate"                                    "1.0"       // Turning rate.
 
     // Status
     //----------------------------------------------------------------
-    "StatusHealth"                                        "33750"        // Base health.
+    "StatusHealth"                                        "25000"        // Base health.
     "StatusHealthRegen"                                   "0"     // Health regeneration rate.
-    "StatusMana"                                          "0"         // Base mana.
-    "StatusManaRegen"                                     "0"         // Mana regeneration rate.
+    "StatusMana"                                          "10000"         // Base mana.
+    "StatusManaRegen"                                     "5000"         // Mana regeneration rate.
 
     // Creature data
     "Creature"
     {
-      // Makes it only have 50% remaining of applied crowd control
-      "DisableResistance"                                 "50.0"
+      "DisableResistance"                                 "80.0"
     }
 
     // Team
@@ -78,9 +78,14 @@
 
     // Vision
     //----------------------------------------------------------------
-    "VisionDaytimeRange"                                  "1800"      // Range of vision during day light.
-    "VisionNighttimeRange"                                "1800"      // Range of vision at night time.
+    "VisionDaytimeRange"                                  "1400"      // Range of vision during day light.
+    "VisionNighttimeRange"                                "1400"      // Range of vision at night time.
 
+    // Inventory
+    //----------------------------------------------------------------
     "HasInventory"                                        "1"
+
+    "MinimapIcon"                                         "minimap_roshancamp"
+    "MinimapIconSize"                                     "450"
   }
 }

--- a/game/scripts/npc/units/boss/charger/charger_tier5.txt
+++ b/game/scripts/npc/units/boss/charger/charger_tier5.txt
@@ -33,8 +33,8 @@
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_MELEE_ATTACK"
-    "AttackDamageMin"                                     "5000"      // Damage range min.
-    "AttackDamageMax"                                     "5000"      // Damage range max.
+    "AttackDamageMin"                                     "7500"      // Damage range min.
+    "AttackDamageMax"                                     "7500"      // Damage range max.
     "AttackDamageType"                                    "DAMAGE_TYPE_ArmorPhysical"
     "AttackRate"                                          "2.0"           // Speed of attack.
     "AttackAnimationPoint"                                "0.3"       // Normalized time in animation cycle to attack.

--- a/game/scripts/npc/units/boss/cleave_boss_tier5.txt
+++ b/game/scripts/npc/units/boss/cleave_boss_tier5.txt
@@ -70,7 +70,6 @@
     // Creature data
     "Creature"
     {
-      // Makes it only have 50% remaining of applied crowd control
       "DisableResistance"                                 "80.0"
     }
 

--- a/game/scripts/npc/units/boss/lycan_boss/lycan_boss.txt
+++ b/game/scripts/npc/units/boss/lycan_boss/lycan_boss.txt
@@ -45,8 +45,8 @@
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_NO_ATTACK"
-    "AttackDamageMin"                                     "300"
-    "AttackDamageMax"                                     "320"
+    "AttackDamageMin"                                     "3500" // damage of Claw Attack
+    "AttackDamageMax"                                     "3500"
     "AttackRate"                                          "1.45"
     "AttackAnimationPoint"                                "0.55"
     "AttackAcquisitionRange"                              "600"

--- a/game/scripts/npc/units/boss/lycan_boss/lycan_boss_tier5.txt
+++ b/game/scripts/npc/units/boss/lycan_boss/lycan_boss_tier5.txt
@@ -45,8 +45,8 @@
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_NO_ATTACK"
-    "AttackDamageMin"                                     "3000"
-    "AttackDamageMax"                                     "3200"
+    "AttackDamageMin"                                     "10000" // damage of Claw Attack tier 5
+    "AttackDamageMax"                                     "10000"
     "AttackRate"                                          "1.45"
     "AttackAnimationPoint"                                "0.55"
     "AttackAcquisitionRange"                              "600"

--- a/game/scripts/npc/units/boss/skeleton_boss_tier5.txt
+++ b/game/scripts/npc/units/boss/skeleton_boss_tier5.txt
@@ -27,7 +27,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "40"      // Physical protection.
+    "ArmorPhysical"                                       "43"      // Physical protection.
     "MagicalResistance"                                   "-50"     // Magical protection (percentage).
 
     // Attack
@@ -68,8 +68,7 @@
     // Creature data
     "Creature"
     {
-      // Makes it only have 50% remaining of applied crowd control
-      "DisableResistance"                                 "50.0"
+      "DisableResistance"                                 "80.0"
     }
 
     // Team

--- a/game/scripts/npc/units/boss/temple_guardian/temple_guardian.txt
+++ b/game/scripts/npc/units/boss/temple_guardian/temple_guardian.txt
@@ -41,8 +41,8 @@
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_NO_ATTACK"
-    "AttackDamageMin"                                     "7000"
-    "AttackDamageMax"                                     "7000"
+    "AttackDamageMin"                                     "4000" // damage of Hammer Smash
+    "AttackDamageMax"                                     "4000"
     "AttackRate"                                          "2.8"
     "AttackAnimationPoint"                                "0.3"
     "AttackAcquisitionRange"                              "1200"

--- a/game/scripts/npc/units/boss/temple_guardian/temple_guardian_tier5.txt
+++ b/game/scripts/npc/units/boss/temple_guardian/temple_guardian_tier5.txt
@@ -47,8 +47,8 @@
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_NO_ATTACK"
-    "AttackDamageMin"                                     "0"
-    "AttackDamageMax"                                     "1"
+    "AttackDamageMin"                                     "6000" // damage of Hammer Smash tier 5
+    "AttackDamageMax"                                     "6000"
     "AttackRate"                                          "0.9"
     "AttackAnimationPoint"                                "0.3"
     "AttackAcquisitionRange"                              "1500"

--- a/game/scripts/npc/units/boss/twin/twin_tier5.txt
+++ b/game/scripts/npc/units/boss/twin/twin_tier5.txt
@@ -34,7 +34,7 @@
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_MELEE_ATTACK"
     "AttackDamageMin"                                     "5000"    // Damage range min.
-    "AttackDamageMax"                                     "5500"    // Damage range max.
+    "AttackDamageMax"                                     "5000"    // Damage range max.
     "AttackDamageType"                                    "DAMAGE_TYPE_ArmorPhysical"
     "AttackRate"                                          "0.75"      // Speed of attack.
     "AttackAnimationPoint"                                "0.3"    // Normalized time in animation cycle to attack.
@@ -69,7 +69,6 @@
     // Creature data
     //"Creature"
     //{
-      // Makes it only have 50% remaining of applied crowd control
       //"DisableResistance"                                 "80.0"
     //}
 

--- a/game/scripts/vscripts/components/boss/bosses.lua
+++ b/game/scripts/vscripts/components/boss/bosses.lua
@@ -1,3 +1,21 @@
+
+local function shielder_or_no (tier)
+  local is1v1 = GetMapName() == "1v1"
+  if tier == 5 then
+    if is1v1 then
+      return "npc_dota_boss_simple_2_tier5"
+    else
+      return "npc_dota_boss_shielder_tier5"
+    end
+  else
+    if is1v1 then
+      return "npc_dota_boss_twin"
+    else
+      return "npc_dota_boss_shielder"
+    end
+  end
+end
+
 Bosses = {
   -----------------------------
   ---- TIER 1 SAFE BOSS PIT
@@ -12,8 +30,8 @@ Bosses = {
       "npc_dota_boss_twin_tier5",
       "npc_dota_creature_ogre_tank_boss_tier5",
       --"npc_dota_creature_temple_guardian_spawner_tier5",
-      "npc_dota_boss_shielder_tier5",
-      "npc_dota_boss_charger_tier5",
+      shielder_or_no(5),
+      "npc_dota_boss_tier_5", -- Big Bird
     }
   },
   -----------------------------
@@ -27,7 +45,7 @@ Bosses = {
     },
     {
       --"npc_dota_boss_twin",
-      "npc_dota_boss_shielder",
+      shielder_or_no(),
       "npc_dota_boss_simple_2", -- Bear Boss (Fury Swipes)
       "npc_dota_creature_slime_spawner",
       "npc_dota_boss_charger",
@@ -51,7 +69,7 @@ Bosses = {
       "npc_dota_boss_simple_1_tier5", -- Tier 5 Skeleton Boss (Geostrike)
       "npc_dota_boss_simple_5_tier5", -- Tier 5 Dire Creep Boss (Great Cleave)
       "npc_dota_boss_twin_tier5",
-      "npc_dota_boss_shielder_tier5",
+      shielder_or_no(5),
       "npc_dota_boss_simple_2_tier5", -- Tier 5 Bear Boss (Fury Swipes)
       "npc_dota_boss_charger_tier5",
       "npc_dota_creature_ogre_tank_boss_tier5",
@@ -71,7 +89,7 @@ Bosses = {
     },
     {
       --"npc_dota_boss_twin",
-      "npc_dota_boss_shielder",
+      shielder_or_no(),
       "npc_dota_boss_simple_2", -- Fury Swipes
       "npc_dota_creature_slime_spawner",
       "npc_dota_boss_charger",
@@ -95,7 +113,7 @@ Bosses = {
       "npc_dota_boss_simple_1_tier5", -- Geostrike
       "npc_dota_boss_simple_5_tier5", -- Great Cleave
       "npc_dota_boss_twin_tier5",
-      "npc_dota_boss_shielder_tier5",
+      shielder_or_no(5),
       "npc_dota_boss_simple_2_tier5", -- Fury Swipes
       "npc_dota_boss_charger_tier5",
       "npc_dota_creature_ogre_tank_boss_tier5",
@@ -110,7 +128,7 @@ Bosses = {
   {
     {
       --"npc_dota_boss_twin",
-      "npc_dota_boss_shielder",
+      shielder_or_no(),
       "npc_dota_boss_simple_2", -- Fury Swipes
       "npc_dota_creature_slime_spawner",
       "npc_dota_boss_charger",
@@ -134,7 +152,7 @@ Bosses = {
       "npc_dota_boss_simple_1_tier5", -- Geostrike
       "npc_dota_boss_simple_5_tier5", -- Great Cleave
       "npc_dota_boss_twin_tier5",
-      "npc_dota_boss_shielder_tier5",
+      shielder_or_no(5),
       "npc_dota_boss_simple_2_tier5", -- Fury Swipes
       "npc_dota_boss_charger_tier5",
       "npc_dota_creature_ogre_tank_boss_tier5",
@@ -164,7 +182,7 @@ Bosses = {
       "npc_dota_boss_simple_1_tier5", -- Geostrike
       "npc_dota_boss_simple_5_tier5", -- Great Cleave
       "npc_dota_boss_twin_tier5",
-      "npc_dota_boss_shielder_tier5",
+      shielder_or_no(5),
       "npc_dota_boss_simple_2_tier5", -- Fury Swipes
       "npc_dota_boss_charger_tier5",
       "npc_dota_creature_ogre_tank_boss_tier5",


### PR DESCRIPTION
* Lycan Tier 5 boss Claw Attack damage reduced from 25000 to 10000.
* Lycan boss attack damage now matches their Claw Attack damage. (Lycan boss still cant attack when taunted)
* Charger Tier 5 attack damage increased from 5000 to 7500.
* Charger Tier 5 will no longer spawn in base boss pits.
* Skelly Tier 5 armor increased from 40 to 43.
* Skelly Tier 5 disable resistance increased from 50% to 80%.
* Temple Guardian attack damage now matches their Hammer Smash damage. (Temple Guardians still cant attack when taunted)
* Twin (melee) max attack damage reduced from 5500 to 5000.
* Shielder boss will no longer spawn on 1v1 map. Twins or Bear boss will spawn instead.
* New tier 5 boss that can spawn in base boss pits is Big Bird - no unique abilities for now.