### PR TITLE
Urn of Shadows and Spirit Vessel 7.37 parity

### DIFF
--- a/game/resource/English/ability/items/tooltip_silver_staff.txt
+++ b/game/resource/English/ability/items/tooltip_silver_staff.txt
@@ -11,7 +11,7 @@
 "DOTA_Tooltip_Ability_item_silver_staff_Note3"                                  "Silver Staff debuff does reduced damage to Bosses."
 "DOTA_Tooltip_Ability_item_silver_staff_bonus_health"                           "+$health"
 "DOTA_Tooltip_Ability_item_silver_staff_bonus_mana_regen"                       "+$mana_regen"
-"DOTA_Tooltip_Ability_item_silver_staff_bonus_all_stats"                        "+$all"
+//"DOTA_Tooltip_Ability_item_silver_staff_bonus_all_stats"                        "+$all"
 "DOTA_Tooltip_Ability_item_silver_staff_bonus_armor"                            "+$armor"
 
 "DOTA_Tooltip_modifier_item_silver_staff_debuff"                                "Silver Staff"
@@ -27,7 +27,7 @@
 "DOTA_Tooltip_Ability_item_silver_staff_2_Note3"                                "#{DOTA_Tooltip_Ability_item_silver_staff_Note3}"
 "DOTA_Tooltip_Ability_item_silver_staff_2_bonus_health"                         "#{DOTA_Tooltip_Ability_item_silver_staff_bonus_health}"
 "DOTA_Tooltip_Ability_item_silver_staff_2_bonus_mana_regen"                     "#{DOTA_Tooltip_Ability_item_silver_staff_bonus_mana_regen}"
-"DOTA_Tooltip_Ability_item_silver_staff_2_bonus_all_stats"                      "#{DOTA_Tooltip_Ability_item_silver_staff_bonus_all_stats}"
+//"DOTA_Tooltip_Ability_item_silver_staff_2_bonus_all_stats"                      "#{DOTA_Tooltip_Ability_item_silver_staff_bonus_all_stats}"
 "DOTA_Tooltip_Ability_item_silver_staff_2_bonus_armor"                          "#{DOTA_Tooltip_Ability_item_silver_staff_bonus_armor}"
 
 "DOTA_Tooltip_Ability_item_silver_staff_3"                                      "#{DOTA_Tooltip_Ability_item_silver_staff}"
@@ -40,5 +40,5 @@
 "DOTA_Tooltip_Ability_item_silver_staff_3_Note3"                                "#{DOTA_Tooltip_Ability_item_silver_staff_Note3}"
 "DOTA_Tooltip_Ability_item_silver_staff_3_bonus_health"                         "#{DOTA_Tooltip_Ability_item_silver_staff_bonus_health}"
 "DOTA_Tooltip_Ability_item_silver_staff_3_bonus_mana_regen"                     "#{DOTA_Tooltip_Ability_item_silver_staff_bonus_mana_regen}"
-"DOTA_Tooltip_Ability_item_silver_staff_3_bonus_all_stats"                      "#{DOTA_Tooltip_Ability_item_silver_staff_bonus_all_stats}"
+//"DOTA_Tooltip_Ability_item_silver_staff_3_bonus_all_stats"                      "#{DOTA_Tooltip_Ability_item_silver_staff_bonus_all_stats}"
 "DOTA_Tooltip_Ability_item_silver_staff_3_bonus_armor"                          "#{DOTA_Tooltip_Ability_item_silver_staff_bonus_armor}"

--- a/game/resource/English/ability/items/tooltip_spirit_vessel.txt
+++ b/game/resource/English/ability/items/tooltip_spirit_vessel.txt
@@ -16,7 +16,7 @@
 "DOTA_Tooltip_ability_item_spirit_vessel_oaa_lore"                              "#{DOTA_Tooltip_ability_item_spirit_vessel_lore}"
 "DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_health"                      "+$health"
 "DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_mana_regen"                  "+$mana_regen"
-"DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_all_stats"                   "+$all"
+//"DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_all_stats"                   "+$all"
 "DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_armor"                       "+$armor"
 
 "DOTA_Tooltip_Ability_item_spirit_vessel_2"                                     "#{DOTA_Tooltip_Ability_item_spirit_vessel}"
@@ -25,7 +25,7 @@
 "DOTA_Tooltip_ability_item_spirit_vessel_2_lore"                                "#{DOTA_Tooltip_ability_item_spirit_vessel_lore}"
 "DOTA_Tooltip_ability_item_spirit_vessel_2_bonus_health"                        "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_health}"
 "DOTA_Tooltip_ability_item_spirit_vessel_2_bonus_mana_regen"                    "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_mana_regen}"
-"DOTA_Tooltip_ability_item_spirit_vessel_2_bonus_all_stats"                     "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_all_stats}"
+//"DOTA_Tooltip_ability_item_spirit_vessel_2_bonus_all_stats"                     "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_all_stats}"
 "DOTA_Tooltip_ability_item_spirit_vessel_2_bonus_armor"                         "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_armor}"
 
 "DOTA_Tooltip_Ability_item_spirit_vessel_3"                                     "#{DOTA_Tooltip_Ability_item_spirit_vessel}"
@@ -34,7 +34,7 @@
 "DOTA_Tooltip_ability_item_spirit_vessel_3_lore"                                "#{DOTA_Tooltip_ability_item_spirit_vessel_lore}"
 "DOTA_Tooltip_ability_item_spirit_vessel_3_bonus_health"                        "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_health}"
 "DOTA_Tooltip_ability_item_spirit_vessel_3_bonus_mana_regen"                    "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_mana_regen}"
-"DOTA_Tooltip_ability_item_spirit_vessel_3_bonus_all_stats"                     "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_all_stats}"
+//"DOTA_Tooltip_ability_item_spirit_vessel_3_bonus_all_stats"                     "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_all_stats}"
 "DOTA_Tooltip_ability_item_spirit_vessel_3_bonus_armor"                         "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_armor}"
 
 "DOTA_Tooltip_Ability_item_spirit_vessel_4"                                     "#{DOTA_Tooltip_Ability_item_spirit_vessel}"
@@ -43,7 +43,7 @@
 "DOTA_Tooltip_ability_item_spirit_vessel_4_lore"                                "#{DOTA_Tooltip_ability_item_spirit_vessel_lore}"
 "DOTA_Tooltip_ability_item_spirit_vessel_4_bonus_health"                        "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_health}"
 "DOTA_Tooltip_ability_item_spirit_vessel_4_bonus_mana_regen"                    "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_mana_regen}"
-"DOTA_Tooltip_ability_item_spirit_vessel_4_bonus_all_stats"                     "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_all_stats}"
+//"DOTA_Tooltip_ability_item_spirit_vessel_4_bonus_all_stats"                     "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_all_stats}"
 "DOTA_Tooltip_ability_item_spirit_vessel_4_bonus_armor"                         "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_armor}"
 
 "DOTA_Tooltip_Ability_item_spirit_vessel_5"                                     "#{DOTA_Tooltip_Ability_item_spirit_vessel}"
@@ -52,12 +52,12 @@
 "DOTA_Tooltip_ability_item_spirit_vessel_5_lore"                                "#{DOTA_Tooltip_ability_item_spirit_vessel_lore}"
 "DOTA_Tooltip_ability_item_spirit_vessel_5_bonus_health"                        "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_health}"
 "DOTA_Tooltip_ability_item_spirit_vessel_5_bonus_mana_regen"                    "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_mana_regen}"
-"DOTA_Tooltip_ability_item_spirit_vessel_5_bonus_all_stats"                     "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_all_stats}"
+//"DOTA_Tooltip_ability_item_spirit_vessel_5_bonus_all_stats"                     "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_all_stats}"
 "DOTA_Tooltip_ability_item_spirit_vessel_5_bonus_armor"                         "#{DOTA_Tooltip_ability_item_spirit_vessel_oaa_bonus_armor}"
 
 "DOTA_Tooltip_modifier_spirit_vessel_oaa_buff"                                  "#{DOTA_Tooltip_modifier_item_spirit_vessel_heal}"
 "DOTA_Tooltip_modifier_spirit_vessel_oaa_buff_Description"                      "#{DOTA_Tooltip_modifier_item_spirit_vessel_heal_Description}"
 "DOTA_Tooltip_modifier_spirit_vessel_oaa_debuff_with_charge"                    "#{DOTA_Tooltip_modifier_item_spirit_vessel_damage}"
-"DOTA_Tooltip_modifier_spirit_vessel_oaa_debuff_with_charge_Description"        "Taking damage and all heals reduced by %dMODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE%%%."
+"DOTA_Tooltip_modifier_spirit_vessel_oaa_debuff_with_charge_Description"        "Taking damage and all health restoration reduced by %dMODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE%%%."
 "DOTA_Tooltip_modifier_spirit_vessel_oaa_debuff_no_charge"                      "#{DOTA_Tooltip_Ability_item_spirit_vessel}"
-"DOTA_Tooltip_modifier_spirit_vessel_oaa_debuff_no_charge_Description"          "All heals reduced by %dMODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE%%%."
+"DOTA_Tooltip_modifier_spirit_vessel_oaa_debuff_no_charge_Description"          "All health restoration reduced by %dMODIFIER_PROPERTY_HP_REGEN_AMPLIFY_PERCENTAGE%%%."

--- a/game/resource/English/ability/items/tooltip_urn_of_shadows.txt
+++ b/game/resource/English/ability/items/tooltip_urn_of_shadows.txt
@@ -20,8 +20,9 @@
 "DOTA_Tooltip_Ability_item_urn_of_shadows_oaa_Note0"                            "#{DOTA_Tooltip_ability_item_urn_of_shadows_Note0}"
 "DOTA_Tooltip_Ability_item_urn_of_shadows_oaa_Note1"                            "#{DOTA_Tooltip_ability_item_urn_of_shadows_Note1}"
 "DOTA_Tooltip_ability_item_urn_of_shadows_oaa_bonus_mana_regen"                 "+$mana_regen"
-"DOTA_Tooltip_ability_item_urn_of_shadows_oaa_bonus_all_stats"                  "+$all"
+//"DOTA_Tooltip_ability_item_urn_of_shadows_oaa_bonus_all_stats"                  "+$all"
 "DOTA_Tooltip_ability_item_urn_of_shadows_oaa_bonus_armor"                      "+$armor"
+"DOTA_Tooltip_ability_item_urn_of_shadows_oaa_bonus_health"                     "+$health"
 
 "DOTA_Tooltip_modifier_urn_of_shadows_oaa_buff"                                 "#{DOTA_Tooltip_Ability_item_urn_of_shadows_oaa}"
 "DOTA_Tooltip_modifier_urn_of_shadows_oaa_buff_Description"                     "#{DOTA_Tooltip_modifier_item_urn_heal_Description}"

--- a/game/scripts/npc/items/custom/item_silver_staff.txt
+++ b/game/scripts/npc/items/custom/item_silver_staff.txt
@@ -56,6 +56,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "7782"
+    "ItemShopTags"                                        "regen_mana;armor;boost_health"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "silver staff; break staff; dragon staff"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
@@ -65,11 +66,11 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "bonus_health"                                      "750 1000 1250"
+      "bonus_health"                                      "875 1125 1375"
       "bonus_mana_regen"                                  "2.5 3.25 4.25"
-      "bonus_all_stats"                                   "17 22 27"
+      "bonus_all_stats"                                   "0"
       "bonus_armor"                                       "5 8 12"
-      "base_damage"                                       "60 90 130"
+      "base_damage"                                       "55 85 125"
       "max_hp_damage"                                     "3.5 4 4.5"
       "duration"                                          "4.5 5.0 5.5"
     }

--- a/game/scripts/npc/items/custom/item_silver_staff_2.txt
+++ b/game/scripts/npc/items/custom/item_silver_staff_2.txt
@@ -56,6 +56,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "15783"
+    "ItemShopTags"                                        "regen_mana;armor;boost_health"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "silver staff 2; break staff 2; dragon staff 2"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
@@ -65,11 +66,11 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "bonus_health"                                      "750 1000 1250"
+      "bonus_health"                                      "875 1125 1375"
       "bonus_mana_regen"                                  "2.5 3.25 4.25"
-      "bonus_all_stats"                                   "17 22 27"
+      "bonus_all_stats"                                   "0"
       "bonus_armor"                                       "5 8 12"
-      "base_damage"                                       "60 90 130"
+      "base_damage"                                       "55 85 125"
       "max_hp_damage"                                     "3.5 4 4.5"
       "duration"                                          "4.5 5.0 5.5"
     }

--- a/game/scripts/npc/items/custom/item_silver_staff_3.txt
+++ b/game/scripts/npc/items/custom/item_silver_staff_3.txt
@@ -56,6 +56,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "32784"
+    "ItemShopTags"                                        "regen_mana;armor;boost_health"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "silver staff 3; break staff 3; dragon staff 3"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
@@ -65,11 +66,11 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "bonus_health"                                      "750 1000 1250"
+      "bonus_health"                                      "875 1125 1375"
       "bonus_mana_regen"                                  "2.5 3.25 4.25"
-      "bonus_all_stats"                                   "17 22 27"
+      "bonus_all_stats"                                   "0"
       "bonus_armor"                                       "5 8 12"
-      "base_damage"                                       "60 90 130"
+      "base_damage"                                       "55 85 125"
       "max_hp_damage"                                     "3.5 4 4.5"
       "duration"                                          "4.5 5.0 5.5"
     }

--- a/game/scripts/npc/items/item_spirit_vessel.txt
+++ b/game/scripts/npc/items/item_spirit_vessel.txt
@@ -16,7 +16,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "1200"
+    "ItemCost"                                            "900"
     "ItemShopTags"                                        ""
 
     // Recipe
@@ -25,7 +25,7 @@
     "ItemResult"                                          "item_spirit_vessel_oaa"
     "ItemRequirements"
     {
-      "01"                                                "item_urn_of_shadows_oaa;item_crown;item_fluffy_hat"
+      "01"                                                "item_urn_of_shadows_oaa;item_vitality_booster"
     }
   }
   //=================================================================================================================
@@ -45,7 +45,7 @@
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
     "AbilityCastRange"                                    "750 850 950 1050 1150"
-    "AbilityCooldown"                                     "7.0"
+    "AbilityCooldown"                                     "10"
     "AbilitySharedCooldown"                               "urn"
 
     // Spicy Parameters
@@ -56,6 +56,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "2780"
+    "ItemShopTags"                                        "regen_mana;armor;boost_health"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "sv;spirit vessel"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
@@ -65,9 +66,9 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "bonus_health"                                      "250 500 750 1000 1250" // vanilla (125);
+      "bonus_health"                                      "375 625 875 1125 1375"
       "bonus_mana_regen"                                  "1.75 2.0 2.5 3.25 4.25"
-      "bonus_all_stats"                                   "7 12 17 22 27" // Urn (2); Crown (4); vanilla (6);
+      "bonus_all_stats"                                   "0"
       "bonus_armor"                                       "2 3 5 8 12"
       "soul_radius"
       {
@@ -76,10 +77,10 @@
       }
       "kill_charges"                                      "1"
       "soul_heal_amount"                                  "45 60 85 120 165" // Urn (30); vanilla (40);
-      "soul_damage_amount"                                "30 40 60 90 130" // Urn (25); vanilla (35);
+      "soul_damage_amount"                                "25 35 55 85 125" // Urn (25); vanilla (25);
       "duration"                                          "8.0"
-      "heal_reduction_with_charge"                        "45 50 55 60 65"
-      "heal_reduction_no_charge"                          "20 25 30 35 40"
+      "heal_reduction_with_charge"                        "50 54 58 62 66"
+      "heal_reduction_no_charge"                          "24 28 32 36 40"
       "current_hp_as_dmg"                                 "4 4.5 5 5.5 6"
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel_2.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_2.txt
@@ -44,7 +44,7 @@
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
     "AbilityCastRange"                                    "750 850 950 1050 1150"
-    "AbilityCooldown"                                     "7.0"
+    "AbilityCooldown"                                     "10"
     "AbilitySharedCooldown"                               "urn"
 
     // Spicy Parameters
@@ -55,6 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "4281"
+    "ItemShopTags"                                        "regen_mana;armor;boost_health"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "sv 2;spirit vessel 2"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
@@ -64,9 +65,9 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "bonus_health"                                      "250 500 750 1000 1250"
+      "bonus_health"                                      "375 625 875 1125 1375"
       "bonus_mana_regen"                                  "1.75 2.0 2.5 3.25 4.25"
-      "bonus_all_stats"                                   "7 12 17 22 27"
+      "bonus_all_stats"                                   "0"
       "bonus_armor"                                       "2 3 5 8 12"
       "soul_radius"
       {
@@ -75,10 +76,10 @@
       }
       "kill_charges"                                      "1"
       "soul_heal_amount"                                  "45 60 85 120 165"
-      "soul_damage_amount"                                "30 40 60 90 130"
+      "soul_damage_amount"                                "25 35 55 85 125"
       "duration"                                          "8.0"
-      "heal_reduction_with_charge"                        "45 50 55 60 65"
-      "heal_reduction_no_charge"                          "20 25 30 35 40"
+      "heal_reduction_with_charge"                        "50 54 58 62 66"
+      "heal_reduction_no_charge"                          "24 28 32 36 40"
       "current_hp_as_dmg"                                 "4 4.5 5 5.5 6"
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel_3.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_3.txt
@@ -44,7 +44,7 @@
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
     "AbilityCastRange"                                    "750 850 950 1050 1150"
-    "AbilityCooldown"                                     "7.0"
+    "AbilityCooldown"                                     "10"
     "AbilitySharedCooldown"                               "urn"
 
     // Spicy Parameters
@@ -55,6 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "7782"
+    "ItemShopTags"                                        "regen_mana;armor;boost_health"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "sv 3;spirit vessel 3"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
@@ -64,9 +65,9 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "bonus_health"                                      "250 500 750 1000 1250"
+      "bonus_health"                                      "375 625 875 1125 1375"
       "bonus_mana_regen"                                  "1.75 2.0 2.5 3.25 4.25"
-      "bonus_all_stats"                                   "7 12 17 22 27"
+      "bonus_all_stats"                                   "0"
       "bonus_armor"                                       "2 3 5 8 12"
       "soul_radius"
       {
@@ -75,10 +76,10 @@
       }
       "kill_charges"                                      "1"
       "soul_heal_amount"                                  "45 60 85 120 165"
-      "soul_damage_amount"                                "30 40 60 90 130"
+      "soul_damage_amount"                                "25 35 55 85 125"
       "duration"                                          "8.0"
-      "heal_reduction_with_charge"                        "45 50 55 60 65"
-      "heal_reduction_no_charge"                          "20 25 30 35 40"
+      "heal_reduction_with_charge"                        "50 54 58 62 66"
+      "heal_reduction_no_charge"                          "24 28 32 36 40"
       "current_hp_as_dmg"                                 "4 4.5 5 5.5 6"
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel_4.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_4.txt
@@ -44,7 +44,7 @@
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
     "AbilityCastRange"                                    "750 850 950 1050 1150"
-    "AbilityCooldown"                                     "7.0"
+    "AbilityCooldown"                                     "10"
     "AbilitySharedCooldown"                               "urn"
 
     // Spicy Parameters
@@ -55,6 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "15783"
+    "ItemShopTags"                                        "regen_mana;armor;boost_health"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "sv 4;spirit vessel 4"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
@@ -64,9 +65,9 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "bonus_health"                                      "250 500 750 1000 1250"
+      "bonus_health"                                      "375 625 875 1125 1375"
       "bonus_mana_regen"                                  "1.75 2.0 2.5 3.25 4.25"
-      "bonus_all_stats"                                   "7 12 17 22 27"
+      "bonus_all_stats"                                   "0"
       "bonus_armor"                                       "2 3 5 8 12"
       "soul_radius"
       {
@@ -75,10 +76,10 @@
       }
       "kill_charges"                                      "1"
       "soul_heal_amount"                                  "45 60 85 120 165"
-      "soul_damage_amount"                                "30 40 60 90 130"
+      "soul_damage_amount"                                "25 35 55 85 125"
       "duration"                                          "8.0"
-      "heal_reduction_with_charge"                        "45 50 55 60 65"
-      "heal_reduction_no_charge"                          "20 25 30 35 40"
+      "heal_reduction_with_charge"                        "50 54 58 62 66"
+      "heal_reduction_no_charge"                          "24 28 32 36 40"
       "current_hp_as_dmg"                                 "4 4.5 5 5.5 6"
     }
   }

--- a/game/scripts/npc/items/item_spirit_vessel_5.txt
+++ b/game/scripts/npc/items/item_spirit_vessel_5.txt
@@ -44,7 +44,7 @@
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
     "AbilityCastRange"                                    "750 850 950 1050 1150"
-    "AbilityCooldown"                                     "7.0"
+    "AbilityCooldown"                                     "10"
     "AbilitySharedCooldown"                               "urn"
 
     // Spicy Parameters
@@ -55,6 +55,7 @@
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "32784"
+    "ItemShopTags"                                        "regen_mana;armor;boost_health"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "sv 5;spirit vessel 5"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
@@ -64,9 +65,9 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "bonus_health"                                      "250 500 750 1000 1250"
+      "bonus_health"                                      "375 625 875 1125 1375"
       "bonus_mana_regen"                                  "1.75 2.0 2.5 3.25 4.25"
-      "bonus_all_stats"                                   "7 12 17 22 27"
+      "bonus_all_stats"                                   "0"
       "bonus_armor"                                       "2 3 5 8 12"
       "soul_radius"
       {
@@ -75,10 +76,10 @@
       }
       "kill_charges"                                      "1"
       "soul_heal_amount"                                  "45 60 85 120 165"
-      "soul_damage_amount"                                "30 40 60 90 130"
+      "soul_damage_amount"                                "25 35 55 85 125"
       "duration"                                          "8.0"
-      "heal_reduction_with_charge"                        "45 50 55 60 65"
-      "heal_reduction_no_charge"                          "20 25 30 35 40"
+      "heal_reduction_with_charge"                        "50 54 58 62 66"
+      "heal_reduction_no_charge"                          "24 28 32 36 40"
       "current_hp_as_dmg"                                 "4 4.5 5 5.5 6"
     }
   }

--- a/game/scripts/npc/items/item_urn_of_shadows.txt
+++ b/game/scripts/npc/items/item_urn_of_shadows.txt
@@ -16,7 +16,7 @@
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
-    "ItemCost"                                            "375"
+    "ItemCost"                                            "280"
     "ItemShopTags"                                        ""
 
     // Recipe
@@ -25,7 +25,7 @@
     "ItemResult"                                          "item_urn_of_shadows_oaa"
     "ItemRequirements"
     {
-      "01"                                                "item_sobi_mask;item_ring_of_protection;item_circlet"
+      "01"                                                "item_sobi_mask;item_ring_of_protection;item_fluffy_hat"
     }
   }
   //=================================================================================================================
@@ -45,13 +45,13 @@
     "SpellDispellableType"                                "SPELL_DISPELLABLE_YES"
 
     "AbilityCastRange"                                    "750"
-    "AbilityCooldown"                                     "7.0"
+    "AbilityCooldown"                                     "10"
     "AbilitySharedCooldown"                               "urn"
 
     // Item Info
     //-------------------------------------------------------------------------------------------------------------
     "ItemCost"                                            "880"
-    "ItemShopTags"                                        "regen_mana;str;int;agi;armor"
+    "ItemShopTags"                                        "regen_mana;armor;boost_health"
     "ItemQuality"                                         "rare"
     "ItemAliases"                                         "urn; urn of shadows"
     "ItemDisassembleRule"                                 "DOTA_ITEM_DISASSEMBLE_NEVER"
@@ -62,9 +62,14 @@
     "AbilityValues"
     {
       "bonus_mana_regen"                                  "1.4"
-      "bonus_all_stats"                                   "2"
+      "bonus_all_stats"                                   "0"
       "bonus_armor"                                       "2"
-      "soul_radius"                                       "1400"
+      "bonus_health"                                      "125"
+      "soul_radius"
+      {
+        "value"                                           "1400"
+        "affected_by_aoe_increase"                        "1"
+      }
       "kill_charges"                                      "1"
       "soul_heal_amount"                                  "30"
       "soul_damage_amount"                                "25"


### PR DESCRIPTION
- Urn of Shadows recipe changed. Now requires Fluffy Hat instead of Circlet. (Total cost unchanged)
- Urn of Shadows no longer provides +2 All Attributes. Now provides +125 Health.
- Urn of Shadows cd increased from 7s to 10s.
- Spirit Vessel recipe changed. Now requires Vitality Booster instead of Fluffy Hat and Crown. (Total cost unchanged)
- Spirit Vessel no longer provides +7/12/17/22/27 All Attributes.
- Spirit Vessel bonus hp increased from 250/500/750/1000/1250 to 375/625/875/1125/1375.
- Spirit Vessel cd increased from 7s to 10s.
- Spirit Vessel base dps decreased from 30/40/60/90/130 to 25/35/55/85/125.
- Spirit Vessel health restoration reduction rescaled from 45/50/55/60/65% to 50/54/58/62/66%. (without charges rescaled from 20/25/30/35/40% to 24/28/32/36/40%.)
- Silver Staff no longer provides +17/22/27 All Attributes.
- Silver Staff bonus hp increased from 750/1000/1250 to 875/1125/1375.
- Silver Staff base dps reduced from 60/90/130 to 55/85/125.