### PR TITLE
Spell block fixes

### DIFF
--- a/game/scripts/vscripts/abilities/neutrals/oaa_mini_rosh_passives.lua
+++ b/game/scripts/vscripts/abilities/neutrals/oaa_mini_rosh_passives.lua
@@ -108,8 +108,9 @@ if IsServer() then
       return 0
     end
 
-    -- Don't block if parent is invulnerable, dominated, under break of if parent is an illusion
-    if parent:IsInvulnerable() or parent:IsDominated() or parent:PassivesDisabled() or parent:IsIllusion() then
+    -- Don't block if parent is dominated, under break of if parent is an illusion
+    -- Some stuff pierce invulnerability (like Nullifier) so we need to block them too
+    if parent:IsDominated() or parent:PassivesDisabled() or parent:IsIllusion() then
       return 0
     end
 

--- a/game/scripts/vscripts/items/bubble_orb.lua
+++ b/game/scripts/vscripts/items/bubble_orb.lua
@@ -225,10 +225,16 @@ end
 if IsServer() then
   -- Spell block is done with modifier filter
   -- function modifier_item_preemptive_bubble_block:GetAbsorbSpell(keys)
-    -- local caster = keys.ability:GetCaster()
+    -- local ability = self:GetAbility()
+    -- local casted_ability = keys.ability
+    -- -- Don't block if we don't have required variables
+    -- if not ability or ability:IsNull() or not casted_ability or casted_ability:IsNull() then
+    --   return 0
+    -- end
+    -- local caster = casted_ability:GetCaster()
     -- local casterIsAlly = caster:GetTeamNumber() == self:GetParent():GetTeamNumber()
 
-    -- if casterIsAlly or IsUnitInBubble(caster, self.bubbleCenter, self:GetAbility()) then
+    -- if casterIsAlly or IsUnitInBubble(caster, self.bubbleCenter, ability) then
       -- return 0
     -- else
       -- self:PlayBlockEffect()

--- a/game/scripts/vscripts/items/reflection_shard.lua
+++ b/game/scripts/vscripts/items/reflection_shard.lua
@@ -157,41 +157,40 @@ end
 -- function modifier_item_reflection_shard_active:GetAbsoluteNoDamagePure()
   -- return 1
 -- end
+if IsServer() then
+  function modifier_item_reflection_shard_active:GetAbsorbSpell(event)
+    local parent = self:GetParent()
+    local casted_ability = event.ability
 
-function modifier_item_reflection_shard_active:GetAbsorbSpell(event)
-  local parent = self:GetParent()
-  local casted_ability = event.ability
-
-  if not casted_ability or casted_ability:IsNull() then
-    return 0
-  end
-
-  local caster = casted_ability:GetCaster()
-
-  -- Don't block allied spells
-  if caster:GetTeamNumber() == parent:GetTeamNumber() then
-    return 0
-  end
-
-  -- No need to block if parent is invulnerable
-  if parent:IsInvulnerable() or parent:IsOutOfGame() then
-    return 0
-  end
-
-  -- Sound
-  parent:EmitSound("Hero_Antimage.Counterspell.Target")
-
-  -- Particle
-  local burst = ParticleManager:CreateParticle("particles/items/reflection_shard/immunity_sphere_yellow.vpcf", PATTACH_ABSORIGIN, self:GetParent())
-  local duration = self:GetDuration()
-  Timers:CreateTimer(duration, function()
-    if burst then
-      ParticleManager:DestroyParticle(burst, false)
-      ParticleManager:ReleaseParticleIndex(burst)
+    -- Don't block if we don't have required variables
+    if not casted_ability or casted_ability:IsNull() then
+      return 0
     end
-  end)
 
-  return 1
+    local caster = casted_ability:GetCaster()
+
+    -- Don't block allied spells
+    if caster:GetTeamNumber() == parent:GetTeamNumber() then
+      return 0
+    end
+
+    -- Some stuff pierce invulnerability (like Nullifier) so we need to block them too
+
+    -- Sound
+    parent:EmitSound("Hero_Antimage.Counterspell.Target")
+
+    -- Particle
+    local burst = ParticleManager:CreateParticle("particles/items/reflection_shard/immunity_sphere_yellow.vpcf", PATTACH_ABSORIGIN, parent)
+    local duration = self:GetDuration()
+    Timers:CreateTimer(duration, function()
+      if burst then
+        ParticleManager:DestroyParticle(burst, false)
+        ParticleManager:ReleaseParticleIndex(burst)
+      end
+    end)
+
+    return 1
+  end
 end
 
 --[[

--- a/game/scripts/vscripts/modifiers/funmodifiers/modifier_roshan_power_oaa.lua
+++ b/game/scripts/vscripts/modifiers/funmodifiers/modifier_roshan_power_oaa.lua
@@ -158,6 +158,7 @@ if IsServer() then
     local parent = self:GetParent()
     local casted_ability = event.ability
 
+    -- Don't block if we don't have required variables
     if not casted_ability or casted_ability:IsNull() then
       return 0
     end
@@ -169,8 +170,9 @@ if IsServer() then
       return 0
     end
 
-    -- No need to block if parent is invulnerable
-    if parent:IsInvulnerable() or parent:IsOutOfGame() then
+    -- Don't block if parent is an illusion
+    -- Some stuff pierce invulnerability (like Nullifier) so we need to block them too
+    if parent:IsIllusion() then
       return 0
     end
 

--- a/game/scripts/vscripts/modifiers/funmodifiers/modifier_spell_block_oaa.lua
+++ b/game/scripts/vscripts/modifiers/funmodifiers/modifier_spell_block_oaa.lua
@@ -44,6 +44,7 @@ if IsServer() then
     local parent = self:GetParent()
     local casted_ability = event.ability
 
+    -- Don't block if we don't have required variables
     if not casted_ability or casted_ability:IsNull() then
       return 0
     end
@@ -55,8 +56,9 @@ if IsServer() then
       return 0
     end
 
-    -- No need to block if parent is invulnerable
-    if parent:IsInvulnerable() or parent:IsOutOfGame() then
+    -- Don't block if parent is an illusion
+    -- Some stuff pierce invulnerability (like Nullifier) so we need to block them too
+    if parent:IsIllusion() then
       return 0
     end
 


### PR DESCRIPTION
* Fixed Mini Roshan Tenacity spell block not blocking enemy single target abilities when Mini Roshan is invulnerable. (or when Doom that devoured Mini Roshan is invulnerable)
* Fixed Reflex Core spell block blocking allied single target abilities.
* Fixed Reflex Core spell block not blocking enemy single target abilities when the wearer is invulnerable.
* Fixed Reflex Core spell block working on illusions.
* Fixed Reflection Shard spell block code working on the clients.
* Fixed Reflection Shard spell block not blocking enemy single target abilities when the wearer is invulnerable.
* Fixed Roshan's Body modifier spell block not blocking enemy single target abilities when the owner is invulnerable.
* Fixed Spell Resistance modifier spell block not blocking enemy single target abilities when the owner is invulnerable.
* Reflex Core now disjoints projectiles when used.