### PR TITLE
Dire Tower Boss buffs

### DIFF
--- a/game/scripts/npc/abilities/boss/dire_tower_boss/dire_tower_boss_passives.txt
+++ b/game/scripts/npc/abilities/boss/dire_tower_boss/dire_tower_boss_passives.txt
@@ -13,6 +13,11 @@
     "SpellDispellableType"                                "SPELL_DISPELLABLE_NO"
 
     "MaxLevel"                                            "1"
+
+    "AbilityValues"
+    {
+      "bonus_magic_resistance"                            "25"
+    }
   }
 
 }

--- a/game/scripts/npc/units/boss/dire_tower_boss/dire_tower_boss.txt
+++ b/game/scripts/npc/units/boss/dire_tower_boss/dire_tower_boss.txt
@@ -23,8 +23,9 @@
     "Ability1"                                            "dire_tower_boss_summon_wave"
     "Ability2"                                            "dire_tower_boss_glyph"
     "Ability3"                                            "dire_tower_boss_passives"
-    "Ability4"                                            "boss_basic_properties_oaa"
-    "Ability5"                                            "boss_regen"
+    "Ability4"                                            "boss_unslowable_attack_speed"
+    "Ability5"                                            "boss_basic_properties_oaa"
+    "Ability6"                                            "boss_regen"
 
     // Armor
     //----------------------------------------------------------------
@@ -34,8 +35,8 @@
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_RANGED_ATTACK"
-    "AttackDamageMin"                                     "1500"    // Damage range min.
-    "AttackDamageMax"                                     "1500"    // Damage range max.
+    "AttackDamageMin"                                     "1620"    // Damage range min.
+    "AttackDamageMax"                                     "1620"    // Damage range max.
     "BaseAttackSpeed"                                     "110"
     "AttackRate"                                          "0.9"   // Speed of attack.
     "AttackAnimationPoint"                                "0.6"   // Normalized time in animation cycle to attack.

--- a/game/scripts/npc/units/boss/dire_tower_boss/ranged_wave_creep.txt
+++ b/game/scripts/npc/units/boss/dire_tower_boss/ranged_wave_creep.txt
@@ -32,8 +32,8 @@
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_RANGED_ATTACK"
-    "AttackDamageMin"                                     "250"
-    "AttackDamageMax"                                     "350"
+    "AttackDamageMin"                                     "300" // melee creep version x 1.5
+    "AttackDamageMax"                                     "450" // melee creep version x 1.5
     "AttackRate"                                          "1"
     "AttackAnimationPoint"                                "0.5"
     "AttackAcquisitionRange"                              "600"
@@ -61,7 +61,7 @@
 
     // Status
     //----------------------------------------------------------------
-    "StatusHealth"                                        "1800"
+    "StatusHealth"                                        "1750"
     "StatusHealthRegen"                                   "2"
     "StatusMana"                                          "500"
     "StatusManaRegen"                                     "1"
@@ -105,14 +105,14 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "2"
+    "ArmorPhysical"                                       "5"
     "MagicalResistance"                                   "25"
 
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_RANGED_ATTACK"
-    "AttackDamageMin"                                     "450"
-    "AttackDamageMax"                                     "550"
+    "AttackDamageMin"                                     "450" // melee creep version x 1.5
+    "AttackDamageMax"                                     "600" // melee creep version x 1.5
     "AttackRate"                                          "1"
     "AttackAnimationPoint"                                "0.5"
     "AttackAcquisitionRange"                              "600"
@@ -140,7 +140,7 @@
 
     // Status
     //----------------------------------------------------------------
-    "StatusHealth"                                        "2300"
+    "StatusHealth"                                        "2250"
     "StatusHealthRegen"                                   "0" // has boss_regen
     "StatusMana"                                          "1000"
     "StatusManaRegen"                                     "2"
@@ -184,14 +184,14 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "8"
-    "MagicalResistance"                                   "25"
+    "ArmorPhysical"                                       "10"
+    "MagicalResistance"                                   "40"
 
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_RANGED_ATTACK"
-    "AttackDamageMin"                                     "650"
-    "AttackDamageMax"                                     "750"
+    "AttackDamageMin"                                     "600" // melee creep version x 1.5
+    "AttackDamageMax"                                     "750" // melee creep version x 1.5
     "AttackRate"                                          "1"
     "AttackAnimationPoint"                                "0.5"
     "AttackAcquisitionRange"                              "600"
@@ -219,7 +219,7 @@
 
     // Status
     //----------------------------------------------------------------
-    "StatusHealth"                                        "2800"
+    "StatusHealth"                                        "2750"
     "StatusHealthRegen"                                   "0" // has boss_regen
     "StatusMana"                                          "2000"
     "StatusManaRegen"                                     "4"
@@ -268,8 +268,8 @@
     // Attack
     //----------------------------------------------------------------
     "AttackCapabilities"                                  "DOTA_UNIT_CAP_RANGED_ATTACK"
-    "AttackDamageMin"                                     "250" // same as npc_dota_creature_ranged_wave1_creep
-    "AttackDamageMax"                                     "350" // same as npc_dota_creature_ranged_wave1_creep
+    "AttackDamageMin"                                     "300" // same as npc_dota_creature_ranged_wave1_creep
+    "AttackDamageMax"                                     "450" // same as npc_dota_creature_ranged_wave1_creep
     "AttackRate"                                          "1"
     "AttackAnimationPoint"                                "0.5"
     "AttackAcquisitionRange"                              "600"
@@ -297,7 +297,7 @@
 
     // Status
     //----------------------------------------------------------------
-    "StatusHealth"                                        "2800" // same as npc_dota_creature_ranged_wave3_creep
+    "StatusHealth"                                        "2750" // same as npc_dota_creature_ranged_wave3_creep
     "StatusHealthRegen"                                   "1"
     "StatusMana"                                          "500"
     "StatusManaRegen"                                     "1"

--- a/game/scripts/npc/units/boss/dire_tower_boss/siege_wave_creep.txt
+++ b/game/scripts/npc/units/boss/dire_tower_boss/siege_wave_creep.txt
@@ -105,7 +105,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "5"
+    "ArmorPhysical"                                       "10"
     "MagicalResistance"                                   "40"
 
     // Attack
@@ -183,7 +183,7 @@
 
     // Armor
     //----------------------------------------------------------------
-    "ArmorPhysical"                                       "10"
+    "ArmorPhysical"                                       "15"
     "MagicalResistance"                                   "80"
 
     // Attack

--- a/game/scripts/vscripts/abilities/boss/dire_tower_boss/dire_tower_boss_passives.lua
+++ b/game/scripts/vscripts/abilities/boss/dire_tower_boss/dire_tower_boss_passives.lua
@@ -49,6 +49,7 @@ end
 function modifier_dire_tower_boss_passives:DeclareFunctions()
   return {
     -- MODIFIER_PROPERTY_DISABLE_TURNING, -- if we disable turning, tower isnt able to attack anything behind it
+    MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS,
     MODIFIER_EVENT_ON_DEATH,
   }
 end
@@ -66,6 +67,10 @@ function modifier_dire_tower_boss_passives:CheckState()
     [MODIFIER_STATE_ROOTED] = true, -- to prevent the tower from moving
     [MODIFIER_STATE_CANNOT_BE_MOTION_CONTROLLED] = true, -- to prevent the tower from being pushed or knocked back
   }
+end
+
+function modifier_dire_tower_boss_passives:GetModifierMagicalResistanceBonus()
+  return self:GetAbility():GetSpecialValueFor("bonus_magic_resistance")
 end
 
 -- For the death sound and animation

--- a/game/scripts/vscripts/units/ai_dire_tower_boss.lua
+++ b/game/scripts/vscripts/units/ai_dire_tower_boss.lua
@@ -126,12 +126,6 @@ function DireTowerBossThink()
       end
     end
 
-    -- Sound
-    if not thisEntity.emitedsound then
-      thisEntity:EmitSound("Dire_Tower_Boss.Aggro")
-      thisEntity.emitedsound = true
-    end
-
     -- Find the target for the minions if there is no attackable unit within tower attack range
     -- this is to make minions less idle
     if not thisEntity.minion_target then
@@ -154,6 +148,22 @@ function DireTowerBossThink()
           end
         end
       end
+    end
+
+    -- Sound
+    local sound_source
+    if not thisEntity.aggro_target:IsNull() then
+      sound_source = thisEntity.aggro_target
+    elseif not thisEntity:GetAggroTarget():IsNull() then
+      sound_source = thisEntity:GetAggroTarget()
+    elseif not thisEntity.minion_target:IsNull() then
+      sound_source = thisEntity.minion_target
+    else
+      sound_source = thisEntity
+    end
+    if not thisEntity.emitedsound and sound_source then
+      sound_source:EmitSound("Dire_Tower_Boss.Aggro")
+      thisEntity.emitedsound = true
     end
 
     -- Phases


### PR DESCRIPTION
- Dire Tower Boss now has 25% bonus magic resist. (Total without reductions is 6.25%)
- Dire Tower Boss attack damage increased from 1500 to 1620.
- Dire Tower Boss now has Unslowable Attack Speed ability.
- Improved Dire Ranged Creeps and Dire Catapults a little bit.
- Maybe fixed Aggro sound origin.