### PR TITLE
Bubble Witch facets + Eul fix

### DIFF
--- a/game/itembuilds/default_bubble_witch.txt
+++ b/game/itembuilds/default_bubble_witch.txt
@@ -1,6 +1,6 @@
 "itembuilds"
 {
-  "author"        "OAA"
+  "author"        "OAA 7.39d (Darkonius)"
   "hero"          "npc_dota_hero_bubble_witch"
   "Title"         "Recommended items for Bubble Witch"
 
@@ -17,11 +17,25 @@
 
     "#DOTA_Item_Build_Core_Items"
     {
-      "item"      "item_kaya"
+      "item"      "item_aether_lens"
+      "item"      "item_octarine_core"
+    }
+
+    "#DOTA_Item_Build_Support_Core"
+    {
+      "item"      "item_spirit_vessel_oaa"
+      "item"      "item_glimmer_cape"
+      "item"      "item_lotus_orb"
       "item"      "item_gungir"
-      "item"      "item_bloodstone_1"
-      "item"      "item_ultimate_scepter"
-      "item"      "item_black_king_bar_1"
+      "item"      "item_bubble_orb_1"
+    }
+
+    "#DOTA_Item_Build_Magical_Core"
+    {
+      "item"      "item_kaya"
+      "item"      "item_ethereal_blade"
+      "item"      "item_shivas_guard"
+      "item"      "item_greater_travel_boots"
       "item"      "item_dagger_of_moriah_1"
     }
 
@@ -32,19 +46,21 @@
 
     "#DOTA_Item_Build_Luxury"
     {
-      "item"      "item_blink"
       "item"      "item_boots_of_bearing"
+      "item"      "item_crimson_guard"
       "item"      "item_disperser"
-      "item"      "item_ethereal_blade"
-      "item"      "item_far_sight"
-      "item"      "item_glimmer_cape"
-      "item"      "item_lotus_orb"
-      "item"      "item_octarine_core"
+      "item"      "item_ghost_king_bar_1"
+      "item"      "item_greater_phase_boots"
+      "item"      "item_manta"
+      "item"      "item_pipe"
+      "item"      "item_shield_staff"
+      "item"      "item_solar_crest"
       "item"      "item_sphere"
-      "item"      "item_bubble_orb_1"
+      "item"      "item_ultimate_scepter"
+      "item"      "item_wind_waker"
+      "item"      "item_heart_transplant"
       "item"      "item_refresher_4"
       "item"      "item_sheepstick_4"
-      "item"      "item_sonic"
     }
   }
 }

--- a/game/itembuilds/default_eul.txt
+++ b/game/itembuilds/default_eul.txt
@@ -46,6 +46,7 @@
     {
       "item"      "item_angels_demise"
       "item"      "item_black_king_bar_1"
+      "item"      "item_devastator"
       "item"      "item_eternal_shroud"
       "item"      "item_greater_phase_boots"
       "item"      "item_heart_oaa_1"

--- a/game/resource/English/npc/tooltip_bubble_witch.txt
+++ b/game/resource/English/npc/tooltip_bubble_witch.txt
@@ -62,12 +62,14 @@
 "DOTA_Tooltip_modifier_bubble_witch_bubble_of_protection_debuff"                "#{DOTA_Tooltip_ability_bubble_witch_bubble_of_protection}"
 "DOTA_Tooltip_modifier_bubble_witch_bubble_of_protection_debuff_Description"    "Slowed."
 
+// innate
 "DOTA_Tooltip_ability_bubble_witch_innate"                                      "Bubbly"
 "DOTA_Tooltip_ability_bubble_witch_innate_Description"                          "Buffs created by Bubble Witch that have duration will explode when removed or when they expire dealing damage to nearby enemies. Enemies that take damage from Bubbly will be immune to Bubbly damage for %immune_time% second."
 "DOTA_Tooltip_ability_bubble_witch_innate_Lore"                                 "Pop!"
 "DOTA_Tooltip_ability_bubble_witch_innate_base_dmg"                             "DAMAGE:"
 "DOTA_Tooltip_ability_bubble_witch_innate_explode_dmg_radius"                   "EXPLODE RADIUS:"
 
+// talents
 "DOTA_Tooltip_ability_special_bonus_unique_bubble_witch_1"                      "+{s:bonus_dps} #{DOTA_Tooltip_ability_bubble_witch_blow_bubbles} DPS"
 "DOTA_Tooltip_ability_special_bonus_unique_bubble_witch_2"                      "+{s:bonus_debuff_duration}s #{DOTA_Tooltip_ability_bubble_witch_cavitation} Duration"
 "DOTA_Tooltip_ability_special_bonus_unique_bubble_witch_3"                      "-{s:bonus_AbilityCooldown}s #{DOTA_Tooltip_ability_bubble_witch_cavitation} Cooldown"
@@ -76,3 +78,11 @@
 "DOTA_Tooltip_ability_special_bonus_unique_bubble_witch_6"                      "+{s:bonus_AbilityCharges} #{DOTA_Tooltip_ability_bubble_witch_magic_bubble} Charge"
 "DOTA_Tooltip_ability_special_bonus_unique_bubble_witch_7"                      "-{s:bonus_AbilityCooldown}s #{DOTA_Tooltip_ability_bubble_witch_bubble_of_protection} Cooldown"
 "DOTA_Tooltip_ability_special_bonus_unique_bubble_witch_8"                      ""
+
+// facets
+"DOTA_Tooltip_facet_bubble_witch_healing_bubble"                                "Healing Bubble"
+"DOTA_Tooltip_facet_bubble_witch_healing_bubble_Description"                    "Magic Bubble heals the affected target for the damage taken after popping."
+"DOTA_Tooltip_ability_bubble_witch_magic_bubble_Facet_bubble_witch_healing_bubble"  "Target ally will be healed after popping. Heal is equal to pop damage."
+"DOTA_Tooltip_facet_bubble_witch_extra_bubbly"                                  "Extra Bubbly"
+"DOTA_Tooltip_facet_bubble_witch_extra_bubbly_Description"                      "Bubbly immune time removed but damage is reduced."
+"DOTA_Tooltip_ability_bubble_witch_innate_Facet_bubble_witch_extra_bubbly"      "#{DOTA_Tooltip_facet_bubble_witch_extra_bubbly_Description}"

--- a/game/resource/English/npc/tooltip_eul.txt
+++ b/game/resource/English/npc/tooltip_eul.txt
@@ -65,7 +65,7 @@
 //"DOTA_Tooltip_ability_tornado_tempest_Description"                              "The Tornado's overpowering winds slow all nearby enemies, flinging debris at them and inflicting damage every second. Enemies closer to the center of the Tornado take more damage."
 "DOTA_Tooltip_ability_eul_innate_oaa"                                           "#{DOTA_Tooltip_ability_tornado_tempest}"
 //"DOTA_Tooltip_ability_eul_innate_oaa_Description"                               "Eul will stay on the battlefield even after death as a Tornado that slows and deals damage based on his attack damage. Tornado's movement speed is the same as the hero's movement speed."
-"DOTA_Tooltip_ability_eul_innate_oaa_Description"                               "Eul will gain some attack damage from Intelligence too."
+"DOTA_Tooltip_ability_eul_innate_oaa_Description"                               "Eul will gain some base attack damage from Intelligence too."
 "DOTA_Tooltip_ability_eul_innate_oaa_Lore"                                      "Overpowering winds slow, fling debris and inflict damage."
 //"DOTA_Tooltip_ability_eul_innate_oaa_tornado_linger_time"                       "TORNADO DURATION:"
 //"DOTA_Tooltip_ability_eul_innate_oaa_movespeed_slow"                            "%MOVE SPEED SLOW:"
@@ -94,6 +94,9 @@
 //"DOTA_Tooltip_modifier_tornado_tempest_debuff_Description"                      "Movement speed reduced by %dMODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE%%% and attack speed reduced by %dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%. Taking damage per second based on proximity to the Tornado."
 "DOTA_Tooltip_modifier_eul_innate_oaa_dead_tornado_debuff"                      "#{DOTA_Tooltip_modifier_tornado_tempest_debuff}"
 "DOTA_Tooltip_modifier_eul_innate_oaa_dead_tornado_debuff_Description"          "Taking damage, move speed reduced by %dMODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE%%% and attack speed by %dMODIFIER_PROPERTY_ATTACKSPEED_PERCENTAGE%%%."
+
+"DOTA_Tooltip_modifier_eul_innate_oaa"                                          "#{DOTA_Tooltip_ability_eul_innate_oaa}"
+"DOTA_Tooltip_modifier_eul_innate_oaa_Description"                              "Bonus %dMODIFIER_PROPERTY_TOOLTIP% base attack damage."
 
 // talents
 "DOTA_Tooltip_Ability_special_bonus_unique_eul_1_oaa"                           "+{s:bonus_damage} Hurricane Damage"

--- a/game/scripts/npc/abilities/bubble_witch_innate_oaa.txt
+++ b/game/scripts/npc/abilities/bubble_witch_innate_oaa.txt
@@ -28,6 +28,7 @@
       "base_dmg"
       {
         "value"                                           "50 75 100 125 250 375"
+        "special_bonus_facet_bubble_witch_extra_bubbly"   "=40 =50 =60 =70 =90 =110"
         "DamageTypeTooltip"                               "DAMAGE_TYPE_MAGICAL"
       }
       "explode_dmg_radius"
@@ -37,7 +38,11 @@
         "CalculateSpellDamageTooltip"                     "0"
         "DamageTypeTooltip"                               "DAMAGE_TYPE_NONE"
       }
-      "immune_time"                                       "0.1"
+      "immune_time"
+      {
+        "value"                                           "0.1"
+        "special_bonus_facet_bubble_witch_extra_bubbly"   "=0"
+      }
     }
   }
 }

--- a/game/scripts/npc/abilities/bubble_witch_magic_bubble_oaa.txt
+++ b/game/scripts/npc/abilities/bubble_witch_magic_bubble_oaa.txt
@@ -82,6 +82,11 @@
         "value"                                           "0"
         "special_bonus_shard"                             "=1"
       }
+      "healing_dmg_ratio"
+      {
+        "value"                                           "0"
+        "special_bonus_facet_bubble_witch_healing_bubble"  "=1"
+      }
     }
   }
 }

--- a/game/scripts/npc/heroes/bubble_witch.txt
+++ b/game/scripts/npc/heroes/bubble_witch.txt
@@ -72,7 +72,18 @@
 
     "Facets"
     {
-
+      "bubble_witch_healing_bubble"
+      {
+        "Icon"                                            "healing"
+        "Color"                                           "Gray"
+        "GradientID"                                      "3"
+      }
+      "bubble_witch_extra_bubbly"
+      {
+        "Icon"                                            "nuke"
+        "Color"                                           "Blue"
+        "GradientID"                                      "0"
+      }
     }
 
     "AbilityTalentStart"                                  "10"

--- a/game/scripts/vscripts/abilities/bubble_witch/bubble_witch_innate.lua
+++ b/game/scripts/vscripts/abilities/bubble_witch/bubble_witch_innate.lua
@@ -144,7 +144,7 @@ function modifier_bubble_witch_innate_buff_oaa:OnCreated(kv)
   else
     self.dmg = 50
     self.radius = 675
-    self.immune_time = 1
+    self.immune_time = 0.1
   end
   if IsServer() and self:GetDuration() > 0.1 and self:GetRemainingTime() > 0.1 and kv.linked_mod then
     self.linked_mod = kv.linked_mod
@@ -195,7 +195,9 @@ if IsServer() then
     for _, enemy in pairs(enemies) do
       if enemy and not enemy:IsNull() then
         if not enemy:HasModifier("modifier_bubble_witch_innate_immune_oaa") then
-          enemy:AddNewModifier(enemy, nil, "modifier_bubble_witch_innate_immune_oaa", {duration = self.immune_time})
+          if self.immune_time > 0 then
+            enemy:AddNewModifier(enemy, nil, "modifier_bubble_witch_innate_immune_oaa", {duration = self.immune_time})
+          end
           damage_table.victim = enemy
           ApplyDamage(damage_table)
         end

--- a/game/scripts/vscripts/abilities/bubble_witch/bubble_witch_magic_bubble.lua
+++ b/game/scripts/vscripts/abilities/bubble_witch/bubble_witch_magic_bubble.lua
@@ -153,6 +153,18 @@ if IsServer() then
       end
     end
 
+    if not parent or parent:IsNull() then
+      return
+    end
+
+    local heal = ability:GetSpecialValueFor("healing_dmg_ratio")
+    if heal > 0 then
+      local heal_amount = total_dmg
+      -- Healing
+      --parent:Heal(heal_amount, ability) -- not affected by heal amp for some reason
+      parent:HealWithParams(heal_amount, ability, false, true, caster, false)
+    end
+
     local innate = caster:FindAbilityByName("bubble_witch_innate")
     if not innate or innate:IsNull() then
       return
@@ -160,10 +172,6 @@ if IsServer() then
 
     -- If owner is affected by break, do nothing
     if caster:PassivesDisabled() then
-      return
-    end
-
-    if not parent or parent:IsNull() then
       return
     end
 


### PR DESCRIPTION
Updated item build/guide for Bubble Witch
Added 2 facets for Bubble Witch.
Eul Tempest is now breakable.
Eul Tempest will now show the bonus dmg gained from INT in the buff tooltip.