### PR TITLE
Devastator tweaks

### DIFF
--- a/game/scripts/npc/items/custom/item_devastator_1.txt
+++ b/game/scripts/npc/items/custom/item_devastator_1.txt
@@ -92,10 +92,10 @@
         "affected_by_aoe_increase"                        "1"
       }
       "devastator_distance"                               "700 750 800 850 900"
-      "devastator_damage"                                 "75 150 300 525 825"
-      "devastator_movespeed_reduction"                    "-10 -20 -30 -40 -50"
+      "devastator_damage"                                 "0 200 300 500 800"
+      "devastator_movespeed_reduction"                    "-15 -20 -25 -30 -35"
       "devastator_movespeed_reduction_duration"           "7"
-      "devastator_armor_reduction"                        "-9 -12 -16 -21 -27" // better than passive
+      "devastator_armor_reduction"                        "-8 -11 -15 -20 -26" // better than passive
       "devastator_armor_reduction_duration"               "7"
       "interval"                                          "2" // to cancel Arcane Blink
       "damage_per_interval"                               "50"

--- a/game/scripts/npc/items/custom/item_devastator_2.txt
+++ b/game/scripts/npc/items/custom/item_devastator_2.txt
@@ -92,10 +92,10 @@
         "affected_by_aoe_increase"                        "1"
       }
       "devastator_distance"                               "700 750 800 850 900"
-      "devastator_damage"                                 "75 150 300 525 825"
-      "devastator_movespeed_reduction"                    "-10 -20 -30 -40 -50"
+      "devastator_damage"                                 "0 200 300 500 800"
+      "devastator_movespeed_reduction"                    "-15 -20 -25 -30 -35"
       "devastator_movespeed_reduction_duration"           "7"
-      "devastator_armor_reduction"                        "-9 -12 -16 -21 -27"
+      "devastator_armor_reduction"                        "-8 -11 -15 -20 -26"
       "devastator_armor_reduction_duration"               "7"
       "interval"                                          "2"
       "damage_per_interval"                               "50"

--- a/game/scripts/npc/items/custom/item_devastator_3.txt
+++ b/game/scripts/npc/items/custom/item_devastator_3.txt
@@ -92,10 +92,10 @@
         "affected_by_aoe_increase"                        "1"
       }
       "devastator_distance"                               "700 750 800 850 900"
-      "devastator_damage"                                 "75 150 300 525 825"
-      "devastator_movespeed_reduction"                    "-10 -20 -30 -40 -50"
+      "devastator_damage"                                 "0 200 300 500 800"
+      "devastator_movespeed_reduction"                    "-15 -20 -25 -30 -35"
       "devastator_movespeed_reduction_duration"           "7"
-      "devastator_armor_reduction"                        "-9 -12 -16 -21 -27"
+      "devastator_armor_reduction"                        "-8 -11 -15 -20 -26"
       "devastator_armor_reduction_duration"               "7"
       "interval"                                          "2"
       "damage_per_interval"                               "50"

--- a/game/scripts/npc/items/custom/item_devastator_4.txt
+++ b/game/scripts/npc/items/custom/item_devastator_4.txt
@@ -92,10 +92,10 @@
         "affected_by_aoe_increase"                        "1"
       }
       "devastator_distance"                               "700 750 800 850 900"
-      "devastator_damage"                                 "75 150 300 525 825"
-      "devastator_movespeed_reduction"                    "-10 -20 -30 -40 -50"
+      "devastator_damage"                                 "0 200 300 500 800"
+      "devastator_movespeed_reduction"                    "-15 -20 -25 -30 -35"
       "devastator_movespeed_reduction_duration"           "7"
-      "devastator_armor_reduction"                        "-9 -12 -16 -21 -27"
+      "devastator_armor_reduction"                        "-8 -11 -15 -20 -26"
       "devastator_armor_reduction_duration"               "7"
       "interval"                                          "2"
       "damage_per_interval"                               "50"

--- a/game/scripts/npc/items/custom/item_devastator_5.txt
+++ b/game/scripts/npc/items/custom/item_devastator_5.txt
@@ -92,10 +92,10 @@
         "affected_by_aoe_increase"                        "1"
       }
       "devastator_distance"                               "700 750 800 850 900"
-      "devastator_damage"                                 "75 150 300 525 825"
-      "devastator_movespeed_reduction"                    "-10 -20 -30 -40 -50"
+      "devastator_damage"                                 "0 200 300 500 800"
+      "devastator_movespeed_reduction"                    "-15 -20 -25 -30 -35"
       "devastator_movespeed_reduction_duration"           "7"
-      "devastator_armor_reduction"                        "-9 -12 -16 -21 -27"
+      "devastator_armor_reduction"                        "-8 -11 -15 -20 -26"
       "devastator_armor_reduction_duration"               "7"
       "interval"                                          "2"
       "damage_per_interval"                               "50"

--- a/game/scripts/vscripts/items/devastator.lua
+++ b/game/scripts/vscripts/items/devastator.lua
@@ -297,7 +297,7 @@ function modifier_item_devastator_oaa_slow_movespeed:OnCreated()
   --local parent = self:GetParent()
   local ability = self:GetAbility()
   local move_speed_slow = -10
-  local interval = 3
+  local interval = 2
   local damage_per_interval = 50
 
   if ability then


### PR DESCRIPTION
Active armor reduction decreased by 1 at all lvls.
Active move speed slow reduced from 20/30/40/50% to 20/25/30/35%.
Active damage rescaled from 150/300/525/825 to 200/300/500/800.