### PR TITLE
Minor item balance

### DIFF
--- a/game/scripts/npc/items/custom/item_giant_form.txt
+++ b/game/scripts/npc/items/custom/item_giant_form.txt
@@ -43,7 +43,7 @@
     "AbilityUnitDamageType"                               "DAMAGE_TYPE_MAGICAL"
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
-    "AbilityManaCost"                                     "75"
+    "AbilityManaCost"                                     "50"
     "AbilityCooldown"                                     "16"
     "AbilitySharedCooldown"                               "giant_form"
 
@@ -71,14 +71,14 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "bonus_damage"                                      "165 215"
+      "bonus_damage"                                      "150 200"
       "bonus_health_regen"                                "17 20"
       "bonus_attack_range_melee"                          "50 100" // doesn't work on ranged heroes
-      "cleave_percent"                                    "100" // doesn't work on ranged heroes
+      "cleave_percent"                                    "55 60" // doesn't work on ranged heroes
       "cleave_starting_width"                             "150"
       "cleave_ending_width"                               "360"
       "cleave_distance"                                   "650"
-      "giant_attack_damage"                               "140 190"
+      "giant_attack_damage"                               "150 200"
       "giant_primary_attribute_bonus"                     "55 75"
       "giant_attack_speed_reduction"                      "30" // percentage attack speed reduction
       "giant_splash_radius"

--- a/game/scripts/npc/items/custom/item_giant_form_2.txt
+++ b/game/scripts/npc/items/custom/item_giant_form_2.txt
@@ -43,7 +43,7 @@
     "AbilityUnitDamageType"                               "DAMAGE_TYPE_MAGICAL"
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
-    "AbilityManaCost"                                     "75"
+    "AbilityManaCost"                                     "50"
     "AbilityCooldown"                                     "16"
     "AbilitySharedCooldown"                               "giant_form"
 
@@ -63,14 +63,14 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "bonus_damage"                                      "165 215"
+      "bonus_damage"                                      "150 200"
       "bonus_health_regen"                                "17 20"
       "bonus_attack_range_melee"                          "50 100" // doesn't work on ranged heroes
-      "cleave_percent"                                    "100" // doesn't work on ranged heroes
+      "cleave_percent"                                    "55 60" // doesn't work on ranged heroes
       "cleave_starting_width"                             "150"
       "cleave_ending_width"                               "360"
       "cleave_distance"                                   "650"
-      "giant_attack_damage"                               "140 190"
+      "giant_attack_damage"                               "150 200"
       "giant_primary_attribute_bonus"                     "55 75"
       "giant_attack_speed_reduction"                      "30" // percentage attack speed reduction
       "giant_splash_radius"

--- a/game/scripts/npc/items/custom/item_martyrs_mail.txt
+++ b/game/scripts/npc/items/custom/item_martyrs_mail.txt
@@ -93,6 +93,7 @@
     "precache"
     {
       "particle"                                          "particles/world_shrine/radiant_shrine_active_ray.vpcf"
+      "particle"                                          "particles/items2_fx/martyrs_plate.vpcf"
     }
   }
 }

--- a/game/scripts/npc/items/custom/item_reduction_orb.txt
+++ b/game/scripts/npc/items/custom/item_reduction_orb.txt
@@ -57,6 +57,11 @@
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
     "ItemDeclarations"                                    "DECLARE_PURCHASES_TO_SPECTATORS"
 
+    "precache"
+    {
+      "particle"                                          "particles/status_fx/status_effect_glow_white_over_time.vpcf"
+    }
+
     // Special
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"

--- a/game/scripts/npc/items/custom/item_silver_staff.txt
+++ b/game/scripts/npc/items/custom/item_silver_staff.txt
@@ -70,8 +70,8 @@
       "bonus_all_stats"                                   "22 27"
       "bonus_armor"                                       "8 12"
       "base_damage"                                       "95 135"
-      "max_hp_damage"                                     "4 5"
-      "duration"                                          "4.0"
+      "max_hp_damage"                                     "4 4.5"
+      "duration"                                          "5.0"
     }
   }
 }

--- a/game/scripts/npc/items/custom/item_silver_staff_2.txt
+++ b/game/scripts/npc/items/custom/item_silver_staff_2.txt
@@ -70,8 +70,8 @@
       "bonus_all_stats"                                   "22 27"
       "bonus_armor"                                       "8 12"
       "base_damage"                                       "95 135"
-      "max_hp_damage"                                     "4 5"
-      "duration"                                          "4.0"
+      "max_hp_damage"                                     "4 4.5"
+      "duration"                                          "5.0"
     }
   }
 }

--- a/game/scripts/npc/items/custom/item_sonic.txt
+++ b/game/scripts/npc/items/custom/item_sonic.txt
@@ -35,7 +35,7 @@
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
     "AbilityManaCost"                                     "50"
-    "AbilityCooldown"                                     "16"
+    "AbilityCooldown"                                     "15"
     "AbilitySharedCooldown"                               "sonic"
 
     "MaxUpgradeLevel"                                     "2"
@@ -54,10 +54,10 @@
       "bonus_movement_speed"                              "75 80"
       "bonus_attack_speed"                                "40 45"
       "bonus_agility"                                     "55 75"
-      "bonus_damage"                                      "75 105"
+      "bonus_damage"                                      "80 120"
       "active_speed_bonus"                                "35 40"
       "active_cast_speed"                                 "25 30"
-      "duration"                                          "6"
+      "duration"                                          "5"
     }
 
     "precache"

--- a/game/scripts/npc/items/custom/item_sonic_2.txt
+++ b/game/scripts/npc/items/custom/item_sonic_2.txt
@@ -31,7 +31,7 @@
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
     "AbilityManaCost"                                     "50"
-    "AbilityCooldown"                                     "16"
+    "AbilityCooldown"                                     "15"
     "AbilitySharedCooldown"                               "sonic"
 
     "MaxUpgradeLevel"                                     "2"
@@ -50,10 +50,10 @@
       "bonus_movement_speed"                              "75 80"
       "bonus_attack_speed"                                "40 45"
       "bonus_agility"                                     "55 75"
-      "bonus_damage"                                      "75 105"
+      "bonus_damage"                                      "80 120"
       "active_speed_bonus"                                "35 40"
       "active_cast_speed"                                 "25 30"
-      "duration"                                          "6"
+      "duration"                                          "5"
     }
   }
 }

--- a/game/scripts/npc/items/custom/item_trumps_fists.txt
+++ b/game/scripts/npc/items/custom/item_trumps_fists.txt
@@ -48,7 +48,7 @@
     "AbilityCastRange"                                    "800"
     "AbilityCooldown"                                     "20"
     "AbilitySharedCooldown"                               "judecca"
-    "AbilityManaCost"                                     "100"
+    "AbilityManaCost"                                     "150"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------
@@ -71,8 +71,8 @@
     {
       "bonus_damage"                                      "37 42"
       "bonus_all_stats"                                   "0"
-      "bonus_health"                                      "1400 1700"
-      "bonus_mana"                                        "1100 1400"
+      "bonus_health"                                      "1450 1750"
+      "bonus_mana"                                        "1150 1450"
       "heal_prevent_percent"                              "55 65"
       "heal_prevent_duration"                             "3"
       "mute_duration"                                     "3 3.5"

--- a/game/scripts/npc/items/custom/item_trumps_fists_2.txt
+++ b/game/scripts/npc/items/custom/item_trumps_fists_2.txt
@@ -48,7 +48,7 @@
     "AbilityCastRange"                                    "800"
     "AbilityCooldown"                                     "20"
     "AbilitySharedCooldown"                               "judecca"
-    "AbilityManaCost"                                     "100"
+    "AbilityManaCost"                                     "150"
 
     // Spicy Parameters
     //-------------------------------------------------------------------------------------------------------------
@@ -70,8 +70,8 @@
     {
       "bonus_damage"                                      "37 42"
       "bonus_all_stats"                                   "0"
-      "bonus_health"                                      "1400 1700"
-      "bonus_mana"                                        "1100 1400"
+      "bonus_health"                                      "1450 1750"
+      "bonus_mana"                                        "1150 1450"
       "heal_prevent_percent"                              "55 65"
       "heal_prevent_duration"                             "3"
       "mute_duration"                                     "3 3.5"

--- a/game/scripts/npc/items/item_abyssal_blade.txt
+++ b/game/scripts/npc/items/item_abyssal_blade.txt
@@ -60,7 +60,7 @@
     "AbilityValues"
     {
       "bonus_damage"                                      "10 20 40 70 110" //OAA
-      "bonus_health"                                      "220 320 470 670 920" //OAA, inherited from Skadi
+      "bonus_health"                                      "250 350 500 700 950" //OAA, inherited from Skadi
       "bonus_health_regen"                                "3 6 9 12 15" //OAA
       "block_damage_melee"                                "70 120 170 220 270"
       "block_damage_ranged"                               "35 70 105 140 175"

--- a/game/scripts/npc/items/item_abyssal_blade_2.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_2.txt
@@ -63,7 +63,7 @@
     "AbilityValues"
     {
       "bonus_damage"                                      "10 20 40 70 110"
-      "bonus_health"                                      "220 320 470 670 920"
+      "bonus_health"                                      "250 350 500 700 950"
       "bonus_health_regen"                                "3 6 9 12 15"
       "block_damage_melee"                                "70 120 170 220 270"
       "block_damage_ranged"                               "35 70 105 140 175"

--- a/game/scripts/npc/items/item_abyssal_blade_3.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_3.txt
@@ -63,7 +63,7 @@
     "AbilityValues"
     {
       "bonus_damage"                                      "10 20 40 70 110"
-      "bonus_health"                                      "220 320 470 670 920"
+      "bonus_health"                                      "250 350 500 700 950"
       "bonus_health_regen"                                "3 6 9 12 15"
       "block_damage_melee"                                "70 120 170 220 270"
       "block_damage_ranged"                               "35 70 105 140 175"

--- a/game/scripts/npc/items/item_abyssal_blade_4.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_4.txt
@@ -63,7 +63,7 @@
     "AbilityValues"
     {
       "bonus_damage"                                      "10 20 40 70 110"
-      "bonus_health"                                      "220 320 470 670 920"
+      "bonus_health"                                      "250 350 500 700 950"
       "bonus_health_regen"                                "3 6 9 12 15"
       "block_damage_melee"                                "70 120 170 220 270"
       "block_damage_ranged"                               "35 70 105 140 175"

--- a/game/scripts/npc/items/item_abyssal_blade_5.txt
+++ b/game/scripts/npc/items/item_abyssal_blade_5.txt
@@ -62,7 +62,7 @@
     "AbilityValues"
     {
       "bonus_damage"                                      "10 20 40 70 110"
-      "bonus_health"                                      "220 320 470 670 920"
+      "bonus_health"                                      "250 350 500 700 950"
       "bonus_health_regen"                                "3 6 9 12 15"
       "block_damage_melee"                                "70 120 170 220 270"
       "block_damage_ranged"                               "35 70 105 140 175"

--- a/game/scripts/vscripts/items/reduction_orb.lua
+++ b/game/scripts/vscripts/items/reduction_orb.lua
@@ -110,32 +110,40 @@ end
 
 function modifier_item_reduction_orb_active:DeclareFunctions()
   return {
-    --MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE,
-    MODIFIER_PROPERTY_TOTAL_CONSTANT_BLOCK,
+    MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE,
+    --MODIFIER_PROPERTY_TOTAL_CONSTANT_BLOCK,
     MODIFIER_PROPERTY_MODEL_SCALE
   }
 end
 
---function modifier_item_reduction_orb_active:GetModifierIncomingDamage_Percentage(event)
+function modifier_item_reduction_orb_active:GetModifierIncomingDamage_Percentage(event)
+  if not IsServer() then
+    return
+  end
 
-  --self.endHeal = self.endHeal + event.original_damage * self.damageheal / 100
+  local damage_before = event.original_damage
+  if damage_before > 0 then
+    self.endHeal = self.endHeal + damage_before * self.damageheal / 100
+  end
 
-  --return self.damageReduction * -1
---end
+  return 0 - self.damageReduction
+end
 
+--[[
 function modifier_item_reduction_orb_active:GetModifierTotal_ConstantBlock(event)
   if not IsServer() then
     return
   end
 
   local parent = self:GetParent()
-  local damage = math.max(event.original_damage, event.damage)
+  local damage_before = event.original_damage
+  local damage_after = event.damage
 
-  if damage > 0 then
-    self.endHeal = self.endHeal + damage * self.damageheal / 100
+  if damage_before > 0 then
+    self.endHeal = self.endHeal + damage_before * self.damageheal / 100
   end
 
-  local block_amount = damage * self.damageReduction / 100
+  local block_amount = damage_after * self.damageReduction / 100
 
   if block_amount > 0 then
     -- Visual effect
@@ -149,6 +157,7 @@ function modifier_item_reduction_orb_active:GetModifierTotal_ConstantBlock(event
 
   return block_amount
 end
+]]
 
 function modifier_item_reduction_orb_active:GetModifierModelScale()
   return -30

--- a/game/scripts/vscripts/precache.lua
+++ b/game/scripts/vscripts/precache.lua
@@ -25,6 +25,7 @@ g_ItemPrecache = {
   "item_martyrs_mail_1",
   --"item_meteor_hammer_1",
   --"item_pull_staff",
+  "item_reduction_orb_1",
   "item_reflection_shard_1",
   --"item_reflex_core",
   "item_regen_crystal_1",


### PR DESCRIPTION
* Abyssal Blade bonus hp by 30. (total hp now same as Skadi)
* Blade of Judecca bonus hp and mana increased by 50. (40 less hp and mana than Skadi)
* Blade of Judecca mana cost increased from 100 to 150.
* Giant Form active bonus damage increased from 140/190 to 150/200.
* Giant Form mana cost reduced from 75 to 50.
* Giant Form passive bonus damage reduced from 165/215 to 150/200.
* Giant Form passive cleave reduced from 100% to 55/60%.
* Reduction Orb: Fixed the buff granting damage shield instead of damage reduction.
* Silver Staff debuff duration increased from 4 to 5 seconds.
* Silver Staff debuff max hp dmg reduced at max level from 5% to 4.5%
* Sonic Mask active duration reduced from 6 to 5 seconds.
* Sonic Mask bonus damage increased from 75/105 to 80/120.
* Sonic Mask cooldown reduced from 16 to 15 seconds.