### PR TITLE
Fixed custom strong dispels not dispelling hex

### DIFF
--- a/game/scripts/vscripts/abilities/boss/alchemist/boss_alchemist_chemical_rage.lua
+++ b/game/scripts/vscripts/abilities/boss/alchemist/boss_alchemist_chemical_rage.lua
@@ -9,7 +9,7 @@ function boss_alchemist_chemical_rage:OnSpellStart()
 
   local remove_stuns = true
 
-  -- Apply Basic Dispel always
+  -- Strong Dispel (for the boss)
   caster:Purge(false, true, false, remove_stuns, remove_stuns)
 
   -- Disjoint disjointable/dodgeable projectiles

--- a/game/scripts/vscripts/abilities/boss/boss_basic_properties.lua
+++ b/game/scripts/vscripts/abilities/boss/boss_basic_properties.lua
@@ -308,8 +308,8 @@ if IsServer() then
     end
 
     if ability:IsCooldownReady() and (parent:IsStunned() or parent:IsSilenced()) then
-      -- Strong Dispel
-      parent:Purge(false, true, false, true, false)
+      -- Strong Dispel (for the boss)
+      parent:Purge(false, true, false, true, true)
 
       -- Add debuff protection
       parent:AddNewModifier(parent, ability, "modifier_boss_debuff_protection_oaa", {duration = self.debuff_protection_duration})

--- a/game/scripts/vscripts/abilities/boss/boss_kraken_shell.lua
+++ b/game/scripts/vscripts/abilities/boss/boss_kraken_shell.lua
@@ -97,7 +97,7 @@ if IsServer() then
       local fx = ParticleManager:CreateParticle("particles/units/heroes/hero_tidehunter/tidehunter_krakenshell_purge.vpcf", PATTACH_ABSORIGIN, parent)
       ParticleManager:ReleaseParticleIndex(fx)
 
-      -- Strong Dispel
+      -- Strong Dispel (for the boss)
       parent:Purge(false, true, false, true, true)
 
       -- Reset the dmg counter

--- a/game/scripts/vscripts/abilities/boss/spooky_ghost/boss_spooky_ghost_ethereal.lua
+++ b/game/scripts/vscripts/abilities/boss/spooky_ghost/boss_spooky_ghost_ethereal.lua
@@ -6,7 +6,7 @@ boss_spooky_ghost_ethereal = class(AbilityBaseClass)
 function boss_spooky_ghost_ethereal:OnSpellStart()
   local caster = self:GetCaster()
 
-  -- Apply Basic Dispel
+  -- Basic Dispel (for the boss)
   caster:Purge(false, true, false, false, false)
 
   -- Apply buff

--- a/game/scripts/vscripts/abilities/dev_attack.lua
+++ b/game/scripts/vscripts/abilities/dev_attack.lua
@@ -77,6 +77,7 @@ function modifier_dev_attack_aura:OnIntervalThink()
     local manaReductionAmount = targetMaxMana / killTicks
 
     target:MakeVisibleDueToAttack(teamID, 200)
+    -- Basic Dispel (for enemies)
     target:Purge(true, false, false, false, false)
     target:ReduceMana(manaReductionAmount, ability)
     caster:GiveMana(manaReductionAmount)

--- a/game/scripts/vscripts/abilities/fountain_attack.lua
+++ b/game/scripts/vscripts/abilities/fountain_attack.lua
@@ -127,6 +127,7 @@ function modifier_fountain_attack_aura:OnIntervalThink()
     local manaReductionAmount = targetMaxMana / killTicks
 
     target:MakeVisibleDueToAttack(teamID, 0)
+    -- Basic Dispel (for enemies)
     target:Purge(true, false, false, false, false)
     target:ReduceMana(manaReductionAmount, ability)
     if targetHealth - healthReductionAmount < 1 then

--- a/game/scripts/vscripts/abilities/oaa_abaddon_borrowed_time.lua
+++ b/game/scripts/vscripts/abilities/oaa_abaddon_borrowed_time.lua
@@ -32,8 +32,8 @@ function abaddon_borrowed_time_oaa:OnSpellStart()
     buff_duration = self:GetSpecialValueFor("duration_scepter")
   end
 
-  -- Strong Dispel
-  caster:Purge(false, true, false, true, false)
+  -- Strong Dispel (for caster)
+  caster:Purge(false, true, false, true, true)
 
   -- Add the Borrowed Time modifier to the caster
   caster:AddNewModifier(caster, self, "modifier_oaa_borrowed_time_buff_caster", {duration = buff_duration})

--- a/game/scripts/vscripts/abilities/oaa_alchemist_chemical_rage.lua
+++ b/game/scripts/vscripts/abilities/oaa_alchemist_chemical_rage.lua
@@ -27,7 +27,7 @@ function alchemist_chemical_rage_oaa:OnSpellStart()
     remove_stuns = true
   end
 
-  -- Apply Basic Dispel always
+  -- Basic Dispel (for caster, always) or Strong Dispel (with talent)
   caster:Purge(false, true, false, remove_stuns, remove_stuns)
 
   -- Disjoint disjointable/dodgeable projectiles

--- a/game/scripts/vscripts/abilities/oaa_viper_strike.lua
+++ b/game/scripts/vscripts/abilities/oaa_viper_strike.lua
@@ -77,7 +77,7 @@ function viper_viper_strike_oaa:OnProjectileHit_ExtraData( target, loc, data )
     -- Check for 'Viper Strike Purges & Silences' talent
     local talent = caster:FindAbilityByName("special_bonus_unique_viper_3_oaa")
     if talent and talent:GetLevel() > 0 then
-      -- Basic Dispel for enemies
+      -- Basic Dispel (for enemies)
       local RemovePositiveBuffs = true
       local RemoveDebuffs = false
       local BuffsCreatedThisFrameOnly = false

--- a/game/scripts/vscripts/abilities/sohei/sohei_guard.lua
+++ b/game/scripts/vscripts/abilities/sohei/sohei_guard.lua
@@ -78,7 +78,7 @@ if IsServer() then
 			-- but really, that still procs magic wand and stuff
 		end
 
-		-- Hard Dispel
+		-- Strong Dispel (for the target)
 		target:Purge( false, true, false, true, true )
 
 		-- Start an animation

--- a/game/scripts/vscripts/abilities/sohei/sohei_wholeness_of_body.lua
+++ b/game/scripts/vscripts/abilities/sohei/sohei_wholeness_of_body.lua
@@ -22,7 +22,7 @@ function sohei_wholeness_of_body:OnSpellStart()
   -- Activation sound
   target:EmitSound("Sohei.Guard")
 
-  -- Strong Dispel
+  -- Strong Dispel (for the target)
   target:Purge(false, true, false, true, true)
 
   -- Remove debuffs that are removed only with BKB/Spell Immunity/Debuff Immunity

--- a/game/scripts/vscripts/components/filters/modifyabilitiesfilter.lua
+++ b/game/scripts/vscripts/components/filters/modifyabilitiesfilter.lua
@@ -64,7 +64,7 @@ function ModifyAbilitiesFilter:ModifierFilter(keys)
   elseif ability_name == "viper_viper_strike" and modifier_name ~= "modifier_viper_viper_strike_silence" then
     local talent = caster:FindAbilityByName("special_bonus_unique_viper_3_oaa")
     if talent and talent:GetLevel() > 0 then
-      -- Basic Dispel for enemies
+      -- Basic Dispel (for enemies)
       local RemovePositiveBuffs = true
       local RemoveDebuffs = false
       local BuffsCreatedThisFrameOnly = false

--- a/game/scripts/vscripts/items/aeon_disk.lua
+++ b/game/scripts/vscripts/items/aeon_disk.lua
@@ -142,8 +142,8 @@ if IsServer() then
       -- Sound
       parent:EmitSound("DOTA_Item.ComboBreaker")
 
-      -- Strong Dispel
-      parent:Purge(false, true, false, true, false)
+      -- Strong Dispel (for the caster)
+      parent:Purge(false, true, false, true, true)
 
       -- Apply Combo Breaker buff
       parent:AddNewModifier(parent, ability, "modifier_item_aeon_disk_oaa_buff", {duration = buff_duration})

--- a/game/scripts/vscripts/items/black_king_bar.lua
+++ b/game/scripts/vscripts/items/black_king_bar.lua
@@ -9,7 +9,7 @@ end
 function item_black_king_bar_1:OnSpellStart()
   local caster = self:GetCaster()
 
-  -- Basic Dispel
+  -- Basic Dispel (for the caster)
   caster:Purge( false, true, false, false, false )
 
   -- Remove debuffs that are removed only with BKB/Spell Immunity/Debuff Immunity

--- a/game/scripts/vscripts/items/bubble_orb.lua
+++ b/game/scripts/vscripts/items/bubble_orb.lua
@@ -71,7 +71,8 @@ function item_bubble_orb_1:OnSpellStart()
   )
   for _, ally in pairs(allies) do
     if ally and not ally:IsNull() then
-      ally:Purge(false, true, false, true, false)
+      -- Strong Dispel (for the allies)
+      ally:Purge(false, true, false, true, true)
     end
   end
 end

--- a/game/scripts/vscripts/items/charge_bkb.lua
+++ b/game/scripts/vscripts/items/charge_bkb.lua
@@ -23,7 +23,7 @@ function item_charge_bkb:OnSpellStart()
   caster:GiveMana(amount_to_restore)
   --RamonNZ: BKB Effect:
   local modifier_duration = self:GetSpecialValueFor("immunity_time_per_charge") * self:GetCurrentCharges()
-  -- Basic Purge:
+  -- Basic Dispel (for the caster)
   local RemovePositiveBuffs = false
   local RemoveDebuffs = true
   local BuffsCreatedThisFrameOnly = false

--- a/game/scripts/vscripts/items/dispel_orb.lua
+++ b/game/scripts/vscripts/items/dispel_orb.lua
@@ -162,6 +162,7 @@ function modifier_item_dispel_orb_active:OnIntervalThink()
   local modifiers = parent:FindAllModifiers()
   local modifierCount = #modifiers
 
+  -- Basic Dispel (for the caster)
   parent:Purge(false, true, false, false, false)
 
   modifiers = parent:FindAllModifiers()

--- a/game/scripts/vscripts/items/enrage_crystal.lua
+++ b/game/scripts/vscripts/items/enrage_crystal.lua
@@ -10,8 +10,8 @@ end
 function item_enrage_crystal_1:OnSpellStart()
   local caster = self:GetCaster()
 
-  -- Strong Dispel
-  caster:Purge(false, true, false, true, false)
+  -- Strong Dispel (for the caster)
+  caster:Purge(false, true, false, true, true)
 
   -- Remove debuffs that are removed only with BKB/Spell Immunity/Debuff Immunity
   caster:RemoveModifierByName("modifier_slark_pounce_leash")

--- a/game/scripts/vscripts/items/ghost_king_bar.lua
+++ b/game/scripts/vscripts/items/ghost_king_bar.lua
@@ -12,7 +12,7 @@ end
 function item_ghost_king_bar_1:OnSpellStart()
   local caster = self:GetCaster()
 
-  -- Apply Basic Dispel
+  -- Basic Dispel (for the caster)
   caster:Purge(false, true, false, false, false)
 
   -- Apply Ghost King Bar buff to caster (but only if they dont have spell immunity)

--- a/game/scripts/vscripts/items/greater_guardian_greaves.lua
+++ b/game/scripts/vscripts/items/greater_guardian_greaves.lua
@@ -25,7 +25,7 @@ function item_greater_guardian_greaves:OnSpellStart()
     false
   )
 
-  -- Apply basic dispel to caster
+  -- Basic Dispel (for the caster)
   caster:Purge(false, true, false, false, false)
 
   local function ReplenishMana(hero)

--- a/game/scripts/vscripts/items/magic_lamp.lua
+++ b/game/scripts/vscripts/items/magic_lamp.lua
@@ -129,7 +129,7 @@ if IsServer() then
 
       -- Dispel all debuffs (99.99% at least)
       parent:DispelUndispellableDebuffs()
-      parent:Purge(false, true, false, true, false)
+      parent:Purge(false, true, false, true, true)
 
       -- Particle
       parent:AddNewModifier(parent, ability, "modifier_item_magic_lamp_oaa_buff", {duration = 2})

--- a/game/scripts/vscripts/items/neutral/rune_breaker.lua
+++ b/game/scripts/vscripts/items/neutral/rune_breaker.lua
@@ -16,7 +16,7 @@ function item_rune_breaker_oaa:OnSpellStart()
     return
   end
 
-  -- Basic Dispel
+  -- Basic Dispel (for enemies)
   local RemovePositiveBuffs = true
   local RemoveDebuffs = false
   local BuffsCreatedThisFrameOnly = false

--- a/game/scripts/vscripts/items/reflection_shard.lua
+++ b/game/scripts/vscripts/items/reflection_shard.lua
@@ -14,7 +14,7 @@ function item_reflection_shard_1:OnSpellStart()
   local caster = self:GetCaster()
   local duration = self:GetSpecialValueFor("duration")
 
-  -- Basic Dispel
+  -- Basic Dispel (for the caster)
   caster:Purge(false, true, false, false, false)
 
   -- Sound

--- a/game/scripts/vscripts/items/spell_breaker.lua
+++ b/game/scripts/vscripts/items/spell_breaker.lua
@@ -26,7 +26,7 @@ function item_spell_breaker_1:OnSpellStart()
     return
   end
 
-  -- Basic Dispel for enemies
+  -- Basic Dispel (for enemies)
   local RemovePositiveBuffs = true
   local RemoveDebuffs = false
   local BuffsCreatedThisFrameOnly = false

--- a/game/scripts/vscripts/items/vladmirs_grimoire.lua
+++ b/game/scripts/vscripts/items/vladmirs_grimoire.lua
@@ -53,7 +53,7 @@ function item_vladmirs_grimoire_1:OnSpellStart()
 
       -- Dispel all debuffs (99.99% at least)
       unit:DispelUndispellableDebuffs()
-      unit:Purge(false, true, false, true, false)
+      unit:Purge(false, true, false, true, true)
 
       -- Hide it
       unit:AddNoDraw()

--- a/game/scripts/vscripts/libraries/basenpc.lua
+++ b/game/scripts/vscripts/libraries/basenpc.lua
@@ -256,9 +256,10 @@ if IsServer() then
 
     -- Dispel bools
     local BuffsCreatedThisFrameOnly = false
-    local RemoveExceptions = false              -- Offensive Strong Dispel (yes or no), can cause errors, crashes etc.
-    local RemoveStuns = true                    -- Defensive Strong Dispel (yes or no)
+    local RemoveExceptions = true               -- For hex and similar
+    local RemoveStuns = true                    -- For stuns
 
+    -- Remove most dispellable modifiers
     self:Purge(true, true, BuffsCreatedThisFrameOnly, RemoveStuns, RemoveExceptions)
   end
 

--- a/game/scripts/vscripts/modifiers/modifyabilitiesfilter/duel_scepter_addition.lua
+++ b/game/scripts/vscripts/modifiers/modifyabilitiesfilter/duel_scepter_addition.lua
@@ -70,6 +70,7 @@ function modifier_legion_duel_debuff_oaa:OnIntervalThink()
     return
   end
   if not parent:IsMagicImmune() and not parent:IsDebuffImmune() then
+    -- Basic Dispel (for enemies)
     parent:Purge(true, false, false, false, false)
   end
 end

--- a/game/scripts/vscripts/units/ai_dire_tower_boss.lua
+++ b/game/scripts/vscripts/units/ai_dire_tower_boss.lua
@@ -245,7 +245,7 @@ function CastSummonWave()
 end
 
 function CastGlyph()
-  -- Super Strong Dispel for the tower
+  -- Dispel all debuffs (99.99% at least)
   thisEntity:Purge(false, true, false, true, true)
   thisEntity:DispelUndispellableDebuffs()
 


### PR DESCRIPTION
The following strong dispels didn't remove hex: Boss debuff protection, Abaddon Borrowed Time, Aeon Disk, Bubble Orb, Magic Lamp, Vladmir's Grimoire and Duel start/end dispel.