### PR TITLE
Modifier February update

### DIFF
--- a/game/resource/English/panorama/game_options.txt
+++ b/game/resource/English/panorama/game_options.txt
@@ -73,7 +73,7 @@
 "game_option_explosive_death_description"                                       "Explodes on death, knocking back and dealing damage to enemies in the vicinity."
 "game_option_no_hp_bar_description"                                             "Health Bar above your hero isn't visible to other players. You cannot see if the hero is full health or near death."
 "game_option_agressive_bosses_description"                                      "Bosses cannot regen, heal or lifesteal. Bosses will never deaggro once aggroed unless they are too far away from the initial aggro location. Bosses with phases never become weaker."
-"game_option_brute_description"                                                 "Grants 1 strength per hero level and 0.08 attack damage per point of HP." // Changes primary attribute to Strength if non-strength hero. Changes primary attribute randomly otherwise.
+"game_option_brute_description"                                                 "Grants 1 strength per hero level and 0.05 attack damage per point of HP." // Changes primary attribute to Strength if non-strength hero. Changes primary attribute randomly otherwise.
 "game_option_wisdom_description"                                                "Grants 1 intelligence per hero level and 0.008% spell amplification per point of mana." // Changes primary attribute to Intelligence if non-intelligence hero. Changes primary attribute randomly otherwise.
 "game_option_aghanim_description"                                               "Heroes start with consumed Aghanim Scepter and Aghanim Shard."
 "game_option_nimble_description"                                                "Grants 1 agility per hero level, and for each point in agility grants 0.08% movement speed and 0.05% evasion. Removes max move speed and max attack speed limits." // Changes primary attribute to Agility if non-agility hero.
@@ -84,7 +84,7 @@
 "game_option_brawler_description"                                               "When attacked you gain bonus attack speed, move speed and attack damage."
 "game_option_chaos_description"                                                 "Every hero has a different modifier. Modifier will change on respawn."
 "game_option_double_multiplier_description"                                     "Every ability number is multiplied by 2 with a few exceptions."
-"game_option_hybrid_description"                                                "Every time you attack you gain bonus spell amp, every time you cast a spell you gain bonus attack damage."
+"game_option_hybrid_description"                                                "Every time you attack you gain bonus spell amp, every time you cast a spell you gain bonus attack damage. Bonus attack damage is equal to spell cooldown."
 
 "game_option_lifesteal_global_description"                                      "All creeps and heroes gain 75% lifesteal and spell lifesteal against heroes. 25% against creeps and illusions."
 "game_option_buyback_description"                                               "#{game_option_buyback}"
@@ -132,7 +132,7 @@
 "DOTA_Tooltip_modifier_boss_aggresive_oaa"                                      "#{game_option_agressive_bosses}"
 "DOTA_Tooltip_modifier_boss_aggresive_oaa_Description"                          "This boss cannot regen, heal or lifesteal. It will never deaggro once aggroed unless it is too far away from the initial aggro location. If this boss has phases, phase number will never go down."
 "DOTA_Tooltip_modifier_brute_oaa"                                               "#{game_option_brute}"
-"DOTA_Tooltip_modifier_brute_oaa_Description"                                   "Grants 1 STR per hero level and 0.08 damage per point of HP." // Changes primary attribute to STR if non-STR hero. Changes primary attribute randomly otherwise.
+"DOTA_Tooltip_modifier_brute_oaa_Description"                                   "Grants 1 STR per hero level and 0.05 damage per point of HP." // Changes primary attribute to STR if non-STR hero. Changes primary attribute randomly otherwise.
 "DOTA_Tooltip_modifier_wisdom_oaa"                                              "#{game_option_wisdom}"
 "DOTA_Tooltip_modifier_wisdom_oaa_Description"                                  "Grants 1 INT per hero level and 0.008%% spell amp per point of mana." // Changes primary attribute to INT if non-INT hero. Changes primary attribute randomly otherwise.
 "DOTA_Tooltip_modifier_aghanim_oaa"                                             "#{game_option_aghanim}"
@@ -158,7 +158,7 @@
 "DOTA_Tooltip_modifier_bonus_armor_negative_magic_resist_oaa"                   "Guardian's Weakness"
 "DOTA_Tooltip_modifier_bonus_armor_negative_magic_resist_oaa_Description"       "+200 Armor, -200%% magic resistance"
 "DOTA_Tooltip_modifier_cursed_attack_oaa"                                       "Cursed Attack"
-"DOTA_Tooltip_modifier_cursed_attack_oaa_Description"                           "You have no agility, all your attacks are missing 50%% of the time, +350 pure damage when they hit."
+"DOTA_Tooltip_modifier_cursed_attack_oaa_Description"                           "You have no agility, -125 attack damage and 50%% chance to do 350 extra pure damage on attack."
 "DOTA_Tooltip_modifier_no_brain_oaa"                                            "No Brain"
 "DOTA_Tooltip_modifier_no_brain_oaa_Description"                                "You have no intelligence, +350 attack speed."
 "DOTA_Tooltip_modifier_courier_kill_bonus_oaa"                                  "Courier Hunter"
@@ -181,6 +181,8 @@
 "DOTA_Tooltip_modifier_titan_soul_oaa"                                          "Titan's Soul"
 "DOTA_Tooltip_modifier_titan_soul_oaa_Description"                              "You are bigger, you have free-Pathing and every second you deal damage to enemies within 180 radius. Damage is 1.75x your primary attribute."
 "DOTA_Tooltip_modifier_hybrid_oaa"                                              "#{game_option_hybrid}"
-"DOTA_Tooltip_modifier_hybrid_oaa_Description"                                  "+3%% spell amp for each attack made, +40 attack damage for each spell cast. Buffs last 6 seconds if not refreshed."
+"DOTA_Tooltip_modifier_hybrid_oaa_Description"                                  "+3%% spell amp for each attack made, +1 attack damage x spell cooldown for each spell cast. Buffs last 6 seconds if not refreshed."
 "DOTA_Tooltip_modifier_hybrid_dmg_stack_oaa"                                    "Hybrid Damage Stacks"
 "DOTA_Tooltip_modifier_hybrid_spell_amp_stack_oaa"                              "Hybrid Spell Amp Stacks"
+"DOTA_Tooltip_modifier_drunk_oaa"                                               "Drunkard"
+"DOTA_Tooltip_modifier_drunk_oaa_Description"                                   "10%% chance to do 3x critical damage on each attack and spell damage instance. 10%% chance to avoid any damage. Has a random chance to miss a spell and moves randomly when idle."

--- a/game/scripts/vscripts/components/team_select/options.lua
+++ b/game/scripts/vscripts/components/team_select/options.lua
@@ -148,6 +148,7 @@ function OAAOptions:Init ()
   LinkLuaModifier("modifier_hero_anti_stun_oaa", "modifiers/funmodifiers/modifier_hero_anti_stun_oaa.lua", LUA_MODIFIER_MOTION_NONE)
   LinkLuaModifier("modifier_roshan_power_oaa", "modifiers/funmodifiers/modifier_roshan_power_oaa.lua", LUA_MODIFIER_MOTION_NONE)
   LinkLuaModifier("modifier_titan_soul_oaa", "modifiers/funmodifiers/modifier_titan_soul_oaa.lua", LUA_MODIFIER_MOTION_NONE)
+  LinkLuaModifier("modifier_drunk_oaa", "modifiers/funmodifiers/modifier_drunk_oaa.lua", LUA_MODIFIER_MOTION_NONE)
 
   DebugPrint('OAAOptions module Initialization finished!')
 end

--- a/game/scripts/vscripts/modifiers/funmodifiers/modifier_blood_magic_oaa.lua
+++ b/game/scripts/vscripts/modifiers/funmodifiers/modifier_blood_magic_oaa.lua
@@ -39,7 +39,6 @@ function modifier_blood_magic_oaa:OnDestroy()
   local parent = self:GetParent()
   if IsServer() and parent and parent:IsHero() then
     parent:CalculateStatBonus(true)
-    parent:GiveMana(self.bonus_hp)
   end
 end
 

--- a/game/scripts/vscripts/modifiers/funmodifiers/modifier_brute_oaa.lua
+++ b/game/scripts/vscripts/modifiers/funmodifiers/modifier_brute_oaa.lua
@@ -19,7 +19,7 @@ end
 
 function modifier_brute_oaa:OnCreated()
   self.bonus_str_per_lvl = 1
-  self.bonus_dmg_per_hp = 0.08
+  self.bonus_dmg_per_hp = 0.05
 
   if not IsServer() then
     return

--- a/game/scripts/vscripts/modifiers/funmodifiers/modifier_chaos_oaa.lua
+++ b/game/scripts/vscripts/modifiers/funmodifiers/modifier_chaos_oaa.lua
@@ -31,6 +31,7 @@ function modifier_chaos_oaa:OnCreated()
     "modifier_bonus_armor_negative_magic_resist_oaa",
     "modifier_brawler_oaa",
     "modifier_courier_kill_bonus_oaa",
+    "modifier_drunk_oaa",
     "modifier_echo_strike_oaa",
     "modifier_explosive_death_oaa",
     "modifier_ham_oaa",
@@ -56,6 +57,7 @@ function modifier_chaos_oaa:OnCreated()
     "modifier_brute_oaa",
     "modifier_cursed_attack_oaa",
     "modifier_debuff_duration_oaa",
+    "modifier_drunk_oaa",
     "modifier_echo_strike_oaa",
     "modifier_explosive_death_oaa",
     "modifier_ham_oaa",
@@ -82,11 +84,13 @@ function modifier_chaos_oaa:OnCreated()
     "modifier_any_damage_crit_oaa",
     "modifier_aoe_radius_increase_oaa",
     "modifier_blood_magic_oaa",
-    "modifier_bonus_armor_negative_magic_resist_oaa",
+    --"modifier_bonus_armor_negative_magic_resist_oaa",
     "modifier_brute_oaa",
+    "modifier_cursed_attack_oaa",
     "modifier_debuff_duration_oaa",
+    "modifier_drunk_oaa",
     "modifier_echo_strike_oaa",
-    "modifier_explosive_death_oaa",
+    --"modifier_explosive_death_oaa",
     "modifier_ham_oaa",
     "modifier_hero_anti_stun_oaa",
     "modifier_hybrid_oaa",
@@ -199,6 +203,10 @@ if IsServer() then
 
     if self.last_mod then
       parent:RemoveModifierByName(self.last_mod)
+    end
+
+    if self.last_mod == "modifier_blood_magic_oaa" then
+      parent:GiveMana(parent:GetMaxMana()+1)
     end
 
     local repeat_loop = true

--- a/game/scripts/vscripts/modifiers/funmodifiers/modifier_cursed_attack_oaa.lua
+++ b/game/scripts/vscripts/modifiers/funmodifiers/modifier_cursed_attack_oaa.lua
@@ -18,22 +18,30 @@ end
 
 function modifier_cursed_attack_oaa:DeclareFunctions()
   return {
-    MODIFIER_PROPERTY_MISS_PERCENTAGE,
+    --MODIFIER_PROPERTY_MISS_PERCENTAGE,
     MODIFIER_PROPERTY_STATS_AGILITY_BONUS,
     MODIFIER_PROPERTY_PROCATTACK_BONUS_DAMAGE_PURE,
+    MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE,
   }
 end
 
-function modifier_cursed_attack_oaa:GetModifierMiss_Percentage()
-  return 50
-end
+--function modifier_cursed_attack_oaa:GetModifierMiss_Percentage(keys)
+  --return 50
+--end
 
 function modifier_cursed_attack_oaa:GetModifierBonusStats_Agility()
   return -999
 end
 
 function modifier_cursed_attack_oaa:GetModifierProcAttack_BonusDamage_Pure()
-  return 350
+  if RandomInt(1, 100) <= 50 then
+    return 350
+  end
+  return 0
+end
+
+function modifier_cursed_attack_oaa:GetModifierPreAttack_BonusDamage()
+  return -125
 end
 
 function modifier_cursed_attack_oaa:GetEffectName()

--- a/game/scripts/vscripts/modifiers/funmodifiers/modifier_drunk_oaa.lua
+++ b/game/scripts/vscripts/modifiers/funmodifiers/modifier_drunk_oaa.lua
@@ -1,0 +1,286 @@
+modifier_drunk_oaa = class(ModifierBaseClass)
+
+function modifier_drunk_oaa:IsHidden()
+  return false
+end
+
+function modifier_drunk_oaa:IsDebuff()
+  return false
+end
+
+function modifier_drunk_oaa:IsPurgable()
+  return false
+end
+
+function modifier_drunk_oaa:RemoveOnDeath()
+  local parent = self:GetParent()
+  if parent:IsRealHero() and not parent:IsOAABoss() then
+    return false
+  end
+  return true
+end
+
+function modifier_drunk_oaa:DeclareFunctions()
+  return {
+    MODIFIER_PROPERTY_PREATTACK_CRITICALSTRIKE,
+    MODIFIER_PROPERTY_AVOID_DAMAGE,
+    MODIFIER_PROPERTY_OVERRIDE_ANIMATION,
+    MODIFIER_EVENT_ON_TAKEDAMAGE,
+    MODIFIER_EVENT_ON_ABILITY_EXECUTED,
+  }
+end
+
+function modifier_drunk_oaa:OnCreated()
+  self.attack_crit_chance = 10
+  self.spell_crit_chance = 10
+  self.avoid_chance = 10
+  self.crit_multiplier = 3
+
+  self:StartIntervalThink(1)
+end
+
+function modifier_drunk_oaa:OnIntervalThink()
+  if not IsServer() then
+    return
+  end
+
+  local parent = self:GetParent()
+
+  if not parent:IsIdle() then
+    return
+  end
+
+  local position = parent:GetAbsOrigin() + RandomVector(1):Normalized() * RandomFloat(50, 200)
+
+  -- The land is moving, not me
+  parent:MoveToPosition(position)
+end
+
+function modifier_drunk_oaa:GetModifierAvoidDamage(event)
+  if RandomInt(1, 100) <= self.avoid_chance then
+    return 1
+  end
+
+  return 0
+end
+
+function modifier_drunk_oaa:GetOverrideAnimation()
+  return ACT_DOTA_FLAIL
+end
+
+if IsServer() then
+  function modifier_drunk_oaa:GetModifierPreAttack_CriticalStrike(event)
+    local target = event.target
+
+    -- Check if attacked entity exists
+    if not target or target:IsNull() then
+      return 0
+    end
+
+    -- Check if attacked entity is an item, rune or something weird
+    if target.GetUnitName == nil then
+      return 0
+    end
+
+    -- Don't affect buildings, wards, invulnerable and dead units.
+    if target:IsTower() or target:IsBarracks() or target:IsBuilding() or target:IsOther() or target:IsInvulnerable() or not target:IsAlive() then
+      return 0
+    end
+
+    if RandomInt(1, 100) <= self.attack_crit_chance then
+      return self.crit_multiplier * 100
+    end
+  end
+
+  function modifier_drunk_oaa:OnTakeDamage(event)
+    local parent = self:GetParent()
+    local attacker = event.attacker
+    local damaged_unit = event.unit
+    local dmg_flags = event.damage_flags
+    local damage = event.original_damage
+
+    -- Check if attacker exists
+    if not attacker or attacker:IsNull() then
+      return
+    end
+
+    -- Check if attacker has this modifier
+    if attacker ~= parent then
+      return
+    end
+
+    -- Check if damaged entity exists
+    if not damaged_unit or damaged_unit:IsNull() then
+      return
+    end
+
+    -- Ignore self damage
+    --if damaged_unit == parent then
+      --return
+    --end
+
+    -- Check if entity is an item, rune or something weird
+    if damaged_unit.GetUnitName == nil then
+      return
+    end
+
+    -- Don't affect buildings, wards, invulnerable and dead units.
+    if damaged_unit:IsTower() or damaged_unit:IsBarracks() or damaged_unit:IsBuilding() or damaged_unit:IsOther() or damaged_unit:IsInvulnerable() or not damaged_unit:IsAlive() then
+      return
+    end
+
+    -- Ignore damage with no-reflect flag
+    if bit.band(dmg_flags, DOTA_DAMAGE_FLAG_REFLECTION) > 0 then
+      return
+    end
+
+    -- Ignore damage with HP removal flag
+    if bit.band(dmg_flags, DOTA_DAMAGE_FLAG_HPLOSS) > 0 then
+      return
+    end
+
+    -- Ignore damage with no-spell-amplification flag
+    if bit.band(dmg_flags, DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION) > 0 then
+      return
+    end
+
+    -- Can't crit on 0 or negative damage
+    if damage <= 0 then
+      return
+    end
+
+    -- Ignore attacks
+    if event.damage_category == DOTA_DAMAGE_CATEGORY_ATTACK then
+      return
+    end
+
+    if RandomInt(1, 100) <= self.spell_crit_chance then
+      local damage_table = {}
+      damage_table.victim = damaged_unit
+      damage_table.attacker = parent
+      damage_table.damage = (self.crit_multiplier - 1) * damage
+      damage_table.damage_type = event.damage_type
+      damage_table.damage_flags = bit.bor(dmg_flags, DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION)
+
+      ApplyDamage(damage_table)
+
+      SendOverheadEventMessage(nil, OVERHEAD_ALERT_BONUS_SPELL_DAMAGE, damaged_unit, damage_table.damage, nil)
+    end
+  end
+
+  function modifier_drunk_oaa:OnAbilityExecuted(event)
+    local parent = self:GetParent()
+    local casting_unit = event.unit
+    local target = event.target
+    local ability = event.ability
+
+    -- Check if caster of the executed ability exists
+    if not casting_unit or casting_unit:IsNull() then
+      return
+    end
+
+    -- Check if target of the executed ability exists
+    if not target or target:IsNull() then
+      return
+    end
+
+		-- Check if caster has this modifier
+		if casting_unit ~= parent then
+			return
+		end
+
+		-- Check if target of the executed ability is an ally of the target
+		--if target:GetTeamNumber() == parent:GetTeamNumber() then
+			--return
+		--end
+
+    -- Stop it you are drunk
+    local new_target
+    local rand = RandomInt(1, 4)
+    if rand == 1 then
+      new_target = casting_unit
+    elseif rand == 2 then
+      new_target = target
+    elseif rand == 3 then
+      new_target = self:FindRandomAlly(ability)
+    else
+      new_target = self:FindRandomEnemy(ability, target)
+    end
+
+		-- Redirect to the new_target (this method doesn't work for every unit target ability and item)
+		casting_unit:SetCursorCastTarget(new_target)
+  end
+
+  function modifier_drunk_oaa:FindRandomAlly(ability)
+    local random_ally
+    local parent = self:GetParent()
+
+    local allies = FindUnitsInRadius(
+      parent:GetTeamNumber(),
+      parent:GetAbsOrigin(),
+      nil,
+      ability:GetEffectiveCastRange(parent:GetAbsOrigin(), parent),
+      DOTA_UNIT_TARGET_TEAM_FRIENDLY,
+      ability:GetAbilityTargetType(),
+      DOTA_UNIT_TARGET_FLAG_NONE,
+      FIND_ANY_ORDER,
+      false
+    )
+
+    for _, ally in pairs(allies) do
+      if ally and not ally:IsNull() and ally ~= parent then
+        random_ally = ally
+        break
+      end
+    end
+
+    return random_ally or parent
+  end
+
+  function modifier_drunk_oaa:FindRandomEnemy(ability, target)
+    local random_enemy
+    local parent = self:GetParent()
+
+    local enemies = FindUnitsInRadius(
+      parent:GetTeamNumber(),
+      parent:GetAbsOrigin(),
+      nil,
+      ability:GetEffectiveCastRange(parent:GetAbsOrigin(), nil),
+      DOTA_UNIT_TARGET_TEAM_ENEMY,
+      ability:GetAbilityTargetType(),
+      DOTA_UNIT_TARGET_FLAG_NONE,
+      FIND_ANY_ORDER,
+      false
+    )
+
+    for _, enemy in pairs(enemies) do
+      if enemy and not enemy:IsNull() and enemy ~= target then
+        random_enemy = enemy
+        break
+      end
+    end
+
+    return random_enemy or target
+  end
+
+end
+
+function modifier_drunk_oaa:GetStatusEffectName()
+  return "particles/status_fx/status_effect_brewmaster_cinder_brew.vpcf"
+end
+
+function modifier_drunk_oaa:StatusEffectPriority()
+  return 5
+end
+
+function modifier_drunk_oaa:GetEffectName()
+  return "particles/units/heroes/hero_brewmaster/brewmaster_cinder_brew_debuff.vpcf"
+end
+
+function modifier_drunk_oaa:GetEffectAttachType()
+  return PATTACH_ABSORIGIN_FOLLOW
+end
+
+function modifier_drunk_oaa:GetTexture()
+  return "brewmaster_drunken_brawler"
+end


### PR DESCRIPTION
* Hybrid modifier attack damage stacks are now based on spell cooldown.
* Blood Magic modifier: hopefully fixed not having mana when respawning after losing this modifier.
* Brute modifier: Damage per hp reduced from 0.08 to 0.05
* Chaos modifier: Added Drunkard modifier to the pool of modifiers. Drunkard: 10% chance to do 3x critical damage on each attack and spell damage instance. 10% chance to avoid any damage. Has a random chance to miss a spell and moves randomly when idle.
* Cursed Attack modifier no longer has a miss chance.
* Cursed Attack modifier now provides a 50% chance to deal 350 pure damage.
* Cursed Attack modifier now also reduced attack damage by 125.