### PR TITLE
Some item changes

### DIFF
--- a/game/resource/English/ability/items/tooltip_black_king_bar.txt
+++ b/game/resource/English/ability/items/tooltip_black_king_bar.txt
@@ -13,14 +13,14 @@
 
 "DOTA_Tooltip_Ability_item_black_king_bar_1"                                    "#{DOTA_Tooltip_Ability_item_black_king_bar}"
 "DOTA_Tooltip_Ability_item_recipe_black_king_bar_1"                             "#{DOTA_Tooltip_Ability_item_recipe_black_king_bar}"
-"DOTA_Tooltip_ability_item_black_king_bar_1_Description"                        "<h1>Active: Avatar</h1> Grants %magic_resist%%% Magic resistance and immunity to some pure damage spells. For the duration of the Avatar effect, most negative debuffs and stuns from enemy spells will have no effect. <br><br>Duration: %duration% <br>Dispel Type: <span class=\"GameplayValues GameplayVariable\">Basic Dispel</span>"
+"DOTA_Tooltip_ability_item_black_king_bar_1_Description"                        "<h1>Active: Avatar</h1> Grants Debuff Immunity and %magic_resist%%% Magic resistance. Debuff Immunity: most debuffs and stuns from enemy spells will have no effect + immunity to reflected damage and some pure damage spells. <br><br>Duration: %duration% <br>Dispel Type: <span class=\"GameplayValues GameplayVariable\">Basic Dispel</span>"
 "DOTA_Tooltip_ability_item_black_king_bar_1_Lore"                               "#{DOTA_Tooltip_ability_item_black_king_bar_Lore}"
 "DOTA_Tooltip_ability_item_black_king_bar_1_Note0"                              "Using Black King Bar will not decrease its duration."
 "DOTA_Tooltip_ability_item_black_king_bar_1_bonus_strength"                     "#{DOTA_Tooltip_ability_item_black_king_bar_bonus_strength}"
 "DOTA_Tooltip_ability_item_black_king_bar_1_bonus_damage"                       "#{DOTA_Tooltip_ability_item_black_king_bar_bonus_damage}"
 
 //"DOTA_Tooltip_modifier_black_king_bar_immune"                                   "Black King Bar"
-"DOTA_Tooltip_modifier_black_king_bar_immune_Description"                       "Bonus magic resistance and debuff immunity."
+"DOTA_Tooltip_modifier_black_king_bar_immune_Description"                       "Bonus magic resistance and Debuff Immunity."
 
 "DOTA_Tooltip_Ability_item_black_king_bar_2"                                    "#{DOTA_Tooltip_Ability_item_black_king_bar_1}"
 "DOTA_Tooltip_Ability_item_recipe_black_king_bar_2"                             "#{DOTA_Tooltip_Ability_item_recipe_black_king_bar_1}"

--- a/game/resource/English/ability/items/tooltip_spiked_mail.txt
+++ b/game/resource/English/ability/items/tooltip_spiked_mail.txt
@@ -3,7 +3,7 @@
 //==========================================================================
 "DOTA_Tooltip_Ability_item_spiked_mail_1"                                       "Spiked Mail"
 "DOTA_Tooltip_Ability_item_recipe_spiked_mail_1"                                "Spiked Mail Recipe"
-"DOTA_Tooltip_Ability_item_spiked_mail_1_Description"                           "<h1>Active: Spiked</h1>For %duration% seconds, returns %active_reflection_pct%%% of the damage taken back to the unit that dealt the damage.\n<h1>Passive: Damage Return</h1>Every time you are damaged, you return %passive_reflection_pct%%% of the damage taken back to the unit that dealt the damage."
+"DOTA_Tooltip_Ability_item_spiked_mail_1_Description"                           "<h1>Active: Spiked</h1>For %duration% seconds, returns %active_reflection_pct%%% of the damage taken back to the unit that dealt the damage. Can be used while stunned but not while hexed or muted.\n<h1>Passive: Damage Return</h1>Every time you are damaged, you return %passive_reflection_pct%%% of the damage taken back to the unit that dealt the damage."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_Lore"                                  "Mail made from Zealot Scarab's carapace."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_Note0"                                 "Damage is calculated before reductions and amplifications. Damage type is the same as it was received."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_Note1"                                 "Spiked and Damage Return don't pierce Debuff Immunity."

--- a/game/resource/English/ability/items/tooltip_spiked_mail.txt
+++ b/game/resource/English/ability/items/tooltip_spiked_mail.txt
@@ -6,7 +6,7 @@
 "DOTA_Tooltip_Ability_item_spiked_mail_1_Description"                           "<h1>Active: Spiked</h1>For %duration% seconds, returns %active_reflection_pct%%% of the damage taken back to the unit that dealt the damage.\n<h1>Passive: Damage Return</h1>Every time you are damaged, you return %passive_reflection_pct%%% of the damage taken back to the unit that dealt the damage."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_Lore"                                  "Mail made from Zealot Scarab's carapace."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_Note0"                                 "Damage is calculated before reductions and amplifications. Damage type is the same as it was received."
-"DOTA_Tooltip_Ability_item_spiked_mail_1_Note1"                                 "Spiked and Damage Return both pierce Debuff Immunity if the original damage pierces Debuff Immunity."
+"DOTA_Tooltip_Ability_item_spiked_mail_1_Note1"                                 "Spiked and Damage Return don't pierce Debuff Immunity."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_Note2"                                 "Shares cooldown with Blade Mail."
 "DOTA_Tooltip_Ability_item_spiked_mail_1_bonus_damage"                          "+$damage"
 "DOTA_Tooltip_Ability_item_spiked_mail_1_bonus_armor"                           "+$armor"

--- a/game/scripts/npc/items/custom/item_spiked_mail_1.txt
+++ b/game/scripts/npc/items/custom/item_spiked_mail_1.txt
@@ -39,14 +39,14 @@
     "ID"                                                  "80127"
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/spiked_mail.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE"
     "AbilityTextureName"                                  "custom/lionsmane_1"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "25.0"
     "AbilitySharedCooldown"                               "blademail"
-    "AbilityManaCost"                                     "75"
+    "AbilityManaCost"                                     "0"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/custom/item_spiked_mail_2.txt
+++ b/game/scripts/npc/items/custom/item_spiked_mail_2.txt
@@ -39,14 +39,14 @@
     "ID"                                                  "3090"
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/spiked_mail.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE"
     "AbilityTextureName"                                  "custom/lionsmane_2"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "25.0"
     "AbilitySharedCooldown"                               "blademail"
-    "AbilityManaCost"                                     "75"
+    "AbilityManaCost"                                     "0"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/custom/item_spiked_mail_3.txt
+++ b/game/scripts/npc/items/custom/item_spiked_mail_3.txt
@@ -39,14 +39,14 @@
     "ID"                                                  "3091"
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/spiked_mail.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE"
     "AbilityTextureName"                                  "custom/lionsmane_3"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "25.0"
     "AbilitySharedCooldown"                               "blademail"
-    "AbilityManaCost"                                     "75"
+    "AbilityManaCost"                                     "0"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/custom/item_spiked_mail_4.txt
+++ b/game/scripts/npc/items/custom/item_spiked_mail_4.txt
@@ -39,14 +39,14 @@
     "ID"                                                  "3875"
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/spiked_mail.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE"
     "AbilityTextureName"                                  "custom/lionsmane_4"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "25.0"
     "AbilitySharedCooldown"                               "blademail"
-    "AbilityManaCost"                                     "75"
+    "AbilityManaCost"                                     "0"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/custom/item_spiked_mail_5.txt
+++ b/game/scripts/npc/items/custom/item_spiked_mail_5.txt
@@ -39,14 +39,14 @@
     "ID"                                                  "3877"
     "BaseClass"                                           "item_lua"
     "ScriptFile"                                          "items/spiked_mail.lua"
-    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL"
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE"
     "AbilityTextureName"                                  "custom/lionsmane_5"
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
     "AbilityCooldown"                                     "25.0"
     "AbilitySharedCooldown"                               "blademail"
-    "AbilityManaCost"                                     "75"
+    "AbilityManaCost"                                     "0"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------

--- a/game/scripts/npc/items/custom/item_stoneskin.txt
+++ b/game/scripts/npc/items/custom/item_stoneskin.txt
@@ -81,7 +81,7 @@
       "lifesteal_amp"                                     "25"
       "spell_lifesteal_amp"                               "25"
       "aura_radius"                                       "1200"
-      "stone_armor"                                       "100"
+      "stone_armor"                                       "100 200"
       "stone_magic_resist"                                "0"
       "stone_status_resist"                               "30"
       "stone_deflect_chance"                              "40"

--- a/game/scripts/npc/items/custom/item_stoneskin_2.txt
+++ b/game/scripts/npc/items/custom/item_stoneskin_2.txt
@@ -78,7 +78,7 @@
       "lifesteal_amp"                                     "25"
       "spell_lifesteal_amp"                               "25"
       "aura_radius"                                       "1200"
-      "stone_armor"                                       "100"
+      "stone_armor"                                       "100 200"
       "stone_magic_resist"                                "0"
       "stone_status_resist"                               "30"
       "stone_deflect_chance"                              "40"

--- a/game/scripts/vscripts/items/spiked_mail.lua
+++ b/game/scripts/vscripts/items/spiked_mail.lua
@@ -155,10 +155,67 @@ if IsServer() then
     end
 
     local damaging_ability = event.inflictor
-    if damaging_ability and not damaging_ability:IsNull() then
-      local kvs = damaging_ability:GetAbilityKeyValues()
-      if kvs and kvs.SpellImmunityType and kvs.SpellImmunityType ~= "SPELL_IMMUNITY_ENEMIES_YES" then
-        return
+    local damage_type = event.damage_type
+
+    -- Interaction with Debuff Immunity
+    if attacker:IsDebuffImmune() then
+      -- Pure damage abilities
+      local ability_blacklist = {
+        "axe_counter_helix",
+        --"axe_culling_blade",
+        "bane_brain_sap",
+        "bane_enfeeble",
+        --"bane_fiends_grip",
+        "bloodseeker_blood_bath",
+        "bloodseeker_bloodrage", -- shard
+        --"bloodseeker_rupture",
+        --"doom_bringer_doom",
+        "enchantress_impetus",
+        --"enigma_black_hole",
+        "huskar_burning_spear", -- talent
+        "invoker_sun_strike",
+        --"jakiro_macropyre", -- scepter
+        "leshrac_diabolic_edict",
+        --"lina_laguna_blade", -- talent
+        "meepo_poof",
+        "meepo_ransack",
+        --"nyx_assassin_vendetta",
+        "omniknight_hammer_of_purity",
+        "omniknight_purification",
+        "phantom_assassin_fan_of_knives", -- shard
+        "pudge_meat_hook",
+        --"queenofpain_sonic_wave",
+        "spectre_desolate",
+        "spectre_spectral_dagger",
+        "templar_assassin_psi_blades",
+        --"shredder_chakram",
+        --"shredder_chakram_2",
+        "shredder_timber_chain",
+        "shredder_whirling_death",
+        "tinker_laser",
+        --"tinkerer_laser_contraption",
+        "warlock_golem_flaming_fists",
+        --"witch_doctor_death_ward_oaa",
+        --"witch_doctor_voodoo_switcheroo_oaa",
+      }
+
+      if damaging_ability and not damaging_ability:IsNull() and damage_type == DAMAGE_TYPE_PURE then
+        local name = damaging_ability:GetAbilityName()
+        for _, v in pairs(ability_blacklist) do
+          if name == v then
+            return -- don't return dmg
+          end
+        end
+      end
+    end
+
+    -- Interaction with Spell Immunity
+    if attacker:IsMagicImmune() then
+      if damaging_ability and not damaging_ability:IsNull() then
+        local kvs = damaging_ability:GetAbilityKeyValues()
+        if kvs and kvs.SpellImmunityType and (kvs.SpellImmunityType == "SPELL_IMMUNITY_ENEMIES_NO" or kvs.SpellImmunityType == "SPELL_IMMUNITY_ALLIES_YES_ENEMIES_NO") then
+          return -- don't return dmg
+        end
       end
     end
 
@@ -184,7 +241,7 @@ if IsServer() then
       attacker = parent,
       victim = attacker,
       damage = new_damage,
-      damage_type = event.damage_type, -- Same damage type as original damage
+      damage_type = damage_type, -- Same damage type as original damage
       damage_flags = bit.bor(damage_flags, DOTA_DAMAGE_FLAG_REFLECTION, DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION, DOTA_DAMAGE_FLAG_NO_SPELL_LIFESTEAL, DOTA_DAMAGE_FLAG_BYPASSES_BLOCK),
       ability = ability,
     }
@@ -315,10 +372,67 @@ if IsServer() then
     end
 
     local damaging_ability = event.inflictor
-    if damaging_ability and not damaging_ability:IsNull() then
-      local kvs = damaging_ability:GetAbilityKeyValues()
-      if kvs and kvs.SpellImmunityType and kvs.SpellImmunityType ~= "SPELL_IMMUNITY_ENEMIES_YES" then
-        return
+    local damage_type = event.damage_type
+
+    -- Interaction with Debuff Immunity
+    if attacker:IsDebuffImmune() then
+      -- Pure damage abilities
+      local ability_blacklist = {
+        "axe_counter_helix",
+        --"axe_culling_blade",
+        "bane_brain_sap",
+        "bane_enfeeble",
+        --"bane_fiends_grip",
+        "bloodseeker_blood_bath",
+        "bloodseeker_bloodrage", -- shard
+        --"bloodseeker_rupture",
+        --"doom_bringer_doom",
+        "enchantress_impetus",
+        --"enigma_black_hole",
+        "huskar_burning_spear", -- talent
+        "invoker_sun_strike",
+        --"jakiro_macropyre", -- scepter
+        "leshrac_diabolic_edict",
+        --"lina_laguna_blade", -- talent
+        "meepo_poof",
+        "meepo_ransack",
+        --"nyx_assassin_vendetta",
+        "omniknight_hammer_of_purity",
+        "omniknight_purification",
+        "phantom_assassin_fan_of_knives", -- shard
+        "pudge_meat_hook",
+        --"queenofpain_sonic_wave",
+        "spectre_desolate",
+        "spectre_spectral_dagger",
+        "templar_assassin_psi_blades",
+        --"shredder_chakram",
+        --"shredder_chakram_2",
+        "shredder_timber_chain",
+        "shredder_whirling_death",
+        "tinker_laser",
+        --"tinkerer_laser_contraption",
+        "warlock_golem_flaming_fists",
+        --"witch_doctor_death_ward_oaa",
+        --"witch_doctor_voodoo_switcheroo_oaa",
+      }
+
+      if damaging_ability and not damaging_ability:IsNull() and damage_type == DAMAGE_TYPE_PURE then
+        local name = damaging_ability:GetAbilityName()
+        for _, v in pairs(ability_blacklist) do
+          if name == v then
+            return -- don't return dmg
+          end
+        end
+      end
+    end
+
+    -- Interaction with Spell Immunity
+    if attacker:IsMagicImmune() then
+      if damaging_ability and not damaging_ability:IsNull() then
+        local kvs = damaging_ability:GetAbilityKeyValues()
+        if kvs and kvs.SpellImmunityType and (kvs.SpellImmunityType == "SPELL_IMMUNITY_ENEMIES_NO" or kvs.SpellImmunityType == "SPELL_IMMUNITY_ALLIES_YES_ENEMIES_NO") then
+          return -- don't return dmg
+        end
       end
     end
 
@@ -329,7 +443,7 @@ if IsServer() then
     if parent:HasModifier("modifier_item_blade_mail") then
       local blade_mail = parent:FindItemInInventory("item_blade_mail")
       if blade_mail then
-        if not blade_mail:IsInBackpack() then
+        if not blade_mail:IsInBackpack() and not damaging_ability then
           damage_return = damage_return - blade_mail:GetSpecialValueFor("passive_reflection_pct")
         end
       end
@@ -354,7 +468,7 @@ if IsServer() then
       attacker = parent,
       victim = attacker,
       damage = new_damage,
-      damage_type = event.damage_type, -- Same damage type as original damage
+      damage_type = damage_type, -- Same damage type as original damage
       damage_flags = bit.bor(damage_flags, DOTA_DAMAGE_FLAG_REFLECTION, DOTA_DAMAGE_FLAG_NO_SPELL_AMPLIFICATION, DOTA_DAMAGE_FLAG_NO_SPELL_LIFESTEAL, DOTA_DAMAGE_FLAG_BYPASSES_BLOCK),
       ability = ability,
     }


### PR DESCRIPTION
* Fixed Spiked Mail not reflecting damage of spells that have 'Pierces Debuff Immunity' set to 'No' in the spell tooltip.
* Fixed tooltips of Spiked Mail and BKB being wrong. Spiked Mail doesn't do damage through Debuff Immunity anymore. Immunity to reflected damage is a part of Debuff Immunity state and not independent like before. Thanks Valve.
* Buffed Spiked Mail because of this ^
* Stoneskin Armor active bonus armor increased from 100 to 100/200.