### PR TITLE
Kill stuff fixes

### DIFF
--- a/game/scripts/vscripts/abilities/boss/magma_boss/magma_boss_volcano.lua
+++ b/game/scripts/vscripts/abilities/boss/magma_boss/magma_boss_volcano.lua
@@ -593,7 +593,11 @@ if IsServer() then
 
     -- To prevent dead staying in memory (preventing SetHealth(0) or SetHealth(-value) )
     if parent:GetHealth() - damage_dealt <= 0 then
-      parent:Kill(ability, attacker)
+      if attacker:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+        parent:ForceKillOAA(false)
+      else
+        parent:Kill(ability, attacker)
+      end
     else
       parent:SetHealth(parent:GetHealth() - damage_dealt)
     end

--- a/game/scripts/vscripts/abilities/boss/slime/boss_slime_split.lua
+++ b/game/scripts/vscripts/abilities/boss/slime/boss_slime_split.lua
@@ -303,14 +303,13 @@ if IsServer() then
     end
 
     local killer = event.attacker
-    local killer_team = killer:GetTeamNumber()
 
     -- Remove invulnerability so we can kill it
     if spawner:HasAbility("boss_out_of_game") then
       spawner:RemoveAbility("boss_out_of_game")
     end
 
-    if killer_team == DOTA_TEAM_NEUTRALS then
+    if killer:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
       spawner:ForceKillOAA(false)
     else
       spawner:Kill(event.inflictor, killer) -- this will crash if the killer is on the neutral team

--- a/game/scripts/vscripts/abilities/dev_attack.lua
+++ b/game/scripts/vscripts/abilities/dev_attack.lua
@@ -82,7 +82,11 @@ function modifier_dev_attack_aura:OnIntervalThink()
     target:ReduceMana(manaReductionAmount, ability)
     caster:GiveMana(manaReductionAmount)
     if targetHealth - healthReductionAmount < 1 then
-      target:Kill(ability, caster)
+      if teamID == DOTA_TEAM_NEUTRALS then
+        target:Kill(ability, target)
+      else
+        target:Kill(ability, caster)
+      end
     else
       target:SetHealth(targetHealth - healthReductionAmount)
       caster:Heal(healthReductionAmount, ability)

--- a/game/scripts/vscripts/abilities/fountain_attack.lua
+++ b/game/scripts/vscripts/abilities/fountain_attack.lua
@@ -131,7 +131,11 @@ function modifier_fountain_attack_aura:OnIntervalThink()
     target:Purge(true, false, false, false, false)
     target:ReduceMana(manaReductionAmount, ability)
     if targetHealth - healthReductionAmount < 1 then
-      target:Kill(ability, caster)
+      if teamID == DOTA_TEAM_NEUTRALS then
+        target:Kill(ability, target)
+      else
+        target:Kill(ability, caster)
+      end
     else
       target:SetHealth(targetHealth - healthReductionAmount)
     end

--- a/game/scripts/vscripts/abilities/oaa_meepo_divided_we_stand.lua
+++ b/game/scripts/vscripts/abilities/oaa_meepo_divided_we_stand.lua
@@ -148,7 +148,12 @@ function modifier_meepo_divided_we_stand_oaa:OnDeath(event)
   if IsMeepoCloneOAA(parent) then
     -- CLone died, kill Meepo Prime
     if mainMeepo:IsAlive() then
-      mainMeepo:Kill(event.inflictor, event.attacker)
+      local killer = event.attacker
+      if killer:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+        mainMeepo:Kill(event.inflictor, mainMeepo)
+      else
+        mainMeepo:Kill(event.inflictor, killer)
+      end
     end
   end
 

--- a/game/scripts/vscripts/abilities/oaa_zuus_cloud.lua
+++ b/game/scripts/vscripts/abilities/oaa_zuus_cloud.lua
@@ -137,7 +137,11 @@ if IsServer() then
     end
     -- To prevent dead nimbuses staying in memory (preventing SetHealth(0) or SetHealth(-value) )
     if parent:GetHealth() - damage <= 0 then
-      parent:Kill(self.ability, attacker)
+      if attacker:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+        parent:ForceKillOAA(false)
+      else
+        parent:Kill(self.ability, attacker)
+      end
     else
       parent:SetHealth(parent:GetHealth() - damage)
     end

--- a/game/scripts/vscripts/abilities/tinkerer/tinkerer_laser_contraption.lua
+++ b/game/scripts/vscripts/abilities/tinkerer/tinkerer_laser_contraption.lua
@@ -558,7 +558,11 @@ if IsServer() then
 
     -- To prevent dead staying in memory (preventing SetHealth(0) or SetHealth(-value) )
     if parent:GetHealth() - damage <= 0 then
-      parent:Kill(ability, attacker)
+      if attacker:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+        parent:ForceKillOAA(false)
+      else
+        parent:Kill(ability, attacker)
+      end
     else
       parent:SetHealth(parent:GetHealth() - damage)
     end

--- a/game/scripts/vscripts/items/azazel_summon.lua
+++ b/game/scripts/vscripts/items/azazel_summon.lua
@@ -23,7 +23,11 @@ function azazel_summon:OnSpellStart()
 
   -- Destroy any existing summons tied to this caster
   if caster.azazel_summon ~= nil and not caster.azazel_summon:IsNull() and IsValidEntity(caster.azazel_summon) then
-    caster.azazel_summon:Kill(nil, caster)
+    if caster:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+      caster.azazel_summon:ForceKillOAA(false)
+    else
+      caster.azazel_summon:Kill(nil, caster)
+    end
   end
 
   -- Summon parameters

--- a/game/scripts/vscripts/items/dagon.lua
+++ b/game/scripts/vscripts/items/dagon.lua
@@ -58,11 +58,15 @@ function item_dagon_oaa_1:OnSpellStart()
   end
 
   -- If the target is an illusion, just kill it and don't do damage; same + heal for non-ancient creeps
-  if (target:IsIllusion() and not target:IsNull() and not target:IsStrongIllusionOAA()) or (target:IsCreep() and not target:IsAncient() and not target:IsOAABoss()) then
+  if (target:IsIllusion() and not target:IsNull() and not target:IsStrongIllusionOAA()) or (target:IsCreep() and not target:IsAncient() and not target:IsOAABoss() and not target:IsCreepHero()) then
     if target:IsCreep() then
       caster:HealWithParams(target:GetHealth() * burst_heal_percent / 100, self, false, true, caster, true)
     end
-    target:Kill(self, caster)
+    if caster:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+      target:ForceKillOAA(false)
+    else
+      target:Kill(self, caster)
+    end
     return
   end
 

--- a/game/scripts/vscripts/items/dev_dagon.lua
+++ b/game/scripts/vscripts/items/dev_dagon.lua
@@ -14,5 +14,9 @@ function item_devDagon:OnSpellStart()
   caster:EmitSound("DOTA_Item.Dagon.Activate")
   target:EmitSound("DOTA_Item.Dagon5.Target")
 
-  target:Kill(self, caster)
+  if caster:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+    target:Kill(self, target)
+  else
+    target:Kill(self, caster)
+  end
 end

--- a/game/scripts/vscripts/items/hand_of_midas.lua
+++ b/game/scripts/vscripts/items/hand_of_midas.lua
@@ -67,10 +67,16 @@ function item_hand_of_midas_1:OnSpellStart()
   --target:SetMaximumGoldBounty(0) -- setting this to 0 will mess up OAA Mud Golems
 
   -- Madstone drop
-  local madstone = CreateItem("item_madstone_bundle", nil, nil) -- CDOTA_Item
-  madstone:SetPurchaseTime(0)
-  CreateItemOnPositionSync(target:GetAbsOrigin(), madstone) -- CDOTA_Item_Physical
-  madstone:LaunchLoot(false, 300, 0.25, location, nil)
+  if target:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+    local madstone = CreateItem("item_madstone_bundle", nil, nil) -- CDOTA_Item
+    madstone:SetPurchaseTime(0)
+    CreateItemOnPositionSync(target:GetAbsOrigin(), madstone) -- CDOTA_Item_Physical
+    madstone:LaunchLoot(false, 300, 0.25, location, nil)
+  end
 
-  target:Kill(self, caster)
+  if caster:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+    target:ForceKillOAA(false)
+  else
+    target:Kill(self, caster)
+  end
 end

--- a/game/scripts/vscripts/items/vladmirs_grimoire.lua
+++ b/game/scripts/vscripts/items/vladmirs_grimoire.lua
@@ -449,7 +449,11 @@ if IsServer() then
 
     if not caster:IsAlive() then
       if parent and not parent:IsNull() and parent:IsAlive() then
-        parent:Kill(self:GetAbility(), self.killer)
+        if self.killer:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+          parent:ForceKillOAA(false)
+        else
+          parent:Kill(self:GetAbility(), self.killer)
+        end
         return
       end
     end

--- a/game/scripts/vscripts/units/ai_temple_guardian_spawner.lua
+++ b/game/scripts/vscripts/units/ai_temple_guardian_spawner.lua
@@ -25,7 +25,11 @@ function TempleGuardianSpawnerThink()
   if thisEntity.bForceKill then
     -- Triggers boss reward
     local killer = EntIndexToHScript( thisEntity.KillValues.entindex_attacker )
-    thisEntity:Kill(nil, killer)
+    if killer:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+      thisEntity:ForceKillOAA(false)
+    else
+      thisEntity:Kill(nil, killer)
+    end
     return -1
   end
 
@@ -100,11 +104,19 @@ function RemovePedestals(p1, p2, killer_index)
 
       if p1 and not p1:IsNull() then
         p1:AddNoDraw()
-        p1:Kill(nil, killer)
+        if killer:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+          p1:ForceKillOAA(false)
+        else
+          p1:Kill(nil, killer)
+        end
       end
       if p2 and not p2:IsNull() then
         p2:AddNoDraw()
-        p2:Kill(nil, killer)
+        if killer:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+          p2:ForceKillOAA(false)
+        else
+          p2:Kill(nil, killer)
+        end
       end
 
       if nFXIndex1 then

--- a/game/scripts/vscripts/units/ai_temple_guardian_spawner_tier5.lua
+++ b/game/scripts/vscripts/units/ai_temple_guardian_spawner_tier5.lua
@@ -25,7 +25,11 @@ function TempleGuardianSpawnerThink()
   if thisEntity.bForceKill then
     -- Triggers boss reward
     local killer = EntIndexToHScript( thisEntity.KillValues.entindex_attacker )
-    thisEntity:Kill(nil, killer)
+    if killer:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+      thisEntity:ForceKillOAA(false)
+    else
+      thisEntity:Kill(nil, killer)
+    end
     return -1
   end
 
@@ -100,11 +104,19 @@ function RemovePedestals(p1, p2, killer_index)
 
       if p1 and not p1:IsNull() then
         p1:AddNoDraw()
-        p1:Kill(nil, killer)
+        if killer:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+          p1:ForceKillOAA(false)
+        else
+          p1:Kill(nil, killer)
+        end
       end
       if p2 and not p2:IsNull() then
         p2:AddNoDraw()
-        p2:Kill(nil, killer)
+        if killer:GetTeamNumber() == DOTA_TEAM_NEUTRALS then
+          p2:ForceKillOAA(false)
+        else
+          p2:Kill(nil, killer)
+        end
       end
 
       if nFXIndex1 then


### PR DESCRIPTION
Wherever Kill method is used, added a failsafe if the killer is on the neutral team to prevent crashes. 
Fixed Dagon killing non-ancient creep heroes.
Fixed Hand of Midas granting madstone bundle even if the killed creep is not on the neutral team.