### PR TITLE
Dragon Knight shard improvement

### DIFF
--- a/game/resource/English/ability/units/tooltip_dragon_knight_elder_dragon_form.txt
+++ b/game/resource/English/ability/units/tooltip_dragon_knight_elder_dragon_form.txt
@@ -2,16 +2,27 @@
 // Dragon Knight Elder Dragon Form
 //=============================================================================
 
-"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa"                      "Elder Dragon Form"
+//"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form"                          "Elder Dragon Form"
+//"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_Description"              "Dragon Knight takes the form of one of three powerful elder dragons, increasing his speed, and Dragon Tail's range, while granting him new powers.\n<font color=\"#9acd32\">LEVEL 1 Green Dragon</font> - Corrosive Breath: attacks deal %corrosive_breath_damage% poison damage per second for %corrosive_breath_duration% seconds. Works on structures.\n<font color=\"#ff0000\">LEVEL 2 Red Dragon</font> - Splash Attack: attacks damage all enemy units in a %splash_radius% radius for %splash_damage_percent%%% damage, with Corrosive Breath added to the targets.\n<font color=\"#87ceeb\">LEVEL 3 Blue Dragon</font> - Frost Breath: slows movement speed by %frost_bonus_movement_speed%%% and attack speed by %frost_bonus_attack_speed% of enemy units in Splash Attack range for %frost_duration% seconds, with Corrosive Breath added to the targets."
+//"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_shard_description"        "Grants Elder Dragon Form the Fireball ability."
+//"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_scepter_description"      "Increases the level of Dragon Knight's ultimate. Adds a 4th level, Black Dragon. Black Dragon has bonus Corrosive Damage, Splash Damage and Slow amount, 25% increased Magic Resistance and free pathing."
+//"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_Lore"                     "The dormant dragon power springs forth from within Davion, combining the powers of a legendary knight with a legendary Eldwurm."
+//"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_Note0"                    "Corrosive Breath poison damage is lethal."
+//"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_Note1"                    "Cooldowns of items that are different for ranged and melee units will be based on which form Dragon Knight was in when the item was used."
+//"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_duration"                 "DURATION:"
+//"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_bonus_movement_speed"     "BONUS MOVE SPEED:"
+//"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_bonus_attack_range"       "BONUS ATTACK RANGE:"
+
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa"                      "#{DOTA_Tooltip_ability_dragon_knight_elder_dragon_form}"
 "DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Description"          "Dragon Knight takes the form of one of four powerful elder dragons, increasing his speed, and Dragon Tail's range, while granting him new powers.\n<font color=\"#9acd32\">LEVEL 1 Green Dragon</font> - Corrosive Breath: attacks deal %corrosive_breath_damage% poison damage per second for %corrosive_breath_duration% seconds.\n<font color=\"#ff0000\">LEVEL 2 Red Dragon</font> - Splash Attack: attacks damage all enemy units in a %splash_radius% radius for %splash_damage_percent%%% damage, with Corrosive Breath added to the targets.\n<font color=\"#87ceeb\">LEVEL 3 Blue Dragon</font> - Frost Breath: slows movement speed by %frost_bonus_movement_speed%%% and attack speed by %frost_bonus_attack_speed% of enemy units in Splash Attack range for %frost_duration% seconds, with Corrosive Breath added to the targets.\n<font color=\"#87ceeb\">LEVEL 4 Black Dragon</font> - Grants %magic_resistance%%% Magic resistance and flying movement. \n<font color=\"#87ceeb\">LEVEL 5 Emperor Black Dragon</font> - Frostbite Attack: attacks reduce healing, health regeneration, lifesteal and spell lifesteal by %heal_suppression_pct%%% for %frost_duration% seconds."
 //Draconic Rage: attacks have a %rage_chance%%% chance to transform Dragon Knight for %rage_duration% seconds. During Elder Dragon Form, its duration is extended instead. \n<font color=\"#87ceeb\">LEVEL 5 Emperor King Blue Dragon</font> - Draconic Rebirth: Elder Dragon Form becomes permanent, losing Dragonic Rage.
-"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Lore"                 "The dormant dragon power springs forth from within Davion, combining the powers of a legendary knight with a legendary Eldwurm."
-"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Note0"                "Corrosive Breath poison damage is lethal."
-"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Note1"                "Cooldowns of items that are different for ranged and melee heroes will be based on which form Dragon Knight was in when the item was used."
-"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_duration"             "DURATION:"
-"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_bonus_movement_speed"  "BONUS MOVE SPEED:"
-"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_bonus_attack_range"   "BONUS ATTACK RANGE:"
-"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_scepter_Description"  "Adds 1 level to Elder Dragon Form. Level 6 Elder Dragon Form is Permanent Dragon Form."
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Lore"                 "#{DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_Lore}"
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Note0"                "#{DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_Note0}"
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_Note1"                "#{DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_Note1}"
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_duration"             "#{DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_duration}"
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_bonus_movement_speed"  "#{DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_bonus_movement_speed}"
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_bonus_attack_range"   "#{DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_bonus_attack_range}"
+"DOTA_Tooltip_ability_dragon_knight_elder_dragon_form_oaa_scepter_Description"  "Increases the level of Elder Dragon Form. Adds a 6th level: Permanent Dragon Form."
 
 "DOTA_Tooltip_modifier_dragon_knight_max_level_oaa"                             "Frostbite Attack"
 "DOTA_Tooltip_modifier_dragon_knight_max_level_oaa_Description"                 "Reduces healing, hp regen, lifesteal and spell lifesteal of the attacked unit."

--- a/game/resource/English/ability/units/tooltip_dragon_knight_fireball.txt
+++ b/game/resource/English/ability/units/tooltip_dragon_knight_fireball.txt
@@ -1,0 +1,21 @@
+//=============================================================================
+// Dragon Knight Fireball
+//=============================================================================
+
+//"DOTA_Tooltip_ability_black_dragon_fireball_Description"                        "Hurls a fire blast on the ground, igniting the area in a %radius% radius for %duration% seconds. Enemies caught in the fire will take %damage% damage per second."
+//"DOTA_Tooltip_ability_dragon_knight_fireball"                                   "Fireball"
+//"DOTA_Tooltip_ability_dragon_knight_fireball_Description"                       "Ignites an area, dealing damage over time that lingers on enemies in it. Has reduced cast range when melee."
+"DOTA_Tooltip_ability_dragon_knight_fireball_Description"                       "#{DOTA_Tooltip_ability_black_dragon_fireball_Description} Fire lingers on enemies after they leave the area. Has reduced cast range when melee.\n<font color='#FFA500'>Enemies caught in the fire are also revealed with true sight and take extra damage based on their max health.</font>"
+//"DOTA_Tooltip_ability_dragon_knight_fireball_radius"                            "RADIUS:"
+//"DOTA_Tooltip_ability_dragon_knight_fireball_duration"                          "DURATION:"
+//"DOTA_Tooltip_ability_dragon_knight_fireball_damage"                            "DAMAGE PER SECOND:"
+//"DOTA_Tooltip_ability_dragon_knight_fireball_linger_duration"                   "LINGER DURATION:"
+//"DOTA_Tooltip_ability_dragon_knight_fireball_dragon_form_cast_range"            "DRAGON FORM CAST RANGE:"
+//"DOTA_Tooltip_ability_dragon_knight_fireball_melee_cast_range"                  "MELEE CAST RANGE:"
+"DOTA_Tooltip_ability_dragon_knight_fireball_max_hp_damage"                     "%MAX HEALTH AS DAMAGE:"
+
+//"DOTA_Tooltip_modifier_dragon_knight_fireball_burn"                             "Fireball"
+//"DOTA_Tooltip_modifier_dragon_knight_fireball_burn_Description"                 "Taking %dMODIFIER_PROPERTY_TOOLTIP% damage per second."
+
+"DOTA_Tooltip_modifier_dragon_knight_custom_shard_effect_oaa"                   "#{DOTA_Tooltip_modifier_dragon_knight_fireball_burn}"
+"DOTA_Tooltip_modifier_dragon_knight_custom_shard_effect_oaa_Description"       "Revealed and taking max hp percent damage per second."

--- a/game/scripts/npc/abilities/dragon_knight_elder_dragon_form_oaa.txt
+++ b/game/scripts/npc/abilities/dragon_knight_elder_dragon_form_oaa.txt
@@ -120,7 +120,7 @@
       "17"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "heal_suppression_pct"                            "50"
+        "heal_suppression_pct"                            "40"
       }
     }
   }

--- a/game/scripts/npc/abilities/dragon_knight_fireball.txt
+++ b/game/scripts/npc/abilities/dragon_knight_fireball.txt
@@ -1,0 +1,46 @@
+"DOTAAbilities"
+{
+  //=================================================================================================================
+  // Dragon Knight: Fireball (shard ability)
+  //=================================================================================================================
+  "dragon_knight_fireball"
+  {
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "ID"                                                  "660"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE | DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_SHOW_IN_GUIDES" //OAA, Valve has extra space
+    "AbilityUnitDamageType"                               "DAMAGE_TYPE_MAGICAL"
+    "SpellImmunityType"                                   "SPELL_IMMUNITY_ENEMIES_NO"
+    "MaxLevel"                                            "1"
+
+    // Casting
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCastPoint"                                    "0.2"
+
+    // Time
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityCooldown"                                     "20"
+
+    // Cost
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityManaCost"                                     "80"
+
+    // Special
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityValues"
+    {
+      "radius"                                            "350"
+      "damage"
+      {
+        "value"                                           "75"
+        "CalculateSpellDamageTooltip"                     "1"
+      }
+      "duration"                                          "8.0"
+      "burn_interval"                                     "0.5"
+      "linger_duration"                                   "2"
+      "dragon_form_cast_range"                            "1400"
+      "melee_cast_range"                                  "600"
+      "max_hp_damage"                                     "4" //OAA
+    }
+  }
+}

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -128,6 +128,7 @@
 #base "abilities/dragon_knight_dragon_blood.txt"
 #base "abilities/dragon_knight_dragon_tail.txt"
 #base "abilities/dragon_knight_elder_dragon_form.txt"
+#base "abilities/dragon_knight_fireball.txt"
 #base "abilities/dragon_knight_frost_breath.txt"
 #base "abilities/drow_ranger_frost_arrows.txt"
 #base "abilities/drow_ranger_marksmanship.txt"

--- a/game/scripts/vscripts/abilities/oaa_elder_dragon_form.lua
+++ b/game/scripts/vscripts/abilities/oaa_elder_dragon_form.lua
@@ -210,11 +210,9 @@ end
 
 --[[
 function modifier_dragon_knight_elder_dragon_form_oaa:DeclareFunctions()
-  local funcs = {
+  return {
     MODIFIER_EVENT_ON_ATTACK_LANDED,
   }
-
-  return funcs
 end
 
 -- Rage chance - chance to transform into Dragon Form when attack lands, doesn't matter what is the attacked target
@@ -321,12 +319,10 @@ function modifier_dragon_knight_max_level_oaa:OnRefresh()
 end
 
 function modifier_dragon_knight_max_level_oaa:DeclareFunctions()
-  local funcs = {
+  return {
     MODIFIER_EVENT_ON_ATTACK_LANDED,
     MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS,
   }
-
-  return funcs
 end
 
 function modifier_dragon_knight_max_level_oaa:GetModifierMagicalResistanceBonus()
@@ -347,11 +343,6 @@ if IsServer() then
 
     -- Check if attacker has this modifier
     if attacker ~= parent then
-      return
-    end
-
-    -- No effect while broken or illusion
-    if parent:PassivesDisabled() or parent:IsIllusion() then
       return
     end
 
@@ -399,20 +390,29 @@ end
 
 function modifier_dragon_knight_frostbite_debuff_oaa:OnCreated()
   self.heal_suppression_pct = self:GetAbility():GetSpecialValueFor("heal_suppression_pct")
+  -- No effect if caster is an illusion
+  local caster = self:GetCaster()
+  if caster:IsNull() or caster:IsIllusion() then
+    self.heal_suppression_pct = 0
+  end
 end
 
 function modifier_dragon_knight_frostbite_debuff_oaa:OnRefresh()
   self.heal_suppression_pct = self:GetAbility():GetSpecialValueFor("heal_suppression_pct")
+  -- No effect if caster is an illusion
+  local caster = self:GetCaster()
+  if caster:IsNull() or caster:IsIllusion() then
+    self.heal_suppression_pct = 0
+  end
 end
 
 function modifier_dragon_knight_frostbite_debuff_oaa:DeclareFunctions()
-  local funcs = {
+  return {
     MODIFIER_PROPERTY_HEAL_AMPLIFY_PERCENTAGE_TARGET,
     MODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE,
     MODIFIER_PROPERTY_LIFESTEAL_AMPLIFY_PERCENTAGE,
     MODIFIER_PROPERTY_SPELL_LIFESTEAL_AMPLIFY_PERCENTAGE,
   }
-  return funcs
 end
 
 function modifier_dragon_knight_frostbite_debuff_oaa:GetModifierHealAmplify_PercentageTarget()


### PR DESCRIPTION
* Fixed some Dragon Knight tooltips
* Fixed Dragon Knight in Elder Dragon Form not applying Frostbite attack with Breathe Fire.
* Elder Dragon Form Frostbite attack healing reduction decreased from 50% to 40%. (because it pierces BKB now and it stacks with Skadi and Shivas).
* Fireball (shard ability) now also deals 4% of max hp as damage and reveals invisible units.
* Fixed Elder Dragon Form Frostbite Attack being disabled with break.