### PR TITLE
Fixes for core points display bugs

### DIFF
--- a/content/panorama/scripts/custom_game/core_points.js
+++ b/content/panorama/scripts/custom_game/core_points.js
@@ -1,25 +1,43 @@
-/* global $, GameEvents, Players, HasModifier, GetStackCount, Game */
+/* global $, GameEvents, Players, HasModifier, GetStackCount, Game, Entities */
 
 'use strict';
 
+// this should trigger when a player gains or loses core points and only if currently selected unit is player's hero
 function OnCorePointsChanged (args) {
-  const unit = Players.GetLocalPlayerPortraitUnit();
+  const currentlySelectedUnit = Players.GetLocalPlayerPortraitUnit();
+  if (currentlySelectedUnit !== Players.GetPlayerHeroEntityIndex(Players.GetLocalPlayer())) return;
   const modifier = 'modifier_core_points_counter_oaa';
   const cpLabel = $('#CorePointsText');
-  let corePoints = args.cp;
-  if (HasModifier(unit, modifier)) {
+  const corePoints = args.cp;
+  if (typeof corePoints === 'number' || typeof corePoints === 'string') {
+    cpLabel.text = corePoints;
+  } else {
+    ShowCorePointsOnSelected();
+  }
+}
+
+// this should trigger when a player selects any unit
+function ShowCorePointsOnSelected () {
+  const currentlySelectedUnit = Players.GetLocalPlayerPortraitUnit();
+  // If selected unit is invalid don't continue
+  if (!Entities.IsValidEntity(currentlySelectedUnit)) return;
+  const modifier = 'modifier_core_points_counter_oaa';
+  const cpLabel = $('#CorePointsText');
+  // Show core points only if selected unit is on player's team
+  if (HasModifier(currentlySelectedUnit, modifier) && Entities.GetTeamNumber(currentlySelectedUnit) !== Players.GetTeam(Players.GetLocalPlayer())) {
     $.Schedule(0.03, function () {
-      corePoints = GetStackCount(unit, modifier);
+      const corePoints = GetStackCount(currentlySelectedUnit, modifier);
       cpLabel.text = corePoints;
     });
+  } else {
+    cpLabel.text = 0;
   }
-
-  cpLabel.text = corePoints;
 }
 
 (function () {
   GameEvents.Subscribe('core_point_number_changed', OnCorePointsChanged);
-  OnCorePointsChanged({ cp: '-' });
+  GameEvents.Subscribe('dota_player_update_query_unit', ShowCorePointsOnSelected);
+  GameEvents.Subscribe('dota_player_update_selected_unit', ShowCorePointsOnSelected);
 
   if (Game.IsHUDFlipped()) {
     const context = $.GetContextPanel();

--- a/content/panorama/scripts/custom_game/core_points.js
+++ b/content/panorama/scripts/custom_game/core_points.js
@@ -2,27 +2,29 @@
 
 'use strict';
 
-// this should trigger when a player gains or loses core points and only if currently selected unit is player's hero
+// this happens for every core points change
 function OnCorePointsChanged (args) {
   const currentlySelectedUnit = Players.GetLocalPlayerPortraitUnit();
+  // If currently selected unit is not the player's hero then don't continue
   if (currentlySelectedUnit !== Players.GetPlayerHeroEntityIndex(Players.GetLocalPlayer())) return;
   const cpLabel = $('#CorePointsText');
   const corePoints = args.cp;
   if (typeof corePoints === 'number' || typeof corePoints === 'string') {
     cpLabel.text = corePoints;
   } else {
+    // Received argument is invalid, do stuff below
     ShowCorePointsOnSelected();
   }
 }
 
-// this should trigger when a player selects any unit
+// this happens when a player selects any unit
 function ShowCorePointsOnSelected () {
   const currentlySelectedUnit = Players.GetLocalPlayerPortraitUnit();
-  // If selected unit is invalid don't continue
+  // If currently selected unit is invalid then don't continue
   if (!Entities.IsValidEntity(currentlySelectedUnit)) return;
   const modifier = 'modifier_core_points_counter_oaa';
   const cpLabel = $('#CorePointsText');
-  // Show core points only if selected unit is on player's team
+  // Show core points only if currently selected unit has the modifier and if it is on the player's team
   if (HasModifier(currentlySelectedUnit, modifier) && Entities.GetTeamNumber(currentlySelectedUnit) === Players.GetTeam(Players.GetLocalPlayer())) {
     $.Schedule(0.03, function () {
       const corePoints = GetStackCount(currentlySelectedUnit, modifier);

--- a/content/panorama/scripts/custom_game/core_points.js
+++ b/content/panorama/scripts/custom_game/core_points.js
@@ -24,7 +24,7 @@ function ShowCorePointsOnSelected () {
   const modifier = 'modifier_core_points_counter_oaa';
   const cpLabel = $('#CorePointsText');
   // Show core points only if selected unit is on player's team
-  if (HasModifier(currentlySelectedUnit, modifier) && Entities.GetTeamNumber(currentlySelectedUnit) !== Players.GetTeam(Players.GetLocalPlayer())) {
+  if (HasModifier(currentlySelectedUnit, modifier) && Entities.GetTeamNumber(currentlySelectedUnit) === Players.GetTeam(Players.GetLocalPlayer())) {
     $.Schedule(0.03, function () {
       const corePoints = GetStackCount(currentlySelectedUnit, modifier);
       cpLabel.text = corePoints;

--- a/content/panorama/scripts/custom_game/core_points.js
+++ b/content/panorama/scripts/custom_game/core_points.js
@@ -6,7 +6,6 @@
 function OnCorePointsChanged (args) {
   const currentlySelectedUnit = Players.GetLocalPlayerPortraitUnit();
   if (currentlySelectedUnit !== Players.GetPlayerHeroEntityIndex(Players.GetLocalPlayer())) return;
-  const modifier = 'modifier_core_points_counter_oaa';
   const cpLabel = $('#CorePointsText');
   const corePoints = args.cp;
   if (typeof corePoints === 'number' || typeof corePoints === 'string') {


### PR DESCRIPTION
- When selecting enemies or non-hero units the indicator will now always show 0 core points. (improvement)
- When deselecting allies and enemies the indicator will now properly refresh and show the real amount of your core points. (1st bug fix)
- When your hero isn't selected and when you or selected hero gains/uses/sells core points, real-time change of core points on the selected hero will no longer be shown. (2nd bug fix) 
Note: You need to select your own hero to see the new and correct amount of core points. If you are interested to see the correct amount on the selected ally, just re-select him.