### PR TITLE
Tinymode score limit fixes

### DIFF
--- a/game/scripts/vscripts/components/points/points.lua
+++ b/game/scripts/vscripts/components/points/points.lua
@@ -26,7 +26,7 @@ function PointsManager:Init ()
     self.limitConstant = 10
   elseif HeroSelection.lowPlayerCount then
     scoreLimit = ONE_V_ONE_KILL_LIMIT
-    self.limitConstant = 10
+    self.limitConstant = 14
   end
 
   scoreLimit = self.limitConstant + scoreLimit * PlayerResource:SafeGetTeamPlayerCount()
@@ -219,14 +219,14 @@ function PointsManager:IncreaseLimit(limit_increase)
   if HeroSelection.is10v10 then
     standard_extend_amount = player_count * TEN_V_TEN_LIMIT_INCREASE
   elseif HeroSelection.lowPlayerCount then
-    standard_extend_amount = player_count * ONE_V_ONE_LIMIT_INCREASE
+    standard_extend_amount = math.min(ONE_V_ONE_LIMIT_INCREASE * player_count, 6)
   end
   if not limit_increase then
     extend_amount = standard_extend_amount
   elseif type(limit_increase) == "number" then
     extend_amount = limit_increase
   elseif limit_increase == "grendel" then
-    extend_amount = math.floor(standard_extend_amount/2)
+    extend_amount = math.max(math.floor(standard_extend_amount/2), 1)
   else
     print("limit_increase argument must be a number or 'grendel' string! When ommited it will use the standard value.")
   end
@@ -282,7 +282,7 @@ function PointsManager:RefreshLimit()
     extend_amount = TEN_V_TEN_LIMIT_INCREASE * current_player_count
   elseif HeroSelection.lowPlayerCount then
     base_limit = ONE_V_ONE_KILL_LIMIT
-    extend_amount = ONE_V_ONE_LIMIT_INCREASE * current_player_count
+    extend_amount = math.min(ONE_V_ONE_LIMIT_INCREASE * current_player_count, 6)
   end
   -- Expected score limit with changed number of players connected:
   -- Expected behavior: Disconnects should reduce player_count and reconnects should increase player_count.

--- a/game/scripts/vscripts/settings.lua
+++ b/game/scripts/vscripts/settings.lua
@@ -36,11 +36,11 @@ ABANDON_NEEDED = 3                        -- how many total abandons you need be
 
 -- kill limits
 NORMAL_KILL_LIMIT = 3                     -- Starting KILL_LIMIT = 16 + NORMAL_KILL_LIMIT x number of players: 5v5 - 46; 4v4 - 40; 3v3 - 34; 2v2 - 28; 1v1 - 22;
-ONE_V_ONE_KILL_LIMIT = 6                  -- Starting KILL_LIMIT = 10 + ONE_V_ONE_KILL_LIMIT x number of players: 1v1 - 22; 2v2 - 34; 3v3 - 46; solo - 16;
+ONE_V_ONE_KILL_LIMIT = 3                  -- Starting KILL_LIMIT = 14 + ONE_V_ONE_KILL_LIMIT x number of players: 1v1 - 20; 2v2 - 26; 3v3 - 32; 4v4 - 38; solo - 17;
 TEN_V_TEN_KILL_LIMIT = 4                  -- Starting KILL_LIMIT = 10 + TEN_V_TEN_KILL_LIMIT x number of players: 6v6 - 58; 8v8 - 74; 10v10 - 90;
 KILL_LIMIT_INCREASE = 1                   -- Extend amount = KILL_LIMIT_INCREASE x number of players: 5v5 - 10; 4v4 - 8;
 TEN_V_TEN_LIMIT_INCREASE = 1              -- Extend amount = TEN_V_TEN_LIMIT_INCREASE x number of players: 10v10 - 20; 8v8 - 16; 6v6 - 12;
-ONE_V_ONE_LIMIT_INCREASE = 2              -- Extend amount = ONE_V_ONE_LIMIT_INCREASE x number of players: 1v1 - 4; solo - 2;
+ONE_V_ONE_LIMIT_INCREASE = 2              -- Extend amount = min(ONE_V_ONE_LIMIT_INCREASE x number of players, 6): 1v1 - 4; 2v2 - 6; 3v3 - 6; 4v4 - 6; solo - 2;
 
 -- poop wards
 POOP_WARD_DURATION = 360


### PR DESCRIPTION
* Changed tinymode starting score limit from 10 + 6 x number of players to 14 + 3 x number of players.
* Changed tinymode score limit extension from 2 x number of players to 6. (For 1v1 is still 4)
* Fixed Grendel extension being 0 when playing solo.