### PR TITLE
Some balance

### DIFF
--- a/content/soundevents/units/game_sounds_electrician.vsndevts
+++ b/content/soundevents/units/game_sounds_electrician.vsndevts
@@ -1,0 +1,75 @@
+<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
+{
+	Electrician.PreAttack = {
+		type = "dota_src1_3d"
+		volume = 1.000000
+		pitch_rand_min = -0.050000
+		pitch_rand_max = 0.050000
+		pitch = 1.000000
+		soundlevel = 72.000000
+		distance_max = 1500.000000
+		event_type = 1.000000
+		vsnd_files =
+		[
+			"sounds/weapons/hero/rattletrap/attack01.vsnd",
+			"sounds/weapons/hero/rattletrap/attack02.vsnd",
+		]
+		vsnd_duration = 0.252245
+	}
+
+	Electrician.Attack = {
+		type = "dota_src1_3d"
+		volume = 1.000000
+		pitch_rand_min = -0.050000
+		pitch_rand_max = 0.050000
+		pitch = 1.000000
+		soundlevel = 75.000000
+		distance_max = 2500.000000
+		event_type = 1.000000
+		vsnd_files =
+		[
+			"sounds/weapons/hero/shared/impacts/heavy_blade_impact1.vsnd",
+			"sounds/weapons/hero/shared/impacts/heavy_blade_impact2.vsnd",
+			"sounds/weapons/hero/shared/impacts/heavy_blade_impact3.vsnd",
+		]
+		vsnd_duration = 0.330499
+	}
+
+	Electrician.Footsteps =	{
+		type = "dota_src1_3d_footsteps"
+		volume_rand_min = -0.049988
+		volume_rand_max = 0.049988
+		volume = 0.349792
+		pitch_rand_min = -0.050000
+		pitch_rand_max = 0.050000
+		pitch = 1.000000
+		soundlevel = 72.000000
+		distance_max = 2000.000000
+		event_type = 4.000000
+		vsnd_files =
+		[
+			"sounds/physics/footsteps/hero/shared/general01.vsnd",
+			"sounds/physics/footsteps/hero/shared/general02.vsnd",
+			"sounds/physics/footsteps/hero/shared/general03.vsnd",
+			"sounds/physics/footsteps/hero/shared/general04.vsnd",
+			"sounds/physics/footsteps/hero/shared/general05.vsnd",
+			"sounds/physics/footsteps/hero/shared/general06.vsnd",
+			"sounds/physics/footsteps/hero/shared/general07.vsnd",
+		]
+		vsnd_duration = 0.453787
+	}
+
+	Electrician.Pick = {
+		type = "dota_src1_3d"
+		volume = 1.000000
+		pitch = 1.000000
+		soundlevel = 81.000000
+		distance_max = 2500.000000
+		limiter_on = 0.000000
+		vsnd_files =
+		[
+			"sounds/weapons/hero/storm_spirit/static_remnant_plant.vsnd",
+		]
+		vsnd_duration = 1.322676
+	}
+}

--- a/content/soundevents/units/game_sounds_sohei.vsndevts
+++ b/content/soundevents/units/game_sounds_sohei.vsndevts
@@ -1,5 +1,87 @@
 <!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
 {
+  Sohei.PreAttack = {
+	type = "dota_src1_3d"
+	volume = 1.000000
+	pitch_rand_min = -0.050000
+	pitch_rand_max = 0.050000
+	pitch = 1.100000
+	soundlevel = 75.000000
+	distance_max = 1500.000000
+	event_type = 1.000000
+	vsnd_files =
+	[
+	  "sounds/weapons/hero/shared/large_blade/whoosh01.vsnd",
+	  "sounds/weapons/hero/shared/large_blade/whoosh02.vsnd",
+	  "sounds/weapons/hero/shared/large_blade/whoosh03.vsnd",
+	]
+	vsnd_duration = 0.734172
+  }
+
+  Sohei.Attack = {
+	type = "dota_update_default"
+	vsnd_files =
+	[
+	  "sounds/weapons/hero/earth_spirit/attack01.vsnd",
+	  "sounds/weapons/hero/earth_spirit/attack02.vsnd",
+	  "sounds/weapons/hero/earth_spirit/attack03.vsnd",
+	]
+	volume = "1.000000"
+	pitch_rand_min = "-0.050000"
+	pitch_rand_max = "0.050000"
+	pitch = "1.000000"
+	soundlevel = "81.000000"
+	mixgroup = "BaseAttacks"
+	spread_radius = "150.000000"
+	distance_max = "2500.000000"
+	soundevent_layer2 = "Sohei.Attack.Impact"
+	soundevent_layer2_on = "1.000000"
+	soundevent_layer3 = "Damage_Melee.Gore"
+	soundevent_layer3_on = "1.000000"
+  }
+
+  Sohei.Attack.Impact = {
+	type = "dota_update_default"
+	vsnd_files =
+	[
+	  "sounds/weapons/hero/shared/large_blade/follow_thru01.vsnd",
+	  "sounds/weapons/hero/shared/large_blade/follow_thru02.vsnd",
+	  "sounds/weapons/hero/shared/large_blade/follow_thru03.vsnd",
+	]
+	volume_rand_min = "-0.049988"
+	volume_rand_max = "0.049988"
+	volume = "0.549988"
+	pitch_rand_min = "-0.050000"
+	pitch_rand_max = "0.050000"
+	pitch = "1.000000"
+	soundlevel = "75.000000"
+	mixgroup = "BaseAttacks"
+	spread_radius = "150.000000"
+  }
+
+  Sohei.Footsteps = {
+	type = "dota_src1_3d_footsteps"
+	vsnd_files =
+	[
+	  "sounds/physics/footsteps/hero/shared/general01.vsnd",
+	  "sounds/physics/footsteps/hero/shared/general02.vsnd",
+	  "sounds/physics/footsteps/hero/shared/general03.vsnd",
+	  "sounds/physics/footsteps/hero/shared/general04.vsnd",
+	  "sounds/physics/footsteps/hero/shared/general05.vsnd",
+	  "sounds/physics/footsteps/hero/shared/general06.vsnd",
+	  "sounds/physics/footsteps/hero/shared/general07.vsnd",
+	]
+	volume_rand_min = "-0.099976"
+	volume_rand_max = "0.099976"
+	volume = "1.000000"
+	pitch_rand_min = "-0.050000"
+	pitch_rand_max = "0.050000"
+	pitch = "1.000000"
+	soundlevel = "72.000000"
+	distance_max = "2000.000000"
+	event_type = "4.000000"
+  }
+
   Sohei.Dash = {
     type = "dota_src1_3d"
     vsnd_files =
@@ -110,98 +192,33 @@
     mixgroup = "Weapons"
   }
 
-  Sohei.Footsteps = {
-		type = "dota_src1_3d_footsteps"
-		vsnd_files =
-		[
-			"sounds/physics/footsteps/hero/shared/general01.vsnd",
-			"sounds/physics/footsteps/hero/shared/general02.vsnd",
-			"sounds/physics/footsteps/hero/shared/general03.vsnd",
-			"sounds/physics/footsteps/hero/shared/general04.vsnd",
-			"sounds/physics/footsteps/hero/shared/general05.vsnd",
-			"sounds/physics/footsteps/hero/shared/general06.vsnd",
-			"sounds/physics/footsteps/hero/shared/general07.vsnd",
-		]
-		volume_rand_min = "-0.099976"
-		volume_rand_max = "0.099976"
-		volume = "1.000000"
-		pitch_rand_min = "-0.050000"
-		pitch_rand_max = "0.050000"
-		pitch = "1.000000"
-		soundlevel = "72.000000"
-		distance_max = "2000.000000"
-		event_type = "4.000000"
-	}
-
-  Sohei.Attack = {
-    type = "dota_update_default"
-    vsnd_files =
-    [
-      "sounds/weapons/hero/earth_spirit/attack01.vsnd",
-      "sounds/weapons/hero/earth_spirit/attack02.vsnd",
-      "sounds/weapons/hero/earth_spirit/attack03.vsnd",
-    ]
-    volume = "1.000000"
-    pitch_rand_min = "-0.050000"
-    pitch_rand_max = "0.050000"
-    pitch = "1.000000"
-    soundlevel = "81.000000"
-    mixgroup = "BaseAttacks"
-    spread_radius = "150.000000"
-    distance_max = "2500.000000"
-    soundevent_layer2 = "Sohei.Attack.Impact"
-    soundevent_layer2_on = "1.000000"
-    soundevent_layer3 = "Damage_Melee.Gore"
-    soundevent_layer3_on = "1.000000"
-  }
-
-  Sohei.Attack.Impact = {
-    type = "dota_update_default"
-		vsnd_files =
-		[
-			"sounds/weapons/hero/shared/large_blade/follow_thru01.vsnd",
-			"sounds/weapons/hero/shared/large_blade/follow_thru02.vsnd",
-			"sounds/weapons/hero/shared/large_blade/follow_thru03.vsnd",
-		]
-		volume_rand_min = "-0.049988"
-		volume_rand_max = "0.049988"
-		volume = "0.549988"
-		pitch_rand_min = "-0.050000"
-		pitch_rand_max = "0.050000"
-		pitch = "1.000000"
-		soundlevel = "75.000000"
-		mixgroup = "BaseAttacks"
-		spread_radius = "150.000000"
-  }
-
   Sohei.PalmOfLife.Heal = {
-		type = "dota_update_default"
-		vsnd_files =
-		[
-			"sounds/weapons/hero/omniknight/purification.vsnd",
-		]
-		volume = "1.000000"
-		pitch_rand_min = "-0.050000"
-		pitch_rand_max = "0.050000"
-		pitch = "1.000000"
-		soundlevel = "81.000000"
-		mixgroup = "Weapons"
-		spread_radius = "300.000000"
-	}
+	type = "dota_update_default"
+	vsnd_files =
+	[
+	  "sounds/weapons/hero/omniknight/purification.vsnd",
+	]
+	volume = "1.000000"
+	pitch_rand_min = "-0.050000"
+	pitch_rand_max = "0.050000"
+	pitch = "1.000000"
+	soundlevel = "81.000000"
+	mixgroup = "Weapons"
+	spread_radius = "300.000000"
+  }
 
-  Sohei.QuiveringPalm =
-	{
-		type = "dota_update_default"
-		vsnd_files =
-		[
-			"sounds/weapons/hero/doom_bringer/lvl_death.vsnd",
-		]
-		volume = "1.000000"
-		pitch_rand_min = "-0.050000"
-		pitch_rand_max = "0.050000"
-		pitch = "1.000000"
-		soundlevel = "81.000000"
-		mixgroup = "Weapons"
-		spread_radius = "300.000000"
-	}
+  Sohei.QuiveringPalm = {
+	type = "dota_update_default"
+	vsnd_files =
+	[
+	  "sounds/weapons/hero/doom_bringer/lvl_death.vsnd",
+	]
+	volume = "1.000000"
+	pitch_rand_min = "-0.050000"
+	pitch_rand_max = "0.050000"
+	pitch = "1.000000"
+	soundlevel = "81.000000"
+	mixgroup = "Weapons"
+	spread_radius = "300.000000"
+  }
 }

--- a/game/resource/English/ability/units/tooltip_broodmother_incapacitating_bite_oaa.txt
+++ b/game/resource/English/ability/units/tooltip_broodmother_incapacitating_bite_oaa.txt
@@ -7,12 +7,12 @@
 // "DOTA_Tooltip_ability_broodmother_incapacitating_bite_duration"                "DURATION:"
 
 "DOTA_Tooltip_ability_broodmother_incapacitating_bite_oaa"                      "Paralyzing Spit"
-"DOTA_Tooltip_ability_broodmother_incapacitating_bite_oaa_Description"          "Broodmother's venom paralyzes enemy units, applying max hp damage, root and disarm while disabling evasion, damage block and turning."
+"DOTA_Tooltip_ability_broodmother_incapacitating_bite_oaa_Description"          "Broodmother's venom paralyzes enemy units, applying max hp damage, root and disarm while disabling evasion and damage block."
 "DOTA_Tooltip_ability_broodmother_incapacitating_bite_oaa_Lore"                 "#{DOTA_Tooltip_ability_broodmother_incapacitating_bite_Lore}"
-"DOTA_Tooltip_ability_broodmother_incapacitating_bite_oaa_Note0"                "Enemies under the debuff will have issues casting spells that require facing because they cannot turn to cast."
+//"DOTA_Tooltip_ability_broodmother_incapacitating_bite_oaa_Note0"                "Enemies under the debuff will have issues casting spells that require facing because they cannot turn to cast."
 "DOTA_Tooltip_ability_broodmother_incapacitating_bite_oaa_base_damage"          "BASE DAMAGE:"
 "DOTA_Tooltip_ability_broodmother_incapacitating_bite_oaa_max_hp_percent_dmg"   "%MAX HP DAMAGE:"
 "DOTA_Tooltip_ability_broodmother_incapacitating_bite_oaa_duration"             "DURATION:"
 
 "DOTA_Tooltip_modifier_broodmother_incapacitating_bite_debuff_oaa"              "Paralyzed"
-"DOTA_Tooltip_modifier_broodmother_incapacitating_bite_debuff_oaa_Description"  "Rooted, disarmed, disabled evasion, disabled damage block and disabled turning."
+"DOTA_Tooltip_modifier_broodmother_incapacitating_bite_debuff_oaa_Description"  "Rooted, disarmed, disabled evasion and disabled damage block."

--- a/game/resource/English/npc/tooltip_tinkerer.txt
+++ b/game/resource/English/npc/tooltip_tinkerer.txt
@@ -77,8 +77,9 @@
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_initial_damage"                "INITIAL LASER DAMAGE:"
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_damage_per_second"             "MAX DAMAGE PER SECOND:"
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_attacks_to_destroy"            "ATTACKS REQUIRED:"
-"DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_description"           "Increases cast range. Trapped enemies are leashed and have reduced healing/regen/lifesteal by %scepter_heal_prevent_percent%%%. Leash and healing reduction pierce spell immunity."
+"DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_description"           "Increases cast range. Trapped enemies are leashed and have reduced healing/regen/lifesteal by %scepter_heal_prevent_percent%%%."
 "DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_cast_range"            "SCEPTER CAST RANGE:"
+"DOTA_Tooltip_ability_tinkerer_laser_contraption_scepter_heal_prevent_percent"  "%SCEPTER HEAL REDUCTION:"
 
 // modifiers
 // "DOTA_Tooltip_modifier_tinker_laser_blind"                                     "Laser Blind"

--- a/game/scripts/npc/abilities/rubick_spell_steal.txt
+++ b/game/scripts/npc/abilities/rubick_spell_steal.txt
@@ -43,7 +43,7 @@
       "01"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "duration"                                        "9999.0" //OAA
+        "duration"                                        "300" //OAA
       }
       "02"
       {

--- a/game/scripts/npc/abilities/shadow_demon_demonic_cleanse.txt
+++ b/game/scripts/npc/abilities/shadow_demon_demonic_cleanse.txt
@@ -12,8 +12,8 @@
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
     "AbilityUnitTargetTeam"                               "DOTA_UNIT_TARGET_TEAM_FRIENDLY"
     "AbilityUnitTargetType"                               "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
-    "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_INVULNERABLE" //OAA, Valve has it wrong
-    "SpellImmunityType"                                   "SPELL_IMMUNITY_ALLIES_YES" //OAA, Valve has it wrong
+    "AbilityUnitTargetFlags"                              "DOTA_UNIT_TARGET_FLAG_INVULNERABLE" //OAA, Valve has it wrong, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES is not needed
+    "SpellImmunityType"                                   "SPELL_IMMUNITY_ALLIES_YES" //OAA, Valve has it wrong (SPELL_IMMUNITY_ENEMIES_YES)
     "SpellDispellableType"                                "SPELL_DISPELLABLE_NO"
 
     "MaxLevel"                                            "5"

--- a/game/scripts/npc/abilities/sohei_flurry_of_blows_oaa.txt
+++ b/game/scripts/npc/abilities/sohei_flurry_of_blows_oaa.txt
@@ -66,7 +66,7 @@
       "attack_interval"                                   "0.3"
       "bonus_damage"
       {
-        "value"                                           "20 25 30 60 120"
+        "value"                                           "50 50 50 100 150"
         "CalculateSpellDamageTooltip"                     "0"
         "DamageTypeTooltip"                               "DAMAGE_TYPE_MAGICAL"
       }

--- a/game/scripts/npc/abilities/talents/tinkerer_talent3_oaa.txt
+++ b/game/scripts/npc/abilities/talents/tinkerer_talent3_oaa.txt
@@ -19,7 +19,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "explode_radius"                                  "400"
+        "explode_radius"                                  "350"
       }
     }
   }

--- a/game/scripts/npc/abilities/talents/tinkerer_talent5_oaa.txt
+++ b/game/scripts/npc/abilities/talents/tinkerer_talent5_oaa.txt
@@ -24,7 +24,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "value2"                                          "10"
+        "value2"                                          "5"
       }
     }
   }

--- a/game/scripts/npc/abilities/techies_sticky_bomb.txt
+++ b/game/scripts/npc/abilities/techies_sticky_bomb.txt
@@ -60,6 +60,7 @@
       "speed"                                             "500.0"
       "acceleration"                                      "2000"
       "pre_chase_time"                                    "0.1"
+      "max_chase_time"                                    "4"
     }
   }
 }

--- a/game/scripts/npc/abilities/tinker_defense_matrix.txt
+++ b/game/scripts/npc/abilities/tinker_defense_matrix.txt
@@ -26,7 +26,7 @@
 
     // Time
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "12"
+    "AbilityCooldown"                                     "15" //OAA
 
     // Cost
     //-------------------------------------------------------------------------------------------------------------
@@ -42,7 +42,7 @@
         "special_bonus_unique_tinker_7"                   "+150"
       }
       "status_resistance"                                 "10 20 30 40 50 60"
-      "barrier_duration"                                  "15"
+      "barrier_duration"                                  "15" // original: 20
       "cooldown_reduction" //OAA
       {
         "value"                                           "0"

--- a/game/scripts/npc/abilities/tinkerer_laser_contraption.txt
+++ b/game/scripts/npc/abilities/tinkerer_laser_contraption.txt
@@ -46,7 +46,7 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "radius"                                            "300" // original: 800 x 100
+      "radius"                                            "350" // original: 800 x 100
       "duration"                                          "8.55"
       "delay"                                             "0.5"
       "initial_damage"
@@ -64,7 +64,7 @@
       }
       "scepter_heal_prevent_percent"
       {
-        "value"                                           "-25"
+        "value"                                           "-20 -25 -30 -35 -40"
         "RequiresScepter"                                 "1"
       }
     }

--- a/game/scripts/npc/abilities/tinkerer_oil_spill.txt
+++ b/game/scripts/npc/abilities/tinkerer_oil_spill.txt
@@ -24,7 +24,7 @@
 
     // Casting
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCastRange"                                    "800"
+    "AbilityCastRange"                                    "700"
     "AbilityCastPoint"                                    "0"
     "AbilityCastAnimation"                                "ACT_DOTA_CAST_ABILITY_3"
 
@@ -64,8 +64,8 @@
       }
       "attack_speed_slow"
       {
-        "value"                                           "10 20 30 40 45 50" // percentage attack speed slow; original: 10/20/30/40%
-        "special_bonus_unique_tinkerer_5"                 "+10"
+        "value"                                           "10 20 30 40 50 60" // percentage attack speed slow; original: 10/20/30/40%
+        "special_bonus_unique_tinkerer_5"                 "+5"
       }
       "burn_dps"
       {

--- a/game/scripts/npc/abilities/tinkerer_smart_missiles.txt
+++ b/game/scripts/npc/abilities/tinkerer_smart_missiles.txt
@@ -59,7 +59,7 @@
       "rocket_range"                                      "3000"
       "rocket_vision"                                     "400"
       "bonus_max_hp_damage"                               "7"
-      "bonus_damage_range"                                "1500"
+      "bonus_damage_range"                                "1800"
       "stun_duration"                                     "0.1"
       "rocket_explode_vision"                             "400"
       "vision_duration"                                   "1.5"

--- a/game/scripts/npc/heroes/chatterjee.txt
+++ b/game/scripts/npc/heroes/chatterjee.txt
@@ -96,8 +96,9 @@
       "model"                                             "models/heroes/electrician/electrician_arcana/electrician_arcana_base.vmdl"
     }
     "particle_folder"                                     "particles/hero/electrician"
-    //"GameSoundsFile"            "soundevents/game_sounds_heroes/game_sounds_electrician.vsndevts"
-    //"SoundSet"                  "Hero_Electrician"
-    //"VoiceFile"                 "soundevents/voscripts/game_sounds_vo_electrician.vsndevts"
+    "GameSoundsFile"                                      "soundevents/units/game_sounds_electrician.vsndevts"
+    "SoundSet"                                            "Electrician"
+    //"VoiceFile"                                           "soundevents/units/game_sounds_vo_electrician.vsndevts"
+    "HeroSelectSoundEffect"                               "Electrician.Pick"
   }
 }

--- a/game/scripts/vscripts/abilities/oaa_broodmother_incapacitating_bite.lua
+++ b/game/scripts/vscripts/abilities/oaa_broodmother_incapacitating_bite.lua
@@ -100,15 +100,15 @@ function modifier_broodmother_incapacitating_bite_debuff_oaa:IsPurgable()
   return true
 end
 
-function modifier_broodmother_incapacitating_bite_debuff_oaa:DeclareFunctions()
-  return {
-    MODIFIER_PROPERTY_DISABLE_TURNING,
-  }
-end
+-- function modifier_broodmother_incapacitating_bite_debuff_oaa:DeclareFunctions()
+  -- return {
+    -- MODIFIER_PROPERTY_DISABLE_TURNING,
+  -- }
+-- end
 
-function modifier_broodmother_incapacitating_bite_debuff_oaa:GetModifierDisableTurning()
-  return 1
-end
+-- function modifier_broodmother_incapacitating_bite_debuff_oaa:GetModifierDisableTurning()
+  -- return 1
+-- end
 
 function modifier_broodmother_incapacitating_bite_debuff_oaa:CheckState()
   return {

--- a/game/scripts/vscripts/abilities/tinkerer/tinkerer_laser_contraption.lua
+++ b/game/scripts/vscripts/abilities/tinkerer/tinkerer_laser_contraption.lua
@@ -234,9 +234,9 @@ function modifier_tinkerer_laser_contraption_thinker:GetAuraSearchType()
   return bit.bor(DOTA_UNIT_TARGET_HERO, DOTA_UNIT_TARGET_BASIC)
 end
 
-function modifier_tinkerer_laser_contraption_thinker:GetAuraSearchFlags()
-  return DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES
-end
+--function modifier_tinkerer_laser_contraption_thinker:GetAuraSearchFlags()
+  --return DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES
+--end
 
 function modifier_tinkerer_laser_contraption_thinker:OnCreated(kv)
   if not IsServer() then

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.20.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
-      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
+      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -1390,7 +1390,7 @@
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -1399,7 +1399,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
           "dev": true
         }
       }
@@ -2367,7 +2367,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "dev": true
     },
     "request": {
@@ -2449,7 +2449,7 @@
     "resumer": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-      "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
         "through": "~2.3.4"


### PR DESCRIPTION
* https://steamdb.info/patchnotes/10202751/
* Broodmother Paralyzing Spit no longer disables turning.
* Rubick Spell Steal stolen spell duration reduced from 9999 to 300 seconds.
* Tinkerer Smart Missiles max hp dmg range increased from 1500 to 1800. (nerf)
* Tinkerer Tar Spill cast range reduced from 800 to 700. (nerf)
* Tinkerer Tar Spill attack speed slow improved at OAA levels from 45/50% to 50/60%. (buff)
* Tinkerer Defense Matrix cooldown increased from 12 to 15 seconds. (nerf)
* Tinkerer Laser Contraption radius increased from 300 to 350. (buff, but also should be easier to get out)
* Tinkerer Laser Contraption scepter effects no longer pierce spell immunity. (nerf)
* Tinkerer Laser Contraption scepter heal reduction increased from 25% to 20/25/30/35/40%. (buff)
* Tinkerer Level 10 Talent Attack speed slow reduced from +10% to +5%. (nerf)
* Tinkerer Level 20 Talent +400 Smart Missiles AoE reduced to +350. (nerf)
* Added some basic sounds for Chatterjee
* Added pre-attack sound for Sohei
* Sohei Flurry of Blows bonus damage increased from 20/25/30/60/120 to 50/50/50/100/150.