### PR TITLE
Vampire Fang rework

### DIFF
--- a/game/resource/English/ability/items/tooltip_vampire_fang.txt
+++ b/game/resource/English/ability/items/tooltip_vampire_fang.txt
@@ -2,8 +2,8 @@
 // Vampire Fang
 //==================================================================
 "dota_tooltip_ability_item_vampire"                                             "Vampire Fang"
-"dota_tooltip_ability_item_vampire_description"                                 "<h1>Active: Vampirism</h1> Grants %active_lifesteal_percent%%% lifesteal but during the day all other sources of healing are disabled. You also take %damage_per_second_pct%%% of current health in damage per second. Lasts %duration% seconds.\n<h1>Passive: Lifesteal</h1>Heals the attacker for %lifesteal_percent%%% of attack damage dealt."
-"dota_tooltip_ability_item_vampire_Note0"                                       "Other sources of lifesteal will also be disabled while #{dota_tooltip_modifier_item_vampire_active} is active."
+"dota_tooltip_ability_item_vampire_description"                                 "<h1>Active: Vampirism</h1> Grants %active_lifesteal_percent%%% lifesteal. During the night: you gain additional %night_bonus_damage% attack damage and you can sense enemies within %night_thirst_radius% range through fog of war. During the day: you take %damage_per_second_pct%%% of current health in damage per second. Lasts %duration% seconds.\n<h1>Passive: Lifesteal</h1>Heals the attacker for %lifesteal_percent%%% of attack damage dealt. No lifesteal penalties against creeps."
+//"dota_tooltip_ability_item_vampire_Note0"                                       "Other sources of lifesteal will also be disabled while #{dota_tooltip_modifier_item_vampire_active} is active."
 //"dota_tooltip_ability_item_vampire_Note1"                                       "#{transformation_note0}"
 "dota_tooltip_ability_item_vampire_bonus_strength"                              "+$str"
 "dota_tooltip_ability_item_vampire_bonus_damage"                                "+$damage"
@@ -15,7 +15,7 @@
 "dota_tooltip_ability_item_vampire_2"                                           "#{dota_tooltip_ability_item_vampire}"
 "dota_tooltip_ability_item_vampire_2_description"                               "#{dota_tooltip_ability_item_vampire_description}"
 //"dota_tooltip_ability_item_vampire_2_Note1"                                     "#{dota_tooltip_ability_item_vampire_Note1}"
-"dota_tooltip_ability_item_vampire_2_Note0"                                     "#{dota_tooltip_ability_item_vampire_Note0}"
+//"dota_tooltip_ability_item_vampire_2_Note0"                                     "#{dota_tooltip_ability_item_vampire_Note0}"
 "dota_tooltip_ability_item_vampire_2_bonus_strength"                            "#{dota_tooltip_ability_item_vampire_bonus_strength}"
 "dota_tooltip_ability_item_vampire_2_bonus_damage"                              "#{dota_tooltip_ability_item_vampire_bonus_damage}"
 "dota_tooltip_ability_item_vampire_2_bonus_attack_speed"                        "#{dota_tooltip_ability_item_vampire_bonus_attack_speed}"
@@ -24,4 +24,7 @@
 "dota_tooltip_ability_item_vampire_2_Lore"                                      "#{dota_tooltip_ability_item_vampire_Lore}"
 
 "dota_tooltip_modifier_item_vampire_active"                                     "Vampirism"
-"dota_tooltip_modifier_item_vampire_active_description"                         "During the day all healing is disabled except for lifesteal. Losing HP over time."
+"dota_tooltip_modifier_item_vampire_active_description"                         "During the night, bonus damage and detecting life through fog of war. During the day, losing HP over time."
+
+"dota_tooltip_modifier_item_vampire_active_detect_life_effect"                  "Vampire Sense"
+"dota_tooltip_modifier_item_vampire_active_detect_life_effect_description"      "Revealed in fog of war."

--- a/game/scripts/npc/items/custom/item_vampire.txt
+++ b/game/scripts/npc/items/custom/item_vampire.txt
@@ -66,14 +66,16 @@
     "AbilityValues"
     {
       "bonus_strength"                                    "70 95"
-      "bonus_damage"                                      "120 170"
+      "bonus_damage"                                      "110 160"
       "bonus_status_resistance"                           "20 25"
       "bonus_attack_speed"                                "40 50"
       "bonus_night_vision"                                "400 600"
       "lifesteal_percent"                                 "45 50"
-      "active_lifesteal_percent"                          "215 225"
-      "damage_per_second_pct"                             "8"
+      "active_lifesteal_percent"                          "175"
+      "damage_per_second_pct"                             "8" // only during the day
       "ticks_per_second"                                  "4"
+      "night_bonus_damage"                                "110 160"
+      "night_thirst_radius"                               "1200"
       "duration"                                          "6.0"
     }
 

--- a/game/scripts/npc/items/custom/item_vampire_2.txt
+++ b/game/scripts/npc/items/custom/item_vampire_2.txt
@@ -66,14 +66,16 @@
     "AbilityValues"
     {
       "bonus_strength"                                    "70 95"
-      "bonus_damage"                                      "120 170"
+      "bonus_damage"                                      "110 160"
       "bonus_status_resistance"                           "20 25"
       "bonus_attack_speed"                                "40 50"
       "bonus_night_vision"                                "400 600"
       "lifesteal_percent"                                 "45 50"
-      "active_lifesteal_percent"                          "215 225"
-      "damage_per_second_pct"                             "8"
+      "active_lifesteal_percent"                          "175"
+      "damage_per_second_pct"                             "8" // only during the day
       "ticks_per_second"                                  "4"
+      "night_bonus_damage"                                "110 160"
+      "night_thirst_radius"                               "1200"
       "duration"                                          "6.0"
     }
 


### PR DESCRIPTION
* Vampirism no longer disables healing from other sources.
* Vampirism now deals self damage only during the day.
* Vampirism now provides bonus damage (110/160) during the night and reveals enemies within 1200 radius in fog of war (like BH Track but without True Sight) during the night.
* Vampirism active lifesteal reduced from 215/225% to 175%.
* Bonus damage reduced from 120/170 to 110/160.