### PR TITLE
Giant Form nerfs

### DIFF
--- a/game/scripts/npc/items/custom/item_giant_form.txt
+++ b/game/scripts/npc/items/custom/item_giant_form.txt
@@ -98,7 +98,7 @@
         "value"                                           "650"
         "affected_by_aoe_increase"                        "1"
       }
-      "giant_splash_damage"                               "75 100" // splash percent, doesn't work on ranged heroes
+      "giant_splash_damage"                               "65 90" // splash percent, doesn't work on ranged heroes
       "giant_scale"                                       "50"
       "duration"                                          "8.0"
     }

--- a/game/scripts/npc/items/custom/item_giant_form_2.txt
+++ b/game/scripts/npc/items/custom/item_giant_form_2.txt
@@ -90,7 +90,7 @@
         "value"                                           "650"
         "affected_by_aoe_increase"                        "1"
       }
-      "giant_splash_damage"                               "75 100" // splash percent, doesn't work on ranged heroes
+      "giant_splash_damage"                               "65 90" // splash percent, doesn't work on ranged heroes
       "giant_scale"                                       "50"
       "duration"                                          "8.0"
     }

--- a/game/scripts/vscripts/items/giant_form.lua
+++ b/game/scripts/vscripts/items/giant_form.lua
@@ -90,6 +90,11 @@ if IsServer() then
       return
     end
 
+    -- Prevent some instant attacks proccing the cleave
+    if event.no_attack_cooldown and not parent:InstantAttackCanProcCleave() then
+      return
+    end
+
     local target = event.target
     if not target or target:IsNull() then
       return
@@ -308,6 +313,11 @@ if IsServer() then
     end
 
     if parent:IsIllusion() or parent:IsRangedAttacker() then
+      return
+    end
+
+    -- Prevent some instant attacks proccing the cleave
+    if event.no_attack_cooldown and not parent:InstantAttackCanProcCleave() then
       return
     end
 

--- a/game/scripts/vscripts/libraries/basenpc.lua
+++ b/game/scripts/vscripts/libraries/basenpc.lua
@@ -473,7 +473,7 @@ if CDOTA_BaseNPC then
       "modifier_tiny_tree_channel",
       "modifier_void_spirit_astral_step_caster",                  -- Void Spirit R
     }
-    for _, v in pairs(lits) do
+    for _, v in pairs(list) do
       if self:HasModifier(v) then
         return true
       end

--- a/game/scripts/vscripts/libraries/basenpc.lua
+++ b/game/scripts/vscripts/libraries/basenpc.lua
@@ -451,6 +451,35 @@ if CDOTA_BaseNPC then
 
     return false
   end
+
+  function CDOTA_BaseNPC:InstantAttackCanProcCleave()
+    local list = {
+      "modifier_ember_spirit_sleight_of_fist_caster",
+      "modifier_ember_spirit_sleight_of_fist_caster_invulnerability",
+      "modifier_ember_spirit_sleight_of_fist_in_progress",
+      "modifier_dawnbreaker_fire_wreath_caster",                  -- Dawnbreaker Q
+      "modifier_juggernaut_omnislash",
+      "modifier_juggernaut_omnislash_invulnerability",
+      --"modifier_mars_gods_rebuke_crit",                         -- Mars W
+      "modifier_monkey_king_boundless_strike_crit",               -- MK Q
+      "modifier_wukongs_command_oaa_buff",                        -- MK R
+      "modifier_pangolier_swashbuckle",
+      "modifier_pangolier_swashbuckle_attack",
+      "modifier_phantom_assassin_stiflingdagger_caster",          -- PA Q
+      "modifier_riki_tricks_of_the_trade_phase",
+      --"modifier_sand_king_scorpion_strike",                     -- Sand King E
+      --"modifier_sand_king_scorpion_strike_attack_bonus",        -- Sand King E
+      "modifier_sohei_flurry_self",
+      "modifier_tiny_tree_channel",
+      "modifier_void_spirit_astral_step_caster",                  -- Void Spirit R
+    }
+    for _, v in pairs(lits) do
+      if self:HasModifier(v) then
+        return true
+      end
+    end
+    return false
+  end
 end
 
 -- On Client:


### PR DESCRIPTION
Cleave and splash now work only for the following instant attacks: 
Ember Spirit Sleight of Fist
Dawnbreaker Starbreaker
Juggernaut Omnislash
Monkey King Boundless Strike (?)
Monkey King Wukongs Command
Pangolier Swashbuckle
Phantom Assassin Stiffling Dagger (?)
Riki Tricks of the Trade
Sohei Flurry of Blows
Tiny Tree Volley
Void Spirit Astral Step