### PR TITLE
Big Big Patch

### DIFF
--- a/game/scripts/npc/abilities/abaddon_aphotic_shield.txt
+++ b/game/scripts/npc/abilities/abaddon_aphotic_shield.txt
@@ -39,10 +39,10 @@
     {
       "duration"                                          "15.0"
       "radius"                                            "675"
-      "damage_absorb"
+      "damage_absorb" //OAA
       {
         "value"                                           "110 140 170 200 400 600"
-        "special_bonus_unique_abaddon"                    "+100"
+        "special_bonus_unique_abaddon"                    "+200"
         "DamageTypeTooltip"                               "DAMAGE_TYPE_NONE"
       }
     }

--- a/game/scripts/npc/abilities/abyssal_underlord_pit_of_malice.txt
+++ b/game/scripts/npc/abilities/abyssal_underlord_pit_of_malice.txt
@@ -9,7 +9,6 @@
     //-------------------------------------------------------------------------------------------------------------
     "ID"                                                  "5614"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
-    "AbilityUnitDamageType"                               "DAMAGE_TYPE_MAGICAL"
     "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_NO"
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 

--- a/game/scripts/npc/abilities/beastmaster_boar_poison.txt
+++ b/game/scripts/npc/abilities/beastmaster_boar_poison.txt
@@ -9,7 +9,6 @@
     //-------------------------------------------------------------------------------------------------------------
     "ID"                                                  "5171"
     "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE"
-    "AbilityUnitDamageType"                               "DAMAGE_TYPE_MAGICAL"
     "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_NO"
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 

--- a/game/scripts/npc/abilities/marci_companion_run.txt
+++ b/game/scripts/npc/abilities/marci_companion_run.txt
@@ -22,7 +22,7 @@
     // Casting
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCastPoint"                                    "0.1"
-    "AbilityCastRange"                                    "450 550 650 750 800 850"
+    "AbilityCastRange"                                    "800" //OAA
     "AbilityCastAnimation"                                "ACT_DOTA_CAST_ABILITY_2"
 
     // Cost
@@ -38,7 +38,7 @@
         "value"                                           "15 14 13 12 11 10"
         "special_bonus_unique_marci_lunge_cooldown"       "-3"
       }
-      "move_speed"                                        "1700"
+      "move_speed"                                        "2000" //OAA
       "min_jump_distance"                                 "450"
       "max_jump_distance" //OAA
       {

--- a/game/scripts/npc/abilities/marci_companion_run.txt
+++ b/game/scripts/npc/abilities/marci_companion_run.txt
@@ -40,9 +40,9 @@
       }
       "move_speed"                                        "1700"
       "min_jump_distance"                                 "450"
-      "max_jump_distance"
+      "max_jump_distance" //OAA
       {
-        "value"                                           "450 550 650 750 800 850"
+        "value"                                           "800"
         "LinkedSpecialBonus"                              "special_bonus_unique_marci_lunge_range"
       }
       "landing_radius"                                    "275"

--- a/game/scripts/npc/abilities/marci_guardian.txt
+++ b/game/scripts/npc/abilities/marci_guardian.txt
@@ -45,7 +45,7 @@
       "02"
       {
         "var_type"                                        "FIELD_FLOAT"
-        "lifesteal_pct"                                   "25 30 35 40 45 50" //OAA
+        "lifesteal_pct"                                   "20 25 30 35 40 45" //OAA
         "LinkedSpecialBonus"                              "special_bonus_unique_marci_guardian_lifesteal"
       }
       "03"

--- a/game/scripts/npc/abilities/tiny_tree_channel.txt
+++ b/game/scripts/npc/abilities/tiny_tree_channel.txt
@@ -17,7 +17,7 @@
     // Casting
     //-------------------------------------------------------------------------------------------------------------
     "AbilityChannelTime"                                  "2.4"
-    "AbilityCastRange"                                    "1200"
+    "AbilityCastRange"                                    "1000" //OAA
     "AbilityCastPoint"                                    "0.2"
     "AbilityCastAnimation"                                "ACT_DOTA_CAST_ABILITY_4"
     "AbilityChannelAnimation"                             "ACT_DOTA_CAST_ABILITY_4"
@@ -43,7 +43,7 @@
       "02"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "range"                                           "1200"
+        "range"                                           "1000" //OAA
         "RequiresScepter"                                 "1"
       }
       "03"

--- a/game/scripts/npc/items/item_helm_of_the_overlord.txt
+++ b/game/scripts/npc/items/item_helm_of_the_overlord.txt
@@ -67,13 +67,13 @@
       "bonus_stats"                                       "6 10 15 20 25" //OAA
       "bonus_armor"                                       "6 7 8 9 10" //OAA
       "bonus_regen"                                       "6 9 12 15 18" //OAA
-      "health_min"                                        "1800 2800 4800 7800 11800"
+      "health_min"                                        "2000 4500 7000 9500 12000" //OAA
       "speed_base"                                        "400"
       "bounty_gold"                                       "250 500 750 1000 1250"
       "creep_bonus_damage"                                "50 100 150 200 250" //OAA
       "creep_bonus_hp_regen"                              "12 15 18 21 24"
       "creep_bonus_mp_regen"                              "4"
-      "creep_bonus_armor"                                 "6 7 8 9 10" //OAA
+      "creep_bonus_armor"                                 "6 8 10 12 14" //OAA
       "model_scale"                                       "20 30 40 50 60"
       "count_limit"                                       "1"
       "armor_aura"                                        "3.0 4.0 6.0 9.0 13.0"

--- a/game/scripts/npc/items/item_helm_of_the_overlord_2.txt
+++ b/game/scripts/npc/items/item_helm_of_the_overlord_2.txt
@@ -15,7 +15,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCorePointCost"                                   "0"
-    "ItemCost"                                            "1500"
+    "ItemCost"                                            "2000"
     "ItemShopTags"                                        ""
 
     // Recipe
@@ -53,7 +53,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "7676"
+    "ItemCost"                                            "8176"
     "ItemShopTags"                                        "damage;armor;unique;hard_to_tag"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "hoto 2;helm of the overlord 2;helm 2;overlord 2"
@@ -69,13 +69,13 @@
       "bonus_stats"                                       "6 10 15 20 25" //OAA
       "bonus_armor"                                       "6 7 8 9 10" //OAA
       "bonus_regen"                                       "6 9 12 15 18" //OAA
-      "health_min"                                        "1800 2800 4800 7800 11800"
+      "health_min"                                        "2000 4500 7000 9500 12000"
       "speed_base"                                        "400"
       "bounty_gold"                                       "250 500 750 1000 1250"
       "creep_bonus_damage"                                "50 100 150 200 250" //OAA
       "creep_bonus_hp_regen"                              "12 15 18 21 24"
       "creep_bonus_mp_regen"                              "4"
-      "creep_bonus_armor"                                 "6 7 8 9 10" //OAA
+      "creep_bonus_armor"                                 "6 8 10 12 14" //OAA
       "model_scale"                                       "20 30 40 50 60"
       "count_limit"                                       "1"
       "armor_aura"                                        "3.0 4.0 6.0 9.0 13.0"

--- a/game/scripts/npc/items/item_helm_of_the_overlord_3.txt
+++ b/game/scripts/npc/items/item_helm_of_the_overlord_3.txt
@@ -53,7 +53,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "11177"
+    "ItemCost"                                            "11677"
     "ItemShopTags"                                        "damage;armor;unique;hard_to_tag"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "hoto 3;helm of the overlord 3;helm 3;overlord 3"
@@ -69,13 +69,13 @@
       "bonus_stats"                                       "6 10 15 20 25" //OAA
       "bonus_armor"                                       "6 7 8 9 10" //OAA
       "bonus_regen"                                       "6 9 12 15 18" //OAA
-      "health_min"                                        "1800 2800 4800 7800 11800"
+      "health_min"                                        "2000 4500 7000 9500 12000"
       "speed_base"                                        "400"
       "bounty_gold"                                       "250 500 750 1000 1250"
       "creep_bonus_damage"                                "50 100 150 200 250" //OAA
       "creep_bonus_hp_regen"                              "12 15 18 21 24"
       "creep_bonus_mp_regen"                              "4"
-      "creep_bonus_armor"                                 "6 7 8 9 10" //OAA
+      "creep_bonus_armor"                                 "6 8 10 12 14" //OAA
       "model_scale"                                       "20 30 40 50 60"
       "count_limit"                                       "1"
       "armor_aura"                                        "3.0 4.0 6.0 9.0 13.0"

--- a/game/scripts/npc/items/item_helm_of_the_overlord_4.txt
+++ b/game/scripts/npc/items/item_helm_of_the_overlord_4.txt
@@ -53,7 +53,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "19178"
+    "ItemCost"                                            "19678"
     "ItemShopTags"                                        "damage;armor;unique;hard_to_tag"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "hoto 4;helm of the overlord 4;helm 4;overlord 4"
@@ -69,13 +69,13 @@
       "bonus_stats"                                       "6 10 15 20 25" //OAA
       "bonus_armor"                                       "6 7 8 9 10" //OAA
       "bonus_regen"                                       "6 9 12 15 18" //OAA
-      "health_min"                                        "1800 2800 4800 7800 11800"
+      "health_min"                                        "2000 4500 7000 9500 12000"
       "speed_base"                                        "400"
       "bounty_gold"                                       "250 500 750 1000 1250"
       "creep_bonus_damage"                                "50 100 150 200 250" //OAA
       "creep_bonus_hp_regen"                              "12 15 18 21 24"
       "creep_bonus_mp_regen"                              "4"
-      "creep_bonus_armor"                                 "6 7 8 9 10" //OAA
+      "creep_bonus_armor"                                 "6 8 10 12 14" //OAA
       "model_scale"                                       "20 30 40 50 60"
       "count_limit"                                       "1"
       "armor_aura"                                        "3.0 4.0 6.0 9.0 13.0"

--- a/game/scripts/npc/items/item_helm_of_the_overlord_5.txt
+++ b/game/scripts/npc/items/item_helm_of_the_overlord_5.txt
@@ -53,7 +53,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "36179"
+    "ItemCost"                                            "36679"
     "ItemShopTags"                                        "damage;armor;unique;hard_to_tag"
     "ItemQuality"                                         "artifact"
     "ItemAliases"                                         "hoto 5;helm of the overlord 5;helm 5;overlord 5"
@@ -69,13 +69,13 @@
       "bonus_stats"                                       "6 10 15 20 25" //OAA
       "bonus_armor"                                       "6 7 8 9 10" //OAA
       "bonus_regen"                                       "6 9 12 15 18" //OAA
-      "health_min"                                        "1800 2800 4800 7800 11800"
+      "health_min"                                        "2000 4500 7000 9500 12000"
       "speed_base"                                        "400"
       "bounty_gold"                                       "250 500 750 1000 1250"
       "creep_bonus_damage"                                "50 100 150 200 250" //OAA
       "creep_bonus_hp_regen"                              "12 15 18 21 24"
       "creep_bonus_mp_regen"                              "4"
-      "creep_bonus_armor"                                 "6 7 8 9 10" //OAA
+      "creep_bonus_armor"                                 "6 8 10 12 14" //OAA
       "model_scale"                                       "20 30 40 50 60"
       "count_limit"                                       "1"
       "armor_aura"                                        "3.0 4.0 6.0 9.0 13.0"


### PR DESCRIPTION
Gonna be useless once 8.00 comes out in 30 minutes

- abadddon gets 100 more damage block on the talent next to the good one (-8s ult cd) bc i didn't actually want to buff aphotic shield
- valve changes to make green
- helm of the overlord so imba now (way more hp at level 2 onwards, slightly more armor, slightly more expensive to upgrade to level 2) still no one will buy it. might need to buff midas to compensate
- revert marci jump to prenerf but nerf guardian lifesteal again bc why not 