### PR TITLE
Minor boss changes

### DIFF
--- a/game/scripts/npc/abilities/boss/alchemist/boss_alchemist_acid_spray.txt
+++ b/game/scripts/npc/abilities/boss/alchemist/boss_alchemist_acid_spray.txt
@@ -48,7 +48,7 @@
       "03"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage_per_second"                               "300"
+        "damage_per_second"                               "350"
       }
       "04"
       {

--- a/game/scripts/npc/abilities/boss/alchemist/boss_alchemist_cannonshot.txt
+++ b/game/scripts/npc/abilities/boss/alchemist/boss_alchemist_cannonshot.txt
@@ -38,7 +38,7 @@
       "01"
       {
         "var_type"                                        "FIELD_INTEGER"
-        "damage"                                          "1875"
+        "damage"                                          "2000"
       }
       "02"
       {

--- a/game/scripts/npc/abilities/boss/alchemist/boss_alchemist_chemical_rage.txt
+++ b/game/scripts/npc/abilities/boss/alchemist/boss_alchemist_chemical_rage.txt
@@ -23,43 +23,15 @@
 
     // Special
     //-------------------------------------------------------------------------------------------------------------
-    "AbilitySpecial"
+    "AbilityValues"
     {
-      "01"
-      {
-        "var_type"                                        "FIELD_FLOAT"
-        "duration"                                        "25.0"
-      }
-      "02"
-      {
-        "var_type"                                        "FIELD_FLOAT"
-        "transformation_time"                             "0.35"
-      }
-      "03"
-      {
-        "var_type"                                        "FIELD_FLOAT"
-        "base_attack_time"                                "1.0"
-      }
-      "04"
-      {
-        "var_type"                                        "FIELD_INTEGER"
-        "bonus_health"                                    "0"
-      }
-      "05"
-      {
-        "var_type"                                        "FIELD_INTEGER"
-        "bonus_health_regen"                              "100"
-      }
-      "06"
-      {
-        "var_type"                                        "FIELD_FLOAT"
-        "bonus_mana_regen"                                "0"
-      }
-      "07"
-      {
-        "var_type"                                        "FIELD_INTEGER"
-        "bonus_movespeed"                                 "500"
-      }
+      "duration"                                          "25"
+      "transformation_time"                               "0.35"
+      "base_attack_time"                                  "1.0"
+      "bonus_health"                                      "0"
+      "bonus_health_regen"                                "150"
+      "bonus_mana_regen"                                  "0"
+      "bonus_movespeed"                                   "400"
     }
   }
 }

--- a/game/scripts/npc/units/boss/alchemist/alchemist_boss.txt
+++ b/game/scripts/npc/units/boss/alchemist/alchemist_boss.txt
@@ -26,7 +26,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "32"            // Physical protection.
+    "ArmorPhysical"                                       "37"            // Physical protection.
     "MagicalResistance"                                   "-25"           // Magical protection (percentage).
 
     // Attack
@@ -34,7 +34,7 @@
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_MELEE_ATTACK"
     "AttackDamageMin"                                     "2500"       // Damage range min.
     "AttackDamageMax"                                     "2500"       // Damage range max.
-    "AttackRate"                                          "2.5"       // BAT
+    "AttackRate"                                          "1.7"       // BAT (this value isnt used unless Taunted)
     "BaseAttackSpeed"                                     "300"       // Attack Speed
     "AttackAnimationPoint"                                "0.3"       // Normalized time in animation cycle to attack.
     "AttackAcquisitionRange"                              "150"       // Range within a target can be acquired.
@@ -42,7 +42,7 @@
 
     // Bounty
     //----------------------------------------------------------------
-    "BountyXP"                                            "3000"  // Experience earn.
+    "BountyXP"                                            "4000"  // Experience earn.
     "BountyGoldMin"                                       "0"     // Gold earned min.
     "BountyGoldMax"                                       "0"     // Gold earned max.
 
@@ -60,16 +60,15 @@
 
     // Status
     //----------------------------------------------------------------
-    "StatusHealth"                                        "10000"     // Base health
+    "StatusHealth"                                        "20000"     // Base health
     "StatusHealthRegen"                                   "0"        // Health regeneration rate.
-    "StatusMana"                                          "5000"     // Base mana.
-    "StatusManaRegen"                                     "10"     // Mana regeneration rate.
+    "StatusMana"                                          "10000"     // Base mana.
+    "StatusManaRegen"                                     "20"     // Mana regeneration rate.
 
     // Creature data
     "Creature"
     {
-      // Makes it only have 50% remaining of applied crowd control
-      "DisableResistance"                                 "50.0"
+      "DisableResistance"                                 "65.0"
       "AttachWearables" // Default npc_dota_hero_alchemist
       {
         "1" // Alchemist's Goblin Head

--- a/game/scripts/npc/units/boss/spooky_ghost.txt
+++ b/game/scripts/npc/units/boss/spooky_ghost.txt
@@ -69,7 +69,6 @@
     // Creature data
     "Creature"
     {
-      // Makes it only have 50% remaining of applied crowd control
       "DisableResistance"                                 "65.0"
     }
 

--- a/game/scripts/vscripts/components/boss/bosses.lua
+++ b/game/scripts/vscripts/components/boss/bosses.lua
@@ -47,17 +47,17 @@ Bosses = {
       "npc_dota_boss_carapace",
     },
     {
-      --"npc_dota_creature_ogre_tank_boss",
+      "npc_dota_creature_ogre_tank_boss",
       "npc_dota_creature_lycan_boss",
-      "npc_dota_boss_spiders", -- Alchemist Boss
       "npc_dota_creature_magma_boss",
     },
     {
-      "npc_dota_boss_tier_4", -- Killer Tomato
+      --"npc_dota_boss_tier_4", -- Killer Tomato
       "npc_dota_creature_spider_boss",
       "npc_dota_creature_temple_guardian_spawner",
       "npc_dota_boss_stopfightingyourself",
       "npc_dota_boss_tier_6", -- Spooky Ghost
+      "npc_dota_boss_spiders", -- Alchemist Boss
     },
     {
       "npc_dota_boss_simple_1_tier5", -- Tier 5 Skeleton Boss (Geostrike)
@@ -90,17 +90,17 @@ Bosses = {
       "npc_dota_boss_carapace",
     },
     {
-      --"npc_dota_creature_ogre_tank_boss",
+      "npc_dota_creature_ogre_tank_boss",
       "npc_dota_creature_lycan_boss",
-      "npc_dota_boss_spiders",
       "npc_dota_creature_magma_boss",
     },
     {
-      "npc_dota_boss_tier_4",
+      --"npc_dota_boss_tier_4",
       "npc_dota_creature_spider_boss",
       "npc_dota_creature_temple_guardian_spawner",
       "npc_dota_boss_stopfightingyourself",
       "npc_dota_boss_tier_6",
+      "npc_dota_boss_spiders",
     },
     {
       "npc_dota_boss_simple_1_tier5", -- Geostrike
@@ -128,17 +128,17 @@ Bosses = {
       "npc_dota_boss_carapace",
     },
     {
-      --"npc_dota_creature_ogre_tank_boss",
+      "npc_dota_creature_ogre_tank_boss",
       "npc_dota_creature_lycan_boss",
-      "npc_dota_boss_spiders",
       "npc_dota_creature_magma_boss",
     },
     {
-      "npc_dota_boss_tier_4",
+      --"npc_dota_boss_tier_4",
       "npc_dota_creature_spider_boss",
       "npc_dota_creature_temple_guardian_spawner",
       "npc_dota_boss_stopfightingyourself",
       "npc_dota_boss_tier_6",
+      "npc_dota_boss_spiders",
     },
     {
       "npc_dota_boss_simple_1_tier5", -- Geostrike
@@ -157,17 +157,17 @@ Bosses = {
   -----------------------------
   {
     {
-      --"npc_dota_creature_ogre_tank_boss",
+      "npc_dota_creature_ogre_tank_boss",
       "npc_dota_creature_lycan_boss",
-      "npc_dota_boss_spiders",
       "npc_dota_creature_magma_boss",
     },
     {
-      "npc_dota_boss_tier_4",
+      --"npc_dota_boss_tier_4",
       "npc_dota_creature_spider_boss",
       "npc_dota_creature_temple_guardian_spawner",
       "npc_dota_boss_stopfightingyourself",
       "npc_dota_boss_tier_6",
+      "npc_dota_boss_spiders",
     },
     {
       "npc_dota_boss_simple_1_tier5", -- Geostrike
@@ -188,7 +188,6 @@ Bosses = {
     {
       "npc_dota_creature_ogre_tank_boss",
       "npc_dota_creature_lycan_boss",
-      "npc_dota_boss_spiders",
       "npc_dota_creature_magma_boss",
     },
     {
@@ -197,6 +196,7 @@ Bosses = {
       "npc_dota_creature_temple_guardian_spawner",
       "npc_dota_boss_stopfightingyourself",
       "npc_dota_boss_tier_6",
+      "npc_dota_boss_spiders",
     },
     {
       "npc_dota_boss_simple_1_tier5", -- Geostrike
@@ -218,7 +218,6 @@ Bosses = {
     {
       "npc_dota_creature_ogre_tank_boss",
       "npc_dota_creature_lycan_boss",
-      "npc_dota_boss_spiders",
       "npc_dota_creature_magma_boss",
     },
     {
@@ -227,6 +226,7 @@ Bosses = {
       "npc_dota_creature_temple_guardian_spawner",
       "npc_dota_boss_stopfightingyourself",
       "npc_dota_boss_tier_6",
+      "npc_dota_boss_spiders",
     },
     {
       "npc_dota_boss_simple_1_tier5", -- Geostrike

--- a/game/scripts/vscripts/units/ai_alchemist.lua
+++ b/game/scripts/vscripts/units/ai_alchemist.lua
@@ -47,7 +47,7 @@ function AlchemistThink()
       table.insert(thisEntity.vPath, thisEntity:GetOrigin() + PointOnCircle(250, 360 / 12 * i))
     end
     thisEntity.lastRoamPoint = thisEntity.spawn_position
-    thisEntity.BossTier = thisEntity.BossTier or 3
+    thisEntity.BossTier = thisEntity.BossTier or 4
     thisEntity.SiltBreakerProtection = true
     thisEntity.state = SIMPLE_AI_STATE_IDLE
     thisEntity.aggro_target = nil


### PR DESCRIPTION
Killer Tomato boss will no longer spawn outside of bases. 
Ogre Tank boss (tier 3) can now spawn outside of bases again. 
Alchemist boss:
- now a tier 4 boss (stats like other tier 4 bosses except attack damage which is unchanged)
- Acid Spray dps increased from 300 to 350.
- Cannonshot damage increased from 1875 to 2000.
- Chemical Rage hp regen increased from 100 to 150.