### PR TITLE
Making Reflection Shard more viable

### DIFF
--- a/game/resource/English/ability/items/tooltip_reflection_shard.txt
+++ b/game/resource/English/ability/items/tooltip_reflection_shard.txt
@@ -3,7 +3,7 @@
 //==========================================
 "DOTA_Tooltip_Ability_item_reflection_shard_1"                                  "Reflection Shard"
 "DOTA_Tooltip_Ability_item_recipe_reflection_shard_1"                           "Reflection Shard Recipe"
-"DOTA_Tooltip_Ability_item_reflection_shard_1_Description"                      "<h1>Active: Riposte</h1> Grants immunity to magic damage and reflects single target spells for %duration% seconds.<br>Dispel Type: <span class=\"GameplayValues GameplayVariable\">Basic Dispel</span>"
+"DOTA_Tooltip_Ability_item_reflection_shard_1_Description"                      "<h1>Active: Riposte</h1> Blocks damage from all spells and reflects single target spells for %duration% seconds.<br>Dispel Type: <span class=\"GameplayValues GameplayVariable\">Basic Dispel</span>"
 //"DOTA_Tooltip_Ability_item_reflection_shard_1_Note0"                            "Cannot reflect channeling or already reflected spells."
 "DOTA_Tooltip_Ability_item_reflection_shard_1_Lore"                             "A chromatic shard from another dimension."
 "DOTA_Tooltip_Ability_item_reflection_shard_1_bonus_strength"                   "+$str"

--- a/game/scripts/npc/items/custom/item_reflection_shard_1.txt
+++ b/game/scripts/npc/items/custom/item_reflection_shard_1.txt
@@ -42,7 +42,7 @@
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "18"
+    "AbilityCooldown"                                     "20"
     "AbilitySharedCooldown"                               "reflection_shard"
     "AbilityManaCost"                                     "45"
 

--- a/game/scripts/npc/items/custom/item_reflection_shard_2.txt
+++ b/game/scripts/npc/items/custom/item_reflection_shard_2.txt
@@ -42,7 +42,7 @@
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "18"
+    "AbilityCooldown"                                     "20"
     "AbilitySharedCooldown"                               "reflection_shard"
     "AbilityManaCost"                                     "45"
 

--- a/game/scripts/npc/items/custom/item_reflection_shard_3.txt
+++ b/game/scripts/npc/items/custom/item_reflection_shard_3.txt
@@ -42,7 +42,7 @@
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "18"
+    "AbilityCooldown"                                     "20"
     "AbilitySharedCooldown"                               "reflection_shard"
     "AbilityManaCost"                                     "45"
 

--- a/game/scripts/npc/items/custom/item_reflection_shard_4.txt
+++ b/game/scripts/npc/items/custom/item_reflection_shard_4.txt
@@ -42,7 +42,7 @@
 
     // Stats
     //-------------------------------------------------------------------------------------------------------------
-    "AbilityCooldown"                                     "18"
+    "AbilityCooldown"                                     "20"
     "AbilitySharedCooldown"                               "reflection_shard"
     "AbilityManaCost"                                     "45"
 

--- a/game/scripts/vscripts/items/reflection_shard.lua
+++ b/game/scripts/vscripts/items/reflection_shard.lua
@@ -142,10 +142,11 @@ end
 function modifier_item_reflection_shard_active:DeclareFunctions()
   return {
     --MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_PHYSICAL,
-    MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_MAGICAL,
+    --MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_MAGICAL,
     --MODIFIER_PROPERTY_ABSOLUTE_NO_DAMAGE_PURE,
     MODIFIER_PROPERTY_ABSORB_SPELL,
     --MODIFIER_PROPERTY_REFLECT_SPELL,
+    MODIFIER_PROPERTY_TOTAL_CONSTANT_BLOCK,
   }
 end
 
@@ -153,9 +154,9 @@ end
   -- return 1
 -- end
 
-function modifier_item_reflection_shard_active:GetAbsoluteNoDamageMagical()
-  return 1
-end
+-- function modifier_item_reflection_shard_active:GetAbsoluteNoDamageMagical()
+  -- return 1
+-- end
 
 -- function modifier_item_reflection_shard_active:GetAbsoluteNoDamagePure()
   -- return 1
@@ -193,6 +194,26 @@ if IsServer() then
     end)
 
     return 1
+  end
+
+  function modifier_item_reflection_shard_active:GetModifierTotal_ConstantBlock(event)
+    local ability = self:GetAbility()
+    local attacker = event.attacker
+
+    -- Check if attacker and ability exist
+    if not attacker or attacker:IsNull() or not ability or ability:IsNull() then
+      return 0
+    end
+
+    local dmg_after_reductions = event.damage
+    local damage_category = event.damage_category
+
+    -- Block only spell damage
+    if damage_category ~= DOTA_DAMAGE_CATEGORY_SPELL then
+      return 0
+    end
+
+    return dmg_after_reductions
   end
 end
 


### PR DESCRIPTION
- Active now blocks damage from all spells (all damage types) not just magical.
- Active no longer blocks damage from magical attacks. (e.g. Revenants Brooch)
- Cooldown increased from 18 to 20 seconds.