### PR TITLE
the great universal hero nerf

### DIFF
--- a/game/scripts/npc/abilities/dark_seer_wall_of_replica.txt
+++ b/game/scripts/npc/abilities/dark_seer_wall_of_replica.txt
@@ -34,12 +34,12 @@
       "duration"                                          "30.0"
       "replica_damage_outgoing" //OAA
       {
-        "value"                                           "-30 0 30 90 150"
+        "value"                                           "-30 -10 10 50 90"
         "special_bonus_unique_dark_seer_7"                "+20"
       }
       "tooltip_outgoing" //OAA
       {
-        "value"                                           "70 100 130 190 250"
+        "value"                                           "70 90 110 150 190"
         "special_bonus_unique_dark_seer_7"                "+20"
       }
       "replica_damage_incoming"                           "100 100 100 75 25"

--- a/game/scripts/npc/abilities/dragon_knight_dragon_blood.txt
+++ b/game/scripts/npc/abilities/dragon_knight_dragon_blood.txt
@@ -26,14 +26,14 @@
         "value"                                           "5 10 15 20 40 80"
         "RequiresFacet"                                   "dragon_knight_corrosive_dragon"
       }
-      "corrosive_breath_duration"
+      "corrosive_breath_duration" //OAA
       {
-        "value"                                           "3"
+        "value"                                           "6"
         "RequiresFacet"                                   "dragon_knight_corrosive_dragon"
       }
-      "corrosive_breath_armor_reduction"
+      "corrosive_breath_armor_reduction" //OAA
       {
-        "value"                                           "0 1 2 3 5 9"
+        "value"                                           "1 2 3 4 6 10"
         "RequiresFacet"                                   "dragon_knight_corrosive_dragon"
       }
       // RED DRAGON

--- a/game/scripts/npc/abilities/dragon_knight_inherited_vigor.txt
+++ b/game/scripts/npc/abilities/dragon_knight_inherited_vigor.txt
@@ -1,0 +1,33 @@
+"DOTAAbilities"
+{
+  "dragon_knight_inherited_vigor"
+  {
+    // General
+    //-------------------------------------------------------------------------------------------------------------
+    "AbilityBehavior"                                     "DOTA_ABILITY_BEHAVIOR_PASSIVE |  DOTA_ABILITY_BEHAVIOR_SHOW_IN_GUIDES | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE"
+    "MaxLevel"                                            "1"
+    "Innate"                                              "1"
+    "IsBreakable"                                         "1"
+
+    "AbilityValues"
+    {
+      "base_health_regen"
+      {
+        "value"                                           "2"
+        "special_bonus_unique_dragon_knight"              "+12"
+        "dynamic_value"                                   "true"
+      }
+      "base_armor"
+      {
+        "value"                                           "2"
+        "special_bonus_unique_dragon_knight"              "+12"
+        "dynamic_value"                                   "true"
+      }
+      "level_mult"                                        "0.3" //OAA
+      "regen_and_armor_multiplier_during_dragon_form" //OAA
+      {
+        "value"                                           "1.3"
+      }
+    }
+  }
+}

--- a/game/scripts/npc/abilities/elder_titan_earth_splitter.txt
+++ b/game/scripts/npc/abilities/elder_titan_earth_splitter.txt
@@ -30,10 +30,10 @@
     //-------------------------------------------------------------------------------------------------------------
     "AbilityValues"
     {
-      "AbilityCooldown" //OAA
+      "AbilityCooldown" //OAA 100s -60s vanilla
       {
-        "value"                                           "60"
-        "special_bonus_unique_elder_titan_3"              "-25"
+        "value"                                           "65"
+        "special_bonus_unique_elder_titan_3"              "-20"
       }
       "crack_time"                                        "2.7182"
       "crack_width"
@@ -50,7 +50,7 @@
       "speed"                                             "1100"
       "damage_pct"
       {
-        "value"                                           "34 42 50 55 60"
+        "value"                                           "34 42 50 54 58"
         "DamageTypeTooltip"                               "DAMAGE_TYPE_NONE"
       }
       "vision_width"

--- a/game/scripts/npc/abilities/huskar_burning_spear.txt
+++ b/game/scripts/npc/abilities/huskar_burning_spear.txt
@@ -55,7 +55,7 @@
         "value"                                           "0"
         "special_bonus_facet_huskar_nothl_conflagration"  "=0.25 =0.35 =0.45 =0.55 =0.65 =0.75"
       }
-      "duration"
+      "duration" //OAA
       {
         "value"                                           "9"
         "special_bonus_unique_huskar_5"                   "+4"

--- a/game/scripts/npc/abilities/huskar_burning_spear.txt
+++ b/game/scripts/npc/abilities/huskar_burning_spear.txt
@@ -58,7 +58,7 @@
       "duration"
       {
         "value"                                           "9"
-        "special_bonus_unique_huskar_5"                   "+6"
+        "special_bonus_unique_huskar_5"                   "+4"
       }
     }
   }

--- a/game/scripts/npc/abilities/sandking_epicenter.txt
+++ b/game/scripts/npc/abilities/sandking_epicenter.txt
@@ -45,16 +45,16 @@
         "special_bonus_shard"                             "+5"
         "CalculateSpellDamageTooltip"                     "1"
       }
-      "epicenter_radius_base"
+      "epicenter_radius_base" //OAA
       {
-        "value"                                           "500"
+        "value"                                           "400"
         "special_bonus_unique_sand_king_5"                "+100"
         "affected_by_aoe_increase"                        "1"
       }
-      "epicenter_radius_increment"
+      "epicenter_radius_increment" //OAA
       {
-        "value"                                           "13"
-        "special_bonus_unique_sand_king_5"                "+12"
+        "value"                                           "8"
+        "special_bonus_unique_sand_king_5"                "+7"
       }
       "epicenter_slow"
       {

--- a/game/scripts/npc/abilities/weaver_geminate_attack.txt
+++ b/game/scripts/npc/abilities/weaver_geminate_attack.txt
@@ -35,7 +35,7 @@
       }
       "bonus_damage"
       {
-        "value"                                           "20 35 50 65 130 260"
+        "value"                                           "20 35 50 65 130 195"
         "special_bonus_unique_weaver_2"                   "+70"
       }
       "shard_beetle_search_range"

--- a/game/scripts/npc/abilities/windrunner_focusfire.txt
+++ b/game/scripts/npc/abilities/windrunner_focusfire.txt
@@ -77,7 +77,7 @@
       "bonus_range"
       {
         "value"                                           "0"
-        "special_bonus_facet_windrunner_whirlwind"        "+100"
+        "special_bonus_facet_windrunner_whirlwind"        "+125"
       }
       "unfocused_cancel_initial_cooldown"                 "0.5"
     }

--- a/game/scripts/npc/heroes/weaver.txt
+++ b/game/scripts/npc/heroes/weaver.txt
@@ -5,6 +5,6 @@
   //=================================================================================================================
   "npc_dota_hero_weaver"
   {
-    "Ability11"                                           "special_bonus_strength_20" // replaces special_bonus_strength_7
+    "Ability11"                                           "special_bonus_strength_12" // replaces special_bonus_strength_7
   }
 }

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -141,6 +141,7 @@
 #base "abilities/dragon_knight_dragon_tail.txt"
 #base "abilities/dragon_knight_elder_dragon_form.txt"
 #base "abilities/dragon_knight_fireball.txt"
+#base "abilities/dragon_knight_inherited_vigor.txt"
 #base "abilities/drow_ranger_frost_arrows.txt"
 #base "abilities/drow_ranger_marksmanship.txt"
 #base "abilities/drow_ranger_multishot.txt"

--- a/game/scripts/vscripts/internal/gamemode.lua
+++ b/game/scripts/vscripts/internal/gamemode.lua
@@ -166,7 +166,7 @@ function GameMode:_CaptureGameMode()
     mode:SetDefaultStickyItem("item_aghanims_shard")
     --mode:DisableHudFlip(true)
     mode:SetCustomAttributeDerivedStatValue(DOTA_ATTRIBUTE_STRENGTH_HP, 20) -- Health per strength
-    --mode:SetCustomAttributeDerivedStatValue(DOTA_ATTRIBUTE_ALL_DAMAGE, 0.6) -- Damage per attribute for universal heroes
+    mode:SetCustomAttributeDerivedStatValue(DOTA_ATTRIBUTE_ALL_DAMAGE, 0.6) -- Damage per attribute for universal heroes
 
     self:OnFirstPlayerLoaded()
   end


### PR DESCRIPTION
- universal hero damage per stat reduced from 0.7 back to 0.6
- dark seer wall of replica damage scaling nerfed at all levels
- dragon knight innate scaling + multiplier nerf (at max level he was getting almost 60 armor + regen for free, extremely solid body)
- elder titan ult cd nerf (currently worse than vanilla past level 25 w/ talent) + small oaa level damage nerf 
- small huskar burning spear duration talent nerf (may need further tinkering, lasts a smidge too long for how much damage it was doing)
- sand king epicenter aoe nerfs (should not take up the entire screen, made worse by increased number of pulses in oaa levels)
- weaver geminate max level damage unbuffed (i was wrong lmfao)
- weaver level 10 str talent reduced from 20 to 12 (lmao)