### PR TITLE
Windranger Windrun changes

### DIFF
--- a/game/resource/English/ability/units/tooltip_windranger_windrun.txt
+++ b/game/resource/English/ability/units/tooltip_windranger_windrun.txt
@@ -1,0 +1,2 @@
+
+"DOTA_Tooltip_ability_windrunner_windrun_scepter_description"                   "Windrun's enemy debuff has increased slow and reduces physical damage taken by %physical_damage_pct%%%."

--- a/game/scripts/npc/abilities/boss/lycan_boss/lycan_boss_rupture_ball.txt
+++ b/game/scripts/npc/abilities/boss/lycan_boss/lycan_boss_rupture_ball.txt
@@ -38,15 +38,15 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "attack_speed"                                    "700"
-      "attack_width_initial"                            "110"
-      "attack_width_end"                                "110"
-      "attack_distance"                                 "1500"
+      "attack_speed"                                      "700"
+      "attack_width_initial"                              "110"
+      "attack_width_end"                                  "110"
+      "attack_distance"                                   "1500"
       // Rupture KVs:
-      "duration"                                        "7.0"
-      "movement_damage_pct"                             "200"
-      "hp_pct"                                          "10"
-      "damage_cap_amount"                               "200"
+      "duration"                                          "7.0"
+      "movement_damage_pct"                               "200"
+      "hp_pct"                                            "10"
+      "damage_cap_amount"                                 "200"
     }
   }
 }

--- a/game/scripts/npc/abilities/boss/lycan_boss/lycan_boss_rupture_ball_tier5.txt
+++ b/game/scripts/npc/abilities/boss/lycan_boss/lycan_boss_rupture_ball_tier5.txt
@@ -38,15 +38,15 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "attack_speed"                                    "2000"
-      "attack_width_initial"                            "110"
-      "attack_width_end"                                "110"
-      "attack_distance"                                 "1500"
+      "attack_speed"                                      "2000"
+      "attack_width_initial"                              "110"
+      "attack_width_end"                                  "110"
+      "attack_distance"                                   "1500"
       // Rupture KVs:
-      "duration"                                        "8.0"
-      "movement_damage_pct"                             "600"
-      "hp_pct"                                          "10"
-      "damage_cap_amount"                               "200"
+      "duration"                                          "8.0"
+      "movement_damage_pct"                               "600"
+      "hp_pct"                                            "10"
+      "damage_cap_amount"                                 "200"
     }
   }
 }

--- a/game/scripts/npc/abilities/windrunner_windrun.txt
+++ b/game/scripts/npc/abilities/windrunner_windrun.txt
@@ -21,7 +21,7 @@
     // Time
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "15 14 13 12 12 12"
-    "AbilityDuration"                                     "2.5 3 3.5 4 4.5 5" //OAA, revert this when no aghs invis
+    "AbilityDuration"                                     "3 4 5 6 6.5 7"
 
     // Cost
     //-------------------------------------------------------------------------------------------------------------
@@ -39,7 +39,7 @@
       }
       "radius" //OAA
       {
-        "value"                                           "525"
+        "value"                                           "550"
         "special_bonus_unique_windranger"                 "+0"
       }
       "scepter_movespeed_bonus_pct"
@@ -57,7 +57,7 @@
         "value"                                           "0"
         "special_bonus_unique_windranger_windrun_undispellable"  "+1"
       }
-      "duration"                                          "2.5 3 3.5 4 4.5 5" //OAA, revert this when no aghs invis
+      "duration"                                          "3 4 5 6 6.5 7"
     }
   }
 }

--- a/game/scripts/vscripts/components/filters/modifyabilitiesfilter.lua
+++ b/game/scripts/vscripts/components/filters/modifyabilitiesfilter.lua
@@ -21,7 +21,7 @@ end
 
 function ModifyAbilitiesFilter:ModifierFilter(keys)
   -- Remove fountain invulnerability
-  if keys.name_const == "modifier_fountain_invulnerability" then
+  if keys.name_const == "modifier_fountain_invulnerability" or keys.name_const == "modifier_windrunner_windrun_invis" then
     return false
   end
 


### PR DESCRIPTION
* Windranger scepter Windrun no longer provides invisibility.
* Windranger Windrun duration increased from 2.5/3/3.5/4/4.5/5 to 3/4/5/6/6.5/7 seconds.
* Windranger Windrun slow radius increased from 525 to 550.